### PR TITLE
docs: update configuration example

### DIFF
--- a/packages/apify/src/configuration.ts
+++ b/packages/apify/src/configuration.ts
@@ -42,8 +42,15 @@ export interface ConfigurationOptions extends CoreConfigurationOptions {
  *    ```javascript
  *    import { BasicCrawler, Configuration } from 'crawlee';
  *
- *    const config = new Configuration({ persistStateIntervalMillis: 30_000 });
- *    const crawler = new BasicCrawler({ ... }, config);
+ *    // Get the global configuration
+ *    const config = Configuration.getGlobalConfig();
+ *    // Set the 'persistStateIntervalMillis' option
+ *    // of global configuration to 30 seconds
+ *    config.set('persistStateIntervalMillis', 30_000);
+ *
+ *    // No need to pass the configuration to the crawler,
+ *    // as it's using the global configuration by default
+ *    const crawler = new BasicCrawler();
  *    ```
  *
  * ## Supported Configuration Options


### PR DESCRIPTION
Quick follow-up to https://github.com/apify/crawlee/pull/1433
We talked about chaning the second example some time ago. So here's it :) 

For reference, your message (I don't really remember where you sent it, but I had it in my notes =D )

> this example should be about global configuration, while its using the same approach as the previous one, it just instantiates the config instead of actor class but its exactly the same use case.
> 
> in v2 we have this simple example, which is indeed too bare bones
> 
> [apify-js/configuration.js at master · apify/apify-js](https://github.com/apify/apify-js/blob/master/src/configuration.js#L20)
> 
> i guess we should showcase that the Configuration.getGlobalConfig() is used automaticaly, e.g. by setting the persistStateIntervalMillis on it and not passing it to the basic crawler, showing it will by default use this global instance