### PR TITLE
docs: fix broken ApiLink (v3.0)

### DIFF
--- a/docs/examples/add_data_to_dataset.mdx
+++ b/docs/examples/add_data_to_dataset.mdx
@@ -8,7 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import AddDataToDatasetSource from '!!raw-loader!./add_data_to_dataset.ts';
 
 This example saves data to the default dataset. If the dataset doesn't exist, it will be created.
-You can save data to custom datasets by using <ApiLink to="core/class/Dataset#open">`Actor.openDataset()`</ApiLink>
+You can save data to custom datasets by using <ApiLink to="apify/class/Dataset#open">`Actor.openDataset()`</ApiLink>
 
 <CodeBlock className="language-js">
 	{AddDataToDatasetSource}

--- a/docs/examples/crawl_relative_links.mdx
+++ b/docs/examples/crawl_relative_links.mdx
@@ -14,15 +14,15 @@ import SameSubdomainSource from '!!raw-loader!./crawl_relative_links_same_subdom
 
 When crawling a website, you may encounter different types of links present that you may want to crawl.
 To facilitate the easy crawling of such links, we provide the `enqueueLinks()` method on the crawler context, which will
-automatically find links and add them to the crawler's <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>.
+automatically find links and add them to the crawler's <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink>.
 
 We provide 3 different strategies for crawling relative links:
 
-- <ApiLink to="core/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></ApiLink> which will enqueue all links found, regardless of
+- <ApiLink to="apify/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></ApiLink> which will enqueue all links found, regardless of
 the domain they point to.
-- <ApiLink to="core/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></ApiLink> which will enqueue all links
+- <ApiLink to="apify/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></ApiLink> which will enqueue all links
 found for the same hostname (regardless of any subdomains present).
-- <ApiLink to="core/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></ApiLink> which will enqueue all links
+- <ApiLink to="apify/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></ApiLink> which will enqueue all links
 found that have the same subdomain and hostname. This is the default strategy.
 
 :::note

--- a/docs/examples/crawl_some_links.mdx
+++ b/docs/examples/crawl_some_links.mdx
@@ -7,7 +7,7 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
 
-This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/class/PseudoUrl">`pseudoUrls`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
+This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="apify/class/PseudoUrl">`pseudoUrls`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
 
 <CodeBlock className="language-js">
 	{CrawlSource}

--- a/docs/examples/forms.mdx
+++ b/docs/examples/forms.mdx
@@ -11,7 +11,7 @@ This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/Puppet
 automatically fill and submit a search form to look up repositories on [GitHub](https://github.com) using headless Chrome / Puppeteer.
 The actor first fills in the search term, repository owner, start date and language of the repository, then submits the form
 and prints out the results. Finally, the results are saved either on the Apify platform to the
-default <ApiLink to="core/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./storage/datasets/default`.
+default <ApiLink to="apify/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./storage/datasets/default`.
 
 :::tip
 

--- a/docs/examples/map_and_reduce.mdx
+++ b/docs/examples/map_and_reduce.mdx
@@ -8,9 +8,9 @@ import ApiLink from '@site/src/components/ApiLink';
 import MapSource from '!!raw-loader!./map.ts';
 import ReduceSource from '!!raw-loader!./reduce.ts';
 
-This example shows an easy use-case of the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> <ApiLink to="core/class/Dataset#map">`map`</ApiLink>
-and <ApiLink to="core/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
-the dataset results workflow process. Both can be called on the <ApiLink to="core/class/Dataset">dataset</ApiLink> directly.
+This example shows an easy use-case of the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> <ApiLink to="apify/class/Dataset#map">`map`</ApiLink>
+and <ApiLink to="apify/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
+the dataset results workflow process. Both can be called on the <ApiLink to="apify/class/Dataset">dataset</ApiLink> directly.
 
 Important to mention is that both methods return a new result (`map` returns a new array and `reduce` can return any type) - neither method updates
 the dataset in any way.
@@ -19,7 +19,7 @@ Examples for both methods are demonstrated on a simple dataset containing the re
 `h1` - `h3` header elements under the `headingCount` key.
 
 This data structure is stored in the default dataset under `{PROJECT_FOLDER}/storage/datasets/default/`. If you want to simulate the
-functionality, you can use the <ApiLink to="core/class/Dataset#pushData">`Actor.pushData()`</ApiLink>
+functionality, you can use the <ApiLink to="apify/class/Dataset#pushData">`Actor.pushData()`</ApiLink>
 method to save the example `JSON array` to your dataset.
 
 ```json
@@ -52,7 +52,7 @@ The `map` method used to check if are there more than 5 header elements on each 
 
 The `moreThan5headers` variable is an array of `headingCount` attributes where the number of headers is greater than 5.
 
-The `map` method's result value saved to the <ApiLink to="core/class/KeyValueStore">`key-value store`</ApiLink> should be:
+The `map` method's result value saved to the <ApiLink to="apify/class/KeyValueStore">`key-value store`</ApiLink> should be:
 
 ```javascript
 [11, 8]
@@ -61,7 +61,7 @@ The `map` method's result value saved to the <ApiLink to="core/class/KeyValueSto
 ### Reduce
 
 The dataset `reduce` method does not produce a new array of values - it reduces a list of values down to a single value. The method iterates through
-the items in the dataset using the <ApiLink to="core/class/Dataset#reduce">`memo` argument</ApiLink>. After performing the necessary
+the items in the dataset using the <ApiLink to="apify/class/Dataset#reduce">`memo` argument</ApiLink>. After performing the necessary
 calculation, the `memo` is sent to the next iteration, while the item just processed is reduced (removed).
 
 Using the `reduce` method to get the total number of headers scraped (all items in the dataset):
@@ -73,7 +73,7 @@ Using the `reduce` method to get the total number of headers scraped (all items 
 The original dataset will be reduced to a single value, `pagesHeadingCount`, which contains the count of all headers for all scraped pages (all
 dataset items).
 
-The `reduce` method's result value saved to the <ApiLink to="core/class/KeyValueStore">`key-value store`</ApiLink> should be:
+The `reduce` method's result value saved to the <ApiLink to="apify/class/KeyValueStore">`key-value store`</ApiLink> should be:
 
 ```javascript
 23

--- a/docs/examples/playwright_crawler.mdx
+++ b/docs/examples/playwright_crawler.mdx
@@ -8,7 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./playwright_crawler.ts';
 
 This example demonstrates how to use <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>
-in combination with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> to
+in combination with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> to
 recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Playwright.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results

--- a/docs/examples/puppeteer_crawler.mdx
+++ b/docs/examples/puppeteer_crawler.mdx
@@ -8,7 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./puppeteer_crawler.ts';
 
 This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> in combination
-with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>
+with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink>
 to recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Puppeteer.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results

--- a/docs/guides/apify_platform.mdx
+++ b/docs/guides/apify_platform.mdx
@@ -64,7 +64,7 @@ variable to your API token.
 
 ### Log in with Configuration
 
-Another option is to use the [`Configuration`](https://apify.github.io/apify-sdk-js/api/apify/class/Configuration) instance and set your api token there.
+Another option is to use the [`Configuration`](https://sdk.apify.com/api/apify/class/Configuration) instance and set your api token there.
 
 ```javascript
 import { Actor } from 'apify';
@@ -109,12 +109,12 @@ apify run
 ## Running Crawlee code as an actor
 
 For running Crawlee code as an actor on [Apify platform](https://apify.com/actors) you should either:
-- use a combination of [`Actor.init()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#init) and [`Actor.exit()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#exit) functions;
-- or wrap it into [`Actor.main()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#main) function.
+- use a combination of [`Actor.init()`](https://sdk.apify.com/api/apify/class/Actor#init) and [`Actor.exit()`](https://sdk.apify.com/api/apify/class/Actor#exit) functions;
+- or wrap it into [`Actor.main()`](https://sdk.apify.com/api/apify/class/Actor#main) function.
 
 :::info NOTE
-- Adding [`Actor.init()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#init) and [`Actor.exit()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#exit) to your code are the only two important things needed to run it on Apify platform as an actor. `Actor.init()` is needed to initialize your actor (e.g. to set the correct storage implementation), while without `Actor.exit()` the process will simply never stop.
-- [`Actor.main()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#main) is an alternative to `Actor.init()` and `Actor.exit()` as it calls both behind the scenes.
+- Adding [`Actor.init()`](https://sdk.apify.com/api/apify/class/Actor#init) and [`Actor.exit()`](https://sdk.apify.com/api/apify/class/Actor#exit) to your code are the only two important things needed to run it on Apify platform as an actor. `Actor.init()` is needed to initialize your actor (e.g. to set the correct storage implementation), while without `Actor.exit()` the process will simply never stop.
+- [`Actor.main()`](https://sdk.apify.com/api/apify/class/Actor#main) is an alternative to `Actor.init()` and `Actor.exit()` as it calls both behind the scenes.
 :::
 
 Let's look at the `CheerioCrawler` example from the [Quick Start](../quick-start) guide:
@@ -160,22 +160,22 @@ There are several things worth mentioning here.
 ### Helper functions for default Key-Value Store and Dataset
 
 To simplify access to the _default_ storages, instead of using the helper functions of respective storage classes, you could use:
-- [`Actor.setValue()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#setValue), [`Actor.getValue()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#getValue), [`Actor.getInput()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#getInput) for `Key-Value Store`
-- [`Actor.pushData()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#pushData) for `Dataset`
+- [`Actor.setValue()`](https://sdk.apify.com/api/apify/class/Actor#setValue), [`Actor.getValue()`](https://sdk.apify.com/api/apify/class/Actor#getValue), [`Actor.getInput()`](https://sdk.apify.com/api/apify/class/Actor#getInput) for `Key-Value Store`
+- [`Actor.pushData()`](https://sdk.apify.com/api/apify/class/Actor#pushData) for `Dataset`
 
 ### Using platform storage in a local actor
 
-When you plan to use the platform storage while developing and running your actor locally, you should use [`Actor.openKeyValueStore()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#openKeyValueStore), [`Actor.openDataset()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#openDataset) and [`Actor.openRequestQueue()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#openRequestQueue) to open the respective storage.
+When you plan to use the platform storage while developing and running your actor locally, you should use [`Actor.openKeyValueStore()`](https://sdk.apify.com/api/apify/class/Actor#openKeyValueStore), [`Actor.openDataset()`](https://sdk.apify.com/api/apify/class/Actor#openDataset) and [`Actor.openRequestQueue()`](https://sdk.apify.com/api/apify/class/Actor#openRequestQueue) to open the respective storage.
 
-Using each of these methods allows to pass the [`OpenStorageOptions`](https://apify.github.io/apify-sdk-js/api/apify/interface/OpenStorageOptions) as a second argument, which has only one optional property: [`forceCloud`](https://apify.github.io/apify-sdk-js/api/apify/interface/OpenStorageOptions#forceCloud). If set to `true` - cloud storage will be used instead of the folder on the local disk.
+Using each of these methods allows to pass the [`OpenStorageOptions`](https://sdk.apify.com/api/apify/interface/OpenStorageOptions) as a second argument, which has only one optional property: [`forceCloud`](https://sdk.apify.com/api/apify/interface/OpenStorageOptions#forceCloud). If set to `true` - cloud storage will be used instead of the folder on the local disk.
 
 :::note
-If you don't plan to force usage of the platform storages when running the actor locally, there is no need to use the [`Actor`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor) class for it. The Crawlee variants <ApiLink to="core/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="core/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="core/class/RequestQueue#open">`RequestQueue.open()`</ApiLink> will work the same.
+If you don't plan to force usage of the platform storages when running the actor locally, there is no need to use the [`Actor`](https://sdk.apify.com/api/apify/class/Actor) class for it. The Crawlee variants <ApiLink to="apify/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="apify/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="apify/class/RequestQueue#open">`RequestQueue.open()`</ApiLink> will work the same.
 :::
 
 ### Getting public url of an item in the platform storage
 
-If you need to share a link to some file stored in a Key-Value Store on Apify Platform, you can use [`getPublicUrl()`](https://apify.github.io/apify-sdk-js/api/apify/class/KeyValueStore#getPublicUrl) method. It accepts only one parameter: `key` - the key of the item you want to share.
+If you need to share a link to some file stored in a Key-Value Store on Apify Platform, you can use [`getPublicUrl()`](https://sdk.apify.com/api/apify/class/KeyValueStore#getPublicUrl) method. It accepts only one parameter: `key` - the key of the item you want to share.
 
 ```js
 import { KeyValueStore } from 'apify';
@@ -188,7 +188,7 @@ const url = store.getPublicUrl('your-file');
 
 ### Exporting dataset data
 
-When the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> is stored on the [Apify platform](https://apify.com/actors), you can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
+When the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> is stored on the [Apify platform](https://apify.com/actors), you can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
 
 **Related links**
 
@@ -266,7 +266,7 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
-Note that unlike using your own proxies in Crawlee, you shouldn't use the constructor to create <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy you should create an instance using the [`Actor.createProxyConfiguration()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#createProxyConfiguration) function instead.
+Note that unlike using your own proxies in Crawlee, you shouldn't use the constructor to create <ApiLink to="apify/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy you should create an instance using the [`Actor.createProxyConfiguration()`](https://sdk.apify.com/api/apify/class/Actor#createProxyConfiguration) function instead.
 
 ### Apify Proxy Configuration
 
@@ -297,8 +297,8 @@ that allows connection through millions of different IP addresses. So the class
 essentially has two modes: Apify Proxy or Own (third party) proxy.
 
 The difference is easy to remember.
-- If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="core/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
-- If you are planning to use Apify Proxy - you should create an instance using the [`Actor.createProxyConfiguration()`](https://apify.github.io/apify-sdk-js/api/apify/class/Actor#createProxyConfiguration) function. <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
+- If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="apify/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="apify/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
+- If you are planning to use Apify Proxy - you should create an instance using the [`Actor.createProxyConfiguration()`](https://sdk.apify.com/api/apify/class/Actor#createProxyConfiguration) function. <ApiLink to="apify/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="apify/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
 
 **Related links**
 

--- a/docs/guides/environment_variables.mdx
+++ b/docs/guides/environment_variables.mdx
@@ -17,7 +17,7 @@ can be changed significantly by setting or unsetting them.
 
 ### `APIFY_LOCAL_STORAGE_DIR`
 
-Defines the path to a local directory where <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> store their data. Typically, it is set to `./storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token) environment variable instead.
+Defines the path to a local directory where <ApiLink to="apify/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> store their data. Typically, it is set to `./storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token) environment variable instead.
 
 ### `APIFY_TOKEN`
 
@@ -63,12 +63,12 @@ are launched in headful mode, i.e. with windows.
 
 Specifies the minimum log level, which can be one of the following values (in order of severity):
 `DEBUG`, `INFO`, `WARNING` and `ERROR`. By default, the log level is set to `INFO`,
-which means that `DEBUG` messages are not printed to console. See the <ApiLink to="core/class/Log">`utils.log`</ApiLink>
+which means that `DEBUG` messages are not printed to console. See the <ApiLink to="apify/class/Log">`utils.log`</ApiLink>
 namespace for logging utilities.
 
 ### `APIFY_MEMORY_MBYTES`
 
-Sets the amount of system memory in megabytes to be used by the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink>.
+Sets the amount of system memory in megabytes to be used by the <ApiLink to="apify/class/AutoscaledPool">`AutoscaledPool`</ApiLink>.
 It is used to limit the number of concurrently running tasks. By default, the max amount of memory
 to be used is set to one quarter of total system memory, i.e. on a system with 8192 MB of memory,
 the autoscaling feature will only use up to 2048 MB of memory.

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -46,7 +46,7 @@ const proxyUrl = proxyConfiguration.newUrl();
 
 ## Proxy Configuration
 
-All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
+All your proxy needs are managed by the <ApiLink to="apify/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. See the <ApiLink to="apify/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
 
 ### Crawler integration
 
@@ -79,7 +79,7 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-&#8203;<ApiLink to="core/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> class for more information on how keeping a real session helps you avoid blocking.
+&#8203;<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <ApiLink to="apify/class/SessionPool">`SessionPool`</ApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
 
@@ -116,7 +116,7 @@ one would call a super-proxy. It's not a single proxy server, but an API endpoin
 that allows connection through millions of different IP addresses. So the class
 essentially has two modes: Apify Proxy or Your proxy.
 
-The difference is easy to remember. <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
+The difference is easy to remember. <ApiLink to="apify/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="apify/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
 
 ## Apify Proxy Configuration
 
@@ -138,6 +138,6 @@ in the [proxy dashboard](https://console.apify.com/proxy).
 ## Inspecting current proxy in Crawlers
 
 `CheerioCrawler` and `PuppeteerCrawler` grant access to information about the currently used proxy
-in their `handlePageFunction` using a <ApiLink to="core/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
+in their `handlePageFunction` using a <ApiLink to="apify/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
 With the  object, you can easily access the proxy URL. If you're using Apify Proxy, the other
 configuration parameters will also be available in the `proxyInfo` object.

--- a/docs/guides/request_storage.mdx
+++ b/docs/guides/request_storage.mdx
@@ -22,7 +22,7 @@ The request queue is a storage of URLs to crawl. The queue is used for the deep 
 
 Each actor run is associated with a **default request queue**, which is created exclusively for the actor run. Typically, it is used to store URLs to crawl in the specific actor run. Its usage is optional.
 
-In Apify SDK, the request queue is represented by the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> class.
+In Apify SDK, the request queue is represented by the <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> class.
 
 In local configuration, the request queue is emulated by [@apify/storage-local](https://github.com/apify/apify-storage-local-js) NPM package and its data is stored in SQLite database in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -60,7 +60,7 @@ The request list is not a storage per se - it represents the list of URLs to cra
 
 Request list is created exclusively for the actor run and only if its usage is explicitly specified in the code. Its usage is optional.
 
-In Apify SDK, the request list is represented by the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class.
+In Apify SDK, the request list is represented by the <ApiLink to="apify/class/RequestList">`RequestList`</ApiLink> class.
 
 The following code demonstrates basic operations of the request list:
 

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -30,7 +30,7 @@ Each actor run is associated with a **default key-value store**, which is create
 and output is stored in the default key-value store under the `INPUT` and `OUTPUT` key, respectively. Typically the input and output is a JSON file,
 although it can be any other format.
 
-In the Apify SDK, the key-value store is represented by the <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
+In the Apify SDK, the key-value store is represented by the <ApiLink to="apify/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
 key-value store, the SDK also provides <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink> and <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> functions.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
@@ -84,7 +84,7 @@ way you can easily share crawling results.
 Each actor run is associated with a **default dataset**, which is created exclusively for the actor run. Typically, it is used to store crawling
 results specific for the actor run. Its usage is optional.
 
-In the Apify SDK, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
+In the Apify SDK, the dataset is represented by the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
 also provides the <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> function.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:

--- a/docs/guides/session_management.mdx
+++ b/docs/guides/session_management.mdx
@@ -5,7 +5,7 @@ title: Session Management
 
 import ApiLink from '@site/src/components/ApiLink';
 
-&#8203;<ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+&#8203;<ApiLink to="apify/class/SessionPool">`SessionPool`</ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.

--- a/website/src/components/ApiLink.jsx
+++ b/website/src/components/ApiLink.jsx
@@ -5,7 +5,7 @@ import { useDocsVersion } from '@docusaurus/theme-common/internal';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 const ApiLink = ({ to, children }) => {
-    const version = useDocsVersion();
+    const { version, isLast } = useDocsVersion();
     const { siteConfig } = useDocusaurusContext();
 
     if (siteConfig.presets[0][1].docs.disableVersioning) {
@@ -14,8 +14,16 @@ const ApiLink = ({ to, children }) => {
         );
     }
 
+    let versionSlug = `${version}/`;
+
+    if (version === 'current') {
+        versionSlug = 'next/';
+    } else if (isLast) {
+        versionSlug = '';
+    }
+
     return (
-        <Link to={`/api/${version.version === 'current' ? 'next' : version.version}/${to}`}>{children}</Link>
+        <Link to={`/api/${versionSlug}${to}`}>{children}</Link>
     );
 };
 

--- a/website/versioned_docs/version-3.0/examples/add_data_to_dataset.mdx
+++ b/website/versioned_docs/version-3.0/examples/add_data_to_dataset.mdx
@@ -8,7 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import AddDataToDatasetSource from '!!raw-loader!./add_data_to_dataset.ts';
 
 This example saves data to the default dataset. If the dataset doesn't exist, it will be created.
-You can save data to custom datasets by using <ApiLink to="core/class/Dataset#open">`Actor.openDataset()`</ApiLink>
+You can save data to custom datasets by using <ApiLink to="apify/class/Dataset#open">`Actor.openDataset()`</ApiLink>
 
 <CodeBlock className="language-js">
 	{AddDataToDatasetSource}

--- a/website/versioned_docs/version-3.0/examples/crawl_relative_links.mdx
+++ b/website/versioned_docs/version-3.0/examples/crawl_relative_links.mdx
@@ -14,15 +14,15 @@ import SameSubdomainSource from '!!raw-loader!./crawl_relative_links_same_subdom
 
 When crawling a website, you may encounter different types of links present that you may want to crawl.
 To facilitate the easy crawling of such links, we provide the `enqueueLinks()` method on the crawler context, which will
-automatically find links and add them to the crawler's <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>.
+automatically find links and add them to the crawler's <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink>.
 
 We provide 3 different strategies for crawling relative links:
 
-- <ApiLink to="core/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></ApiLink> which will enqueue all links found, regardless of
+- <ApiLink to="apify/enum/EnqueueStrategy#All"><inlineCode>All</inlineCode></ApiLink> which will enqueue all links found, regardless of
 the domain they point to.
-- <ApiLink to="core/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></ApiLink> which will enqueue all links
+- <ApiLink to="apify/enum/EnqueueStrategy#SameHostname"><inlineCode>SameHostname</inlineCode></ApiLink> which will enqueue all links
 found for the same hostname (regardless of any subdomains present).
-- <ApiLink to="core/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></ApiLink> which will enqueue all links
+- <ApiLink to="apify/enum/EnqueueStrategy#SameSubdomain"><inlineCode>SameSubdomain</inlineCode></ApiLink> which will enqueue all links
 found that have the same subdomain and hostname. This is the default strategy.
 
 :::note

--- a/website/versioned_docs/version-3.0/examples/crawl_some_links.mdx
+++ b/website/versioned_docs/version-3.0/examples/crawl_some_links.mdx
@@ -7,7 +7,7 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
 
-This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="core/class/PseudoUrl">`pseudoUrls`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
+This <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> example uses the <ApiLink to="apify/class/PseudoUrl">`pseudoUrls`</ApiLink> property in the <ApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</ApiLink> method to only add links to the <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
 
 <CodeBlock className="language-js">
 	{CrawlSource}

--- a/website/versioned_docs/version-3.0/examples/forms.mdx
+++ b/website/versioned_docs/version-3.0/examples/forms.mdx
@@ -11,7 +11,7 @@ This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/Puppet
 automatically fill and submit a search form to look up repositories on [GitHub](https://github.com) using headless Chrome / Puppeteer.
 The actor first fills in the search term, repository owner, start date and language of the repository, then submits the form
 and prints out the results. Finally, the results are saved either on the Apify platform to the
-default <ApiLink to="core/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./storage/datasets/default`.
+default <ApiLink to="apify/class/Dataset">`dataset`</ApiLink> or on the local machine as JSON files in `./storage/datasets/default`.
 
 :::tip
 

--- a/website/versioned_docs/version-3.0/examples/map_and_reduce.mdx
+++ b/website/versioned_docs/version-3.0/examples/map_and_reduce.mdx
@@ -8,9 +8,9 @@ import ApiLink from '@site/src/components/ApiLink';
 import MapSource from '!!raw-loader!./map.ts';
 import ReduceSource from '!!raw-loader!./reduce.ts';
 
-This example shows an easy use-case of the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> <ApiLink to="core/class/Dataset#map">`map`</ApiLink>
-and <ApiLink to="core/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
-the dataset results workflow process. Both can be called on the <ApiLink to="core/class/Dataset">dataset</ApiLink> directly.
+This example shows an easy use-case of the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> <ApiLink to="apify/class/Dataset#map">`map`</ApiLink>
+and <ApiLink to="apify/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
+the dataset results workflow process. Both can be called on the <ApiLink to="apify/class/Dataset">dataset</ApiLink> directly.
 
 Important to mention is that both methods return a new result (`map` returns a new array and `reduce` can return any type) - neither method updates
 the dataset in any way.
@@ -19,7 +19,7 @@ Examples for both methods are demonstrated on a simple dataset containing the re
 `h1` - `h3` header elements under the `headingCount` key.
 
 This data structure is stored in the default dataset under `{PROJECT_FOLDER}/storage/datasets/default/`. If you want to simulate the
-functionality, you can use the <ApiLink to="core/class/Dataset#pushData">`Actor.pushData()`</ApiLink>
+functionality, you can use the <ApiLink to="apify/class/Dataset#pushData">`Actor.pushData()`</ApiLink>
 method to save the example `JSON array` to your dataset.
 
 ```json
@@ -52,7 +52,7 @@ The `map` method used to check if are there more than 5 header elements on each 
 
 The `moreThan5headers` variable is an array of `headingCount` attributes where the number of headers is greater than 5.
 
-The `map` method's result value saved to the <ApiLink to="core/class/KeyValueStore">`key-value store`</ApiLink> should be:
+The `map` method's result value saved to the <ApiLink to="apify/class/KeyValueStore">`key-value store`</ApiLink> should be:
 
 ```javascript
 [11, 8]
@@ -61,7 +61,7 @@ The `map` method's result value saved to the <ApiLink to="core/class/KeyValueSto
 ### Reduce
 
 The dataset `reduce` method does not produce a new array of values - it reduces a list of values down to a single value. The method iterates through
-the items in the dataset using the <ApiLink to="core/class/Dataset#reduce">`memo` argument</ApiLink>. After performing the necessary
+the items in the dataset using the <ApiLink to="apify/class/Dataset#reduce">`memo` argument</ApiLink>. After performing the necessary
 calculation, the `memo` is sent to the next iteration, while the item just processed is reduced (removed).
 
 Using the `reduce` method to get the total number of headers scraped (all items in the dataset):
@@ -73,7 +73,7 @@ Using the `reduce` method to get the total number of headers scraped (all items 
 The original dataset will be reduced to a single value, `pagesHeadingCount`, which contains the count of all headers for all scraped pages (all
 dataset items).
 
-The `reduce` method's result value saved to the <ApiLink to="core/class/KeyValueStore">`key-value store`</ApiLink> should be:
+The `reduce` method's result value saved to the <ApiLink to="apify/class/KeyValueStore">`key-value store`</ApiLink> should be:
 
 ```javascript
 23

--- a/website/versioned_docs/version-3.0/examples/playwright_crawler.mdx
+++ b/website/versioned_docs/version-3.0/examples/playwright_crawler.mdx
@@ -8,7 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./playwright_crawler.ts';
 
 This example demonstrates how to use <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>
-in combination with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> to
+in combination with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> to
 recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Playwright.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results

--- a/website/versioned_docs/version-3.0/examples/puppeteer_crawler.mdx
+++ b/website/versioned_docs/version-3.0/examples/puppeteer_crawler.mdx
@@ -8,7 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!./puppeteer_crawler.ts';
 
 This example demonstrates how to use <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> in combination
-with <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink>
+with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink>
 to recursively scrape the [Hacker News website](https://news.ycombinator.com) using headless Chrome / Puppeteer.
 
 The crawler starts with a single URL, finds links to next pages, enqueues them and continues until no more desired links are available. The results

--- a/website/versioned_docs/version-3.0/guides/environment_variables.mdx
+++ b/website/versioned_docs/version-3.0/guides/environment_variables.mdx
@@ -17,7 +17,7 @@ can be changed significantly by setting or unsetting them.
 
 ### `APIFY_LOCAL_STORAGE_DIR`
 
-Defines the path to a local directory where <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="core/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> store their data. Typically, it is set to `./storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token) environment variable instead.
+Defines the path to a local directory where <ApiLink to="apify/class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink>, and <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> store their data. Typically, it is set to `./storage`. If omitted, you should define the [`APIFY_TOKEN`](#apify_token) environment variable instead.
 
 ### `APIFY_TOKEN`
 
@@ -63,12 +63,12 @@ are launched in headful mode, i.e. with windows.
 
 Specifies the minimum log level, which can be one of the following values (in order of severity):
 `DEBUG`, `INFO`, `WARNING` and `ERROR`. By default, the log level is set to `INFO`,
-which means that `DEBUG` messages are not printed to console. See the <ApiLink to="core/class/Log">`utils.log`</ApiLink>
+which means that `DEBUG` messages are not printed to console. See the <ApiLink to="apify/class/Log">`utils.log`</ApiLink>
 namespace for logging utilities.
 
 ### `APIFY_MEMORY_MBYTES`
 
-Sets the amount of system memory in megabytes to be used by the <ApiLink to="core/class/AutoscaledPool">`AutoscaledPool`</ApiLink>.
+Sets the amount of system memory in megabytes to be used by the <ApiLink to="apify/class/AutoscaledPool">`AutoscaledPool`</ApiLink>.
 It is used to limit the number of concurrently running tasks. By default, the max amount of memory
 to be used is set to one quarter of total system memory, i.e. on a system with 8192 MB of memory,
 the autoscaling feature will only use up to 2048 MB of memory.

--- a/website/versioned_docs/version-3.0/guides/proxy_management.mdx
+++ b/website/versioned_docs/version-3.0/guides/proxy_management.mdx
@@ -46,7 +46,7 @@ const proxyUrl = proxyConfiguration.newUrl();
 
 ## Proxy Configuration
 
-All your proxy needs are managed by the <ApiLink to="core/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. See the <ApiLink to="core/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
+All your proxy needs are managed by the <ApiLink to="apify/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> class. You create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. See the <ApiLink to="apify/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink> for all the possible constructor options.
 
 ### Crawler integration
 
@@ -79,7 +79,7 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-&#8203;<ApiLink to="core/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> class for more information on how keeping a real session helps you avoid blocking.
+&#8203;<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <ApiLink to="apify/class/SessionPool">`SessionPool`</ApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
 
@@ -116,7 +116,7 @@ one would call a super-proxy. It's not a single proxy server, but an API endpoin
 that allows connection through millions of different IP addresses. So the class
 essentially has two modes: Apify Proxy or Your proxy.
 
-The difference is easy to remember. <ApiLink to="core/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="core/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
+The difference is easy to remember. <ApiLink to="apify/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="apify/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy. Visit the [Apify Proxy docs](https://docs.apify.com/proxy) for more info on how these parameters work.
 
 ## Apify Proxy Configuration
 
@@ -138,6 +138,6 @@ in the [proxy dashboard](https://console.apify.com/proxy).
 ## Inspecting current proxy in Crawlers
 
 `CheerioCrawler` and `PuppeteerCrawler` grant access to information about the currently used proxy
-in their `handlePageFunction` using a <ApiLink to="core/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
+in their `handlePageFunction` using a <ApiLink to="apify/interface/ProxyInfo">`proxyInfo`</ApiLink> object.
 With the  object, you can easily access the proxy URL. If you're using Apify Proxy, the other
 configuration parameters will also be available in the `proxyInfo` object.

--- a/website/versioned_docs/version-3.0/guides/request_storage.mdx
+++ b/website/versioned_docs/version-3.0/guides/request_storage.mdx
@@ -22,7 +22,7 @@ The request queue is a storage of URLs to crawl. The queue is used for the deep 
 
 Each actor run is associated with a **default request queue**, which is created exclusively for the actor run. Typically, it is used to store URLs to crawl in the specific actor run. Its usage is optional.
 
-In Apify SDK, the request queue is represented by the <ApiLink to="core/class/RequestQueue">`RequestQueue`</ApiLink> class.
+In Apify SDK, the request queue is represented by the <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> class.
 
 In local configuration, the request queue is emulated by [@apify/storage-local](https://github.com/apify/apify-storage-local-js) NPM package and its data is stored in SQLite database in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
 
@@ -60,7 +60,7 @@ The request list is not a storage per se - it represents the list of URLs to cra
 
 Request list is created exclusively for the actor run and only if its usage is explicitly specified in the code. Its usage is optional.
 
-In Apify SDK, the request list is represented by the <ApiLink to="core/class/RequestList">`RequestList`</ApiLink> class.
+In Apify SDK, the request list is represented by the <ApiLink to="apify/class/RequestList">`RequestList`</ApiLink> class.
 
 The following code demonstrates basic operations of the request list:
 

--- a/website/versioned_docs/version-3.0/guides/result_storage.mdx
+++ b/website/versioned_docs/version-3.0/guides/result_storage.mdx
@@ -30,7 +30,7 @@ Each actor run is associated with a **default key-value store**, which is create
 and output is stored in the default key-value store under the `INPUT` and `OUTPUT` key, respectively. Typically the input and output is a JSON file,
 although it can be any other format.
 
-In the Apify SDK, the key-value store is represented by the <ApiLink to="core/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
+In the Apify SDK, the key-value store is represented by the <ApiLink to="apify/class/KeyValueStore">`KeyValueStore`</ApiLink> class. In order to simplify access to the default
 key-value store, the SDK also provides <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink> and <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink> functions.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:
@@ -84,7 +84,7 @@ way you can easily share crawling results.
 Each actor run is associated with a **default dataset**, which is created exclusively for the actor run. Typically, it is used to store crawling
 results specific for the actor run. Its usage is optional.
 
-In the Apify SDK, the dataset is represented by the <ApiLink to="core/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
+In the Apify SDK, the dataset is represented by the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> class. In order to simplify writes to the default dataset, the SDK
 also provides the <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> function.
 
 In local configuration, the data is stored in the directory specified by the `APIFY_LOCAL_STORAGE_DIR` environment variable as follows:

--- a/website/versioned_docs/version-3.0/guides/session_management.mdx
+++ b/website/versioned_docs/version-3.0/guides/session_management.mdx
@@ -5,7 +5,7 @@ title: Session Management
 
 import ApiLink from '@site/src/components/ApiLink';
 
-&#8203;<ApiLink to="core/class/SessionPool">`SessionPool`</ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+&#8203;<ApiLink to="apify/class/SessionPool">`SessionPool`</ApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.


### PR DESCRIPTION
The `ApiLink.tsx` URL update is a bit janky (and so is the logic behind the URLs), ideas welcome. 