### PR TITLE
chore: convert some tests to use spies instead of property overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "@typescript-eslint/eslint-plugin": "5.40.0",
                 "@typescript-eslint/parser": "5.40.0",
                 "commitlint": "^17.0.3",
-                "crawlee": "^3.0.0",
+                "crawlee": "^3.1.0",
                 "eslint": "~8.25.0",
                 "fs-extra": "^10.1.0",
                 "gen-esm-wrapper": "^1.1.3",
@@ -1159,12 +1159,12 @@
             }
         },
         "node_modules/@crawlee/cli": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.0.4.tgz",
-            "integrity": "sha512-0aM+xiJVW/fUV4IRT14NIVOQ75Fru/3WpKbAElgY6lE6Kxh5eVtca5VkHewfui6uvnCW244xjleWkWW6Wb+7Ew==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.1.0.tgz",
+            "integrity": "sha512-gaZCtquvI6eVkrwTEvbId3SW8BHzzXcjA8HWsurxNnYGr+7TuLMyFJ755+E0OIDdcbQgd8iGDmEi9gONKzLaUg==",
             "dev": true,
             "dependencies": {
-                "@crawlee/templates": "^3.0.4",
+                "@crawlee/templates": "^3.1.0",
                 "ansi-colors": "^4.1.3",
                 "fs-extra": "^10.1.0",
                 "inquirer": "^8.2.4",
@@ -1253,14 +1253,14 @@
             }
         },
         "node_modules/@crawlee/jsdom": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.0.4.tgz",
-            "integrity": "sha512-QMoXJmcBSPU6dD+8QtiwFyJnmYXFdfsFlJYc4jA7N32Dl/JPMZILTZ5gfzbhxVMZJP/lVyk/AOUdiDzWxh4XMg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.1.0.tgz",
+            "integrity": "sha512-+cXeEy/CTL9FEAbXtlm37hB1Z4kx/AABPD7zheMHB2Et6ZndXdSEGgNpwSpIIw6mSixHrM+J9H2Ao075IIoAiQ==",
             "dev": true,
             "dependencies": {
                 "@apify/utilities": "^2.1.4",
-                "@crawlee/http": "^3.0.4",
-                "@crawlee/types": "^3.0.4",
+                "@crawlee/http": "^3.1.0",
+                "@crawlee/types": "^3.1.0",
                 "@types/jsdom": "^20.0.0",
                 "jsdom": "^20.0.0"
             },
@@ -1344,9 +1344,9 @@
             }
         },
         "node_modules/@crawlee/templates": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.0.4.tgz",
-            "integrity": "sha512-yiH+2gZEbrWu16AHIpeRgW/eqR6AsufHaL5PEFdFRm/9Y10j0zhaljpyjqGoDUoSy5GfNbpAEElyBgD+jcs/UQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.1.0.tgz",
+            "integrity": "sha512-gyMidulFF/DAlaS/NuRYckf7noAzOX+J3udDhTM5jwp3gUAUgO5F0y7ix8xG7P0osyPIn6A/GN6sCqYhjhSyhQ==",
             "dev": true,
             "dependencies": {
                 "ansi-colors": "^4.1.3",
@@ -1386,9 +1386,9 @@
             }
         },
         "node_modules/@crawlee/templates/node_modules/ansi-styles": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.1.tgz",
-            "integrity": "sha512-qDOv24WjnYuL+wbwHdlsYZFy+cgPtrYw0Tn7GLORicQp9BkQLzrgI3Pm4VyR9ERZ41YTn7KlMPuL1n05WdZvmg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -1433,9 +1433,9 @@
             }
         },
         "node_modules/@crawlee/templates/node_modules/chalk": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.0.tgz",
-            "integrity": "sha512-56zD4khRTBoIyzUYAFgDDaPhUMN/fC/rySe6aZGqbj/VWiU2eI3l6ZLOtYGFZAV5v02mwPjtpzlrOveJiz5eZQ==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+            "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
             "dev": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -6305,21 +6305,21 @@
             }
         },
         "node_modules/crawlee": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.0.4.tgz",
-            "integrity": "sha512-nrWERtdm1uF9KhDpTmzWH6QNs1+bP4mqN6m/rsSAjK+hQHke2vAuxBktWiEU9IdfCPuTllFEUaqQGFABhtSF+g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.1.0.tgz",
+            "integrity": "sha512-Z1yvIYDj5lQsYA0WSGrbuEQNcK5qI0CI2e1uT6hpJ0KkXsV5eNyZEu6PJ0PHJ4RbvHvRWrBn3+p49cvatWU4/g==",
             "dev": true,
             "dependencies": {
-                "@crawlee/basic": "^3.0.4",
-                "@crawlee/browser": "^3.0.4",
-                "@crawlee/cheerio": "^3.0.4",
-                "@crawlee/cli": "^3.0.4",
-                "@crawlee/core": "^3.0.4",
-                "@crawlee/http": "^3.0.4",
-                "@crawlee/jsdom": "^3.0.4",
-                "@crawlee/playwright": "^3.0.4",
-                "@crawlee/puppeteer": "^3.0.4",
-                "@crawlee/utils": "^3.0.4",
+                "@crawlee/basic": "^3.1.0",
+                "@crawlee/browser": "^3.1.0",
+                "@crawlee/cheerio": "^3.1.0",
+                "@crawlee/cli": "^3.1.0",
+                "@crawlee/core": "^3.1.0",
+                "@crawlee/http": "^3.1.0",
+                "@crawlee/jsdom": "^3.1.0",
+                "@crawlee/playwright": "^3.1.0",
+                "@crawlee/puppeteer": "^3.1.0",
+                "@crawlee/utils": "^3.1.0",
                 "import-local": "^3.1.0"
             },
             "bin": {
@@ -6330,7 +6330,7 @@
             },
             "peerDependencies": {
                 "playwright": "^1.21.1",
-                "puppeteer": ">= 9.x <= 15.1"
+                "puppeteer": "<= 18.0"
             },
             "peerDependenciesMeta": {
                 "playwright": {
@@ -6519,9 +6519,9 @@
             }
         },
         "node_modules/decimal.js": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
-            "integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==",
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
+            "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
             "dev": true
         },
         "node_modules/decompress-response": {
@@ -16819,12 +16819,12 @@
             }
         },
         "@crawlee/cli": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.0.4.tgz",
-            "integrity": "sha512-0aM+xiJVW/fUV4IRT14NIVOQ75Fru/3WpKbAElgY6lE6Kxh5eVtca5VkHewfui6uvnCW244xjleWkWW6Wb+7Ew==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.1.0.tgz",
+            "integrity": "sha512-gaZCtquvI6eVkrwTEvbId3SW8BHzzXcjA8HWsurxNnYGr+7TuLMyFJ755+E0OIDdcbQgd8iGDmEi9gONKzLaUg==",
             "dev": true,
             "requires": {
-                "@crawlee/templates": "^3.0.4",
+                "@crawlee/templates": "^3.1.0",
                 "ansi-colors": "^4.1.3",
                 "fs-extra": "^10.1.0",
                 "inquirer": "^8.2.4",
@@ -16893,14 +16893,14 @@
             }
         },
         "@crawlee/jsdom": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.0.4.tgz",
-            "integrity": "sha512-QMoXJmcBSPU6dD+8QtiwFyJnmYXFdfsFlJYc4jA7N32Dl/JPMZILTZ5gfzbhxVMZJP/lVyk/AOUdiDzWxh4XMg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.1.0.tgz",
+            "integrity": "sha512-+cXeEy/CTL9FEAbXtlm37hB1Z4kx/AABPD7zheMHB2Et6ZndXdSEGgNpwSpIIw6mSixHrM+J9H2Ao075IIoAiQ==",
             "dev": true,
             "requires": {
                 "@apify/utilities": "^2.1.4",
-                "@crawlee/http": "^3.0.4",
-                "@crawlee/types": "^3.0.4",
+                "@crawlee/http": "^3.1.0",
+                "@crawlee/types": "^3.1.0",
                 "@types/jsdom": "^20.0.0",
                 "jsdom": "^20.0.0"
             }
@@ -16956,9 +16956,9 @@
             }
         },
         "@crawlee/templates": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.0.4.tgz",
-            "integrity": "sha512-yiH+2gZEbrWu16AHIpeRgW/eqR6AsufHaL5PEFdFRm/9Y10j0zhaljpyjqGoDUoSy5GfNbpAEElyBgD+jcs/UQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.1.0.tgz",
+            "integrity": "sha512-gyMidulFF/DAlaS/NuRYckf7noAzOX+J3udDhTM5jwp3gUAUgO5F0y7ix8xG7P0osyPIn6A/GN6sCqYhjhSyhQ==",
             "dev": true,
             "requires": {
                 "ansi-colors": "^4.1.3",
@@ -16983,9 +16983,9 @@
                     "dev": true
                 },
                 "ansi-styles": {
-                    "version": "6.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.1.tgz",
-                    "integrity": "sha512-qDOv24WjnYuL+wbwHdlsYZFy+cgPtrYw0Tn7GLORicQp9BkQLzrgI3Pm4VyR9ERZ41YTn7KlMPuL1n05WdZvmg==",
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
                     "dev": true
                 },
                 "bl": {
@@ -17010,9 +17010,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.0.tgz",
-                    "integrity": "sha512-56zD4khRTBoIyzUYAFgDDaPhUMN/fC/rySe6aZGqbj/VWiU2eI3l6ZLOtYGFZAV5v02mwPjtpzlrOveJiz5eZQ==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+                    "integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
                     "dev": true
                 },
                 "cli-cursor": {
@@ -20900,21 +20900,21 @@
             "requires": {}
         },
         "crawlee": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.0.4.tgz",
-            "integrity": "sha512-nrWERtdm1uF9KhDpTmzWH6QNs1+bP4mqN6m/rsSAjK+hQHke2vAuxBktWiEU9IdfCPuTllFEUaqQGFABhtSF+g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.1.0.tgz",
+            "integrity": "sha512-Z1yvIYDj5lQsYA0WSGrbuEQNcK5qI0CI2e1uT6hpJ0KkXsV5eNyZEu6PJ0PHJ4RbvHvRWrBn3+p49cvatWU4/g==",
             "dev": true,
             "requires": {
-                "@crawlee/basic": "^3.0.4",
-                "@crawlee/browser": "^3.0.4",
-                "@crawlee/cheerio": "^3.0.4",
-                "@crawlee/cli": "^3.0.4",
-                "@crawlee/core": "^3.0.4",
-                "@crawlee/http": "^3.0.4",
-                "@crawlee/jsdom": "^3.0.4",
-                "@crawlee/playwright": "^3.0.4",
-                "@crawlee/puppeteer": "^3.0.4",
-                "@crawlee/utils": "^3.0.4",
+                "@crawlee/basic": "^3.1.0",
+                "@crawlee/browser": "^3.1.0",
+                "@crawlee/cheerio": "^3.1.0",
+                "@crawlee/cli": "^3.1.0",
+                "@crawlee/core": "^3.1.0",
+                "@crawlee/http": "^3.1.0",
+                "@crawlee/jsdom": "^3.1.0",
+                "@crawlee/playwright": "^3.1.0",
+                "@crawlee/puppeteer": "^3.1.0",
+                "@crawlee/utils": "^3.1.0",
                 "import-local": "^3.1.0"
             }
         },
@@ -21056,9 +21056,9 @@
             }
         },
         "decimal.js": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.1.tgz",
-            "integrity": "sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==",
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
+            "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
             "dev": true
         },
         "decompress-response": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@typescript-eslint/eslint-plugin": "5.40.0",
         "@typescript-eslint/parser": "5.40.0",
         "commitlint": "^17.0.3",
-        "crawlee": "^3.0.0",
+        "crawlee": "^3.1.0",
         "eslint": "~8.25.0",
         "fs-extra": "^10.1.0",
         "gen-esm-wrapper": "^1.1.3",

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -3,10 +3,10 @@ import { ACT_JOB_STATUSES, ENV_VARS, KEY_VALUE_STORE_KEYS, WEBHOOK_EVENT_TYPES }
 import log from '@apify/log';
 import { encryptInputSecrets } from '@apify/input_secrets';
 import type { ApifyEnv } from 'apify';
-import { Actor, ProxyConfiguration } from 'apify';
+import { Actor, ProxyConfiguration, KeyValueStore, Dataset } from 'apify';
 import type { WebhookUpdateData } from 'apify-client';
 import { ActorClient, ApifyClient, RunClient, TaskClient } from 'apify-client';
-import { Configuration, EventType, Dataset, KeyValueStore, RequestList, StorageManager } from '@crawlee/core';
+import { Configuration, EventType, StorageManager } from '@crawlee/core';
 import { sleep } from '@crawlee/utils';
 import { MemoryStorageEmulator } from '../MemoryStorageEmulator';
 
@@ -993,12 +993,11 @@ describe('Actor', () => {
             const defaultStore = await KeyValueStore.open();
             const setValueSpy = jest.spyOn(defaultStore, 'setValue');
 
-            setValueSpy.mockImplementation(async (key, value) => {
-                expect(key).toEqual('key-1');
-                expect(value).toEqual(record);
-            });
+            setValueSpy.mockImplementation(async () => {});
 
             await Actor.setValue('key-1', record);
+
+            expect(setValueSpy).toHaveBeenCalledWith('key-1', record, {});
         });
     });
 
@@ -1007,9 +1006,11 @@ describe('Actor', () => {
             const defaultStore = await KeyValueStore.open();
             const getValueSpy = jest.spyOn(defaultStore, 'getValue');
 
-            getValueSpy.mockImplementationOnce(async (key) => expect(key).toBe('key-1'));
+            getValueSpy.mockImplementationOnce(async () => {});
 
             await Actor.getValue('key-1');
+
+            expect(getValueSpy).toHaveBeenCalledWith('key-1');
         });
     });
 
@@ -1018,9 +1019,11 @@ describe('Actor', () => {
             const defaultStore = await Dataset.open();
             const pushDataSpy = jest.spyOn(defaultStore, 'pushData');
 
-            pushDataSpy.mockImplementationOnce(async (data) => expect(data).toStrictEqual({ hello: 'apify' }));
+            pushDataSpy.mockImplementationOnce(async () => {});
 
             await Actor.pushData({ hello: 'apify' });
+
+            expect(pushDataSpy).toHaveBeenCalledWith({ hello: 'apify' });
         });
     });
 });

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -991,42 +991,36 @@ describe('Actor', () => {
         test('should work', async () => {
             const record = { foo: 'bar' };
             const defaultStore = await KeyValueStore.open();
+            const setValueSpy = jest.spyOn(defaultStore, 'setValue');
 
-            const oldSet = defaultStore.setValue;
-            defaultStore.setValue = async (key, value) => {
-                expect(key).toBe('key-1');
-                expect(value).toBe(record);
-            };
+            setValueSpy.mockImplementation(async (key, value) => {
+                expect(key).toEqual('key-1');
+                expect(value).toEqual(record);
+            });
 
             await Actor.setValue('key-1', record);
-
-            defaultStore.setValue = oldSet;
         });
     });
 
     describe('Actor.getValue', () => {
         test('should work', async () => {
             const defaultStore = await KeyValueStore.open();
+            const getValueSpy = jest.spyOn(defaultStore, 'getValue');
 
-            const oldGet = defaultStore.getValue;
-            defaultStore.getValue = async (key) => expect(key).toBe('key-1');
+            getValueSpy.mockImplementationOnce(async (key) => expect(key).toBe('key-1'));
 
             await Actor.getValue('key-1');
-
-            defaultStore.getValue = oldGet;
         });
     });
 
     describe('Actor.pushData', () => {
         test('should work', async () => {
-            const defaultStore = await KeyValueStore.open();
+            const defaultStore = await Dataset.open();
+            const pushDataSpy = jest.spyOn(defaultStore, 'pushData');
 
-            const oldGet = defaultStore.getValue;
-            defaultStore.getValue = async (key) => expect(key).toBe('key-1');
+            pushDataSpy.mockImplementationOnce(async (data) => expect(data).toStrictEqual({ hello: 'apify' }));
 
-            await Actor.getValue('key-1');
-
-            defaultStore.getValue = oldGet;
+            await Actor.pushData({ hello: 'apify' });
         });
     });
 });


### PR DESCRIPTION
Tackles a part of #84 