### PR TITLE
chore: update generic scrapers readme and input schema

### DIFF
--- a/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
@@ -1,7 +1,7 @@
 {
     "title": "Cheerio Scraper Input",
     "type": "object",
-    "description": "Cheerio Scraper loads <b>Start URLs</b> using raw HTTP requests, parses the HTML using the <a href='https://cheerio.js.org' target='_blank' rel='noopener noreferrer'>Cheerio</a> library and then executes <b>Page function</b> for each page to extract data from it. To follow links and scrape additional pages, set <b>Link selector</b> with <b>Pseudo-URLs</b> to specify which links to follow. Alternatively, you can manually enqueue new links in the <b>Page function</b>. For details, see the actor's <a href='https://apify.com/apify/cheerio-scraper' target='_blank' rel='noopener'>README</a> or the <a href='https://apify.com/docs/scraping/tutorial/introduction' target='_blank' rel='noopener'>Web scraping tutorial</a> in the Apify documentation.",
+    "description": "Cheerio Scraper loads <b>Start URLs</b> using raw HTTP requests, parses the HTML using the <a href='https://cheerio.js.org' target='_blank' rel='noopener noreferrer'>Cheerio</a> library and then executes <b>Page function</b> for each page to extract data from it. To follow links and scrape additional pages, set <b>Link selector</b> with <b>Pseudo-URLs</b> and/or <b>Glob patterns</b> to specify which links to follow. Alternatively, you can manually enqueue new links in the <b>Page function</b>. For details, see the actor's <a href='https://apify.com/apify/cheerio-scraper' target='_blank' rel='noopener'>README</a> or the <a href='https://apify.com/docs/scraping/tutorial/introduction' target='_blank' rel='noopener'>Web scraping tutorial</a> in the Apify documentation.",
     "schemaVersion": 1,
     "properties": {
         "startUrls": {
@@ -28,7 +28,7 @@
             "prefill": ["https://crawlee.dev/*/*"]
         },
         "pseudoUrls": {
-            "title": "Pseudo-URLs (deprecated)",
+            "title": "Pseudo-URLs",
             "type": "array",
             "description": "Specifies what kind of URLs found by the <b>Link selector</b> should be added to the request queue. A pseudo-URL is a URL with <b>regular expressions</b> enclosed in <code>[]</code> brackets, e.g. <code>http://www.example.com/[.*]</code>. <br><br>If <b>Pseudo-URLs</b> are omitted, the actor enqueues all links matched by the <b>Link selector</b>.<br><br>For details, see <a href='https://apify.com/apify/cheerio-scraper#pseudo-urls' target='_blank' rel='noopener'>Pseudo-URLs</a> in README.",
             "editor": "pseudoUrls",
@@ -38,7 +38,7 @@
         "linkSelector": {
             "title": "Link selector",
             "type": "string",
-            "description": "A CSS selector stating which links on the page (<code>&lt;a&gt;</code> elements with <code>href</code> attribute) shall be followed and added to the request queue. To filter the links added to the queue, use the <b>Pseudo-URLs</b> field.<br><br>If the <b>Link selector</b> is empty, the page links are ignored.<br><br>For details, see the <a href='https://apify.com/apify/cheerio-scraper#link-selector' target='_blank' rel='noopener'>Link selector</a> in README.",
+            "description": "A CSS selector stating which links on the page (<code>&lt;a&gt;</code> elements with <code>href</code> attribute) shall be followed and added to the request queue. To filter the links added to the queue, use the <b>Pseudo-URLs</b> and/or <b>Glob patterns</b> field.<br><br>If the <b>Link selector</b> is empty, the page links are ignored.<br><br>For details, see the <a href='https://apify.com/apify/cheerio-scraper#link-selector' target='_blank' rel='noopener'>Link selector</a> in README.",
             "editor": "textfield",
             "prefill": "a[href]"
         },

--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -424,7 +424,7 @@ The **Proxy configuration** (`proxyConfiguration`) option enables you to set
 proxies that will be used by the scraper in order to prevent its detection by target web pages.
 You can use both the [Apify Proxy](https://apify.com/proxy) and custom HTTP or SOCKS5 proxy servers.
 
-The following table lists the available options of the proxy configuration setting:
+Proxy is required to run the scraper. The following table lists the available options of the proxy configuration setting:
 
 <table class="table table-bordered table-condensed">
     <tbody>

--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -43,7 +43,7 @@ use the **Additional MIME types** (`additionalMimeTypes`) input option.
 
 Note that while the default `Accept` HTTP header will allow any content type to be received,
 HTML and XML are preferred over JSON and other types. Thus, if you're allowing additional MIME
-types and you're still receiving invalid responses, be sure to override the `Accept`
+types, and you're still receiving invalid responses, be sure to override the `Accept`
 HTTP header setting in the requests from the scraper,
 either in [**Start URLs**](#start-urls), [**Pseudo URLs**](#pseudo-urls) or in the **Prepare request function**.
 
@@ -588,3 +588,6 @@ v2 introduced several minor breaking changes, you can read about those in the
 
 v3 introduces even more breaking changes.
 This [v3 migration guide](https://sdk.apify.com/docs/upgrading/upgrading-to-v3) should take you through these.
+
+Scraper-specific breaking changes:
+- Proxy usage is now required.

--- a/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
@@ -21,7 +21,7 @@
             "prefill": ["https://crawlee.dev/*/*"]
         },
         "pseudoUrls": {
-            "title": "Pseudo-URLs (deprecated)",
+            "title": "Pseudo-URLs",
             "type": "array",
             "description": "Pseudo-URLs to match links in the page that you want to enqueue. Combine with Link selector to tell the scraper where to find links. Omitting the Pseudo-URLs will cause the scraper to enqueue all links matched by the Link selector.",
             "editor": "pseudoUrls",

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -24,7 +24,7 @@ In summary, Playwright Scraper works as follows:
 2. For each request:
     - Evaluates all hooks in [Pre-navigation hooks](#pre-navigation-hooks)
     - Executes the [Page function](#page-function) on the loaded page
-    - Optionally, finds all links from the page using [Link selector](#link-selector). If a link matches any of the [Pseudo URLs](#pseudo-urls) and has not yet been requested, it is added to the queue.
+    - Optionally, finds all links from the page using [Link selector](#link-selector). If a link matches any of the **[Glob Patterns](#glob-patterns)** and/or **[Pseudo-URLs](#pseudo-urls)** and has not yet been requested, it is added to the queue.
     - Evaluates [Post-navigation hooks](#post-navigation-hooks)
 3. If there are more items in the queue, repeats step 2. Otherwise, finishes the crawl.
 
@@ -147,7 +147,7 @@ const context = {
     setValue, // Reference to the Actor.setValue() function.
     getValue, // Reference to the Actor.getValue() function.
     saveSnapshot, // Saves a screenshot and full HTML of the current page to the key value store.
-    skipLinks, // Prevents enqueueing more links via glob patterns/Pseudo URLs on the current page.
+    skipLinks, // Prevents enqueueing more links via Glob patterns/Pseudo URLs on the current page.
     enqueueRequest, // Adds a page to the request queue.
 
     // PLAYWRIGHT CONTEXT-AWARE UTILITY FUNCTIONS
@@ -362,7 +362,7 @@ You can find the latest screenshot under the `SNAPSHOT-SCREENSHOT` key and the H
 
 > This function is async! Don't forget the `await` keyword!
 
-With each invocation of the pageFunction, the scraper attempts to extract new URLs from the page using the Link selector and glob patterns/Pseudo-URLs provided in the input UI. If you want to prevent this behavior in certain cases, call the `skipLinks` function, and no URLs will be added to the queue for the given page.
+With each invocation of the pageFunction, the scraper attempts to extract new URLs from the page using the Link selector and Glob patterns/Pseudo-URLs provided in the input UI. If you want to prevent this behavior in certain cases, call the `skipLinks` function, and no URLs will be added to the queue for the given page.
 
 Usage:
 
@@ -378,7 +378,7 @@ await context.skipLinks()
 
 > This function is async! Don't forget the `await` keyword!
 
-To enqueue a specific URL manually instead of automatically by a combination of a Link selector and a Pseudo URL, use the enqueueRequest function. It accepts a plain object as argument that needs to have the structure to construct a [Request object](https://crawlee.dev/api/core/class/Request), but frankly, you just need an object with a `url` key.
+To enqueue a specific URL manually instead of automatically by a combination of a Link selector and a Pseudo URL/Glob pattern, use the enqueueRequest function. It accepts a plain object as argument that needs to have the structure to construct a [Request object](https://crawlee.dev/api/core/class/Request), but frankly, you just need an object with a `url` key.
 
 Usage:
 

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -448,7 +448,7 @@ that will be used by the scraper in order to prevent its detection by target web
 You can use both [Apify Proxy](https://apify.com/proxy)
 and custom HTTP or SOCKS5 proxy servers.
 
-The following table lists the available options of the proxy configuration setting:
+Proxy is required to run the scraper. The following table lists the available options of the proxy configuration setting:
 
 | Option                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
@@ -21,7 +21,7 @@
             "prefill": ["https://crawlee.dev/*/*"]
         },
         "pseudoUrls": {
-            "title": "Pseudo-URLs (deprecated)",
+            "title": "Pseudo-URLs",
             "type": "array",
             "description": "Pseudo-URLs to match links in the page that you want to enqueue. Combine with Link selector to tell the scraper where to find links. Omitting the Pseudo-URLs will cause the scraper to enqueue all links matched by the Link selector.",
             "editor": "pseudoUrls",
@@ -38,7 +38,7 @@
         "clickableElementsSelector": {
             "title": "Clickable elements selector",
             "type": "string",
-            "description": "For pages where simple 'href' links are not available, this attribute allows you to specify a CSS selector matching elements that the scraper will mouse click after the page function finishes. Any triggered requests, navigations or open tabs will be intercepted and the target URLs will be filtered using Pseudo URLs and subsequently added to the request queue. Leave empty to prevent the scraper from clicking in the page. Using this setting will have a performance impact.",
+            "description": "For pages where simple 'href' links are not available, this attribute allows you to specify a CSS selector matching elements that the scraper will mouse click after the page function finishes. Any triggered requests, navigations or open tabs will be intercepted and the target URLs will be filtered using Pseudo URLs and/or Glob patterns and subsequently added to the request queue. Leave empty to prevent the scraper from clicking in the page. Using this setting will have a performance impact.",
             "editor": "textfield"
         },
         "keepUrlFragments": {

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -145,7 +145,7 @@ const context = {
     setValue, // Reference to the Actor.setValue() function.
     getValue, // Reference to the Actor.getValue() function.
     saveSnapshot, // Saves a screenshot and full HTML of the current page to the key value store.
-    skipLinks, // Prevents enqueueing more links via Pseudo URLs on the current page.
+    skipLinks, // Prevents enqueueing more links via Glob patterns/Pseudo URLs on the current page.
     enqueueRequest, // Adds a page to the request queue.
 
     // PUPPETEER CONTEXT-AWARE UTILITY FUNCTIONS
@@ -360,7 +360,7 @@ You can find the latest screenshot under the `SNAPSHOT-SCREENSHOT` key and the H
 
 > This function is async! Don't forget the `await` keyword!
 
-With each invocation of the pageFunction, the scraper attempts to extract new URLs from the page using the Link selector and glob patterns/Pseudo-URLs provided in the input UI. If you want to prevent this behavior in certain cases, call the `skipLinks` function, and no URLs will be added to the queue for the given page.
+With each invocation of the pageFunction, the scraper attempts to extract new URLs from the page using the Link selector and Glob patterns/Pseudo-URLs provided in the input UI. If you want to prevent this behavior in certain cases, call the `skipLinks` function, and no URLs will be added to the queue for the given page.
 
 Usage:
 
@@ -376,7 +376,7 @@ await context.skipLinks()
 
 > This function is async! Don't forget the `await` keyword!
 
-To enqueue a specific URL manually instead of automatically by a combination of a Link selector and a Pseudo URL, use the enqueueRequest function. It accepts a plain object as argument that needs to have the structure to construct a [Request object](https://crawlee.dev/api/core/class/Request), but frankly, you just need an object with a `url` key.
+To enqueue a specific URL manually instead of automatically by a combination of a Link selector and a Pseudo URL/Glob pattern, use the enqueueRequest function. It accepts a plain object as argument that needs to have the structure to construct a [Request object](https://crawlee.dev/api/core/class/Request), but frankly, you just need an object with a `url` key.
 
 Usage:
 
@@ -594,3 +594,6 @@ v2 introduced several minor breaking changes, you can read about those in the [m
 
 v3 introduces even more breaking changes.
 This [v3 migration guide](https://sdk.apify.com/docs/upgrading/upgrading-to-v3) should take you through these.
+
+Scraper-specific breaking changes:
+- Proxy usage is now required.

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -446,7 +446,7 @@ that will be used by the scraper in order to prevent its detection by target web
 You can use both [Apify Proxy](https://apify.com/proxy)
 and custom HTTP or SOCKS5 proxy servers.
 
-The following table lists the available options of the proxy configuration setting:
+Proxy is required to run the scraper. The following table lists the available options of the proxy configuration setting:
 
 | Option                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
@@ -1,7 +1,7 @@
 {
     "title": "Web Scraper Input",
     "type": "object",
-    "description": "Web Scraper loads <b>Start URLs</b> in the Chrome browser and executes <b>Page function</b> on each page to extract data from it. To follow links and scrape additional pages, set <b>Link selector</b> with <b>Pseudo-URLs</b> to specify which links to follow. Alternatively, you can manually enqueue new links in <b>Page function</b>. For details, see actor's <a href='https://apify.com/apify/web-scraper' target='_blank' rel='noopener'>README</a> or <a href='https://apify.com/docs/scraping/tutorial/introduction' target='_blank' rel='noopener'>Web scraping tutorial</a> in the Apify documentation.",
+    "description": "Web Scraper loads <b>Start URLs</b> in the Chrome browser and executes <b>Page function</b> on each page to extract data from it. To follow links and scrape additional pages, set <b>Link selector</b> with <b>Pseudo-URLs</b> and/or <b>Glob patterns</b> to specify which links to follow. Alternatively, you can manually enqueue new links in <b>Page function</b>. For details, see actor's <a href='https://apify.com/apify/web-scraper' target='_blank' rel='noopener'>README</a> or <a href='https://apify.com/docs/scraping/tutorial/introduction' target='_blank' rel='noopener'>Web scraping tutorial</a> in the Apify documentation.",
     "schemaVersion": 1,
     "properties": {
         "runMode": {
@@ -34,7 +34,7 @@
         "linkSelector": {
             "title": "Link selector",
             "type": "string",
-            "description": "A CSS selector saying which links on the page (<code>&lt;a&gt;</code> elements with <code>href</code> attribute) shall be followed and added to the request queue. To filter the links added to the queue, use the <b>Pseudo-URLs</b> setting.<br><br>If <b>Link selector</b> is empty, the page links are ignored.<br><br>For details, see <a href='https://apify.com/apify/web-scraper#link-selector' target='_blank' rel='noopener'>Link selector</a> in README.",
+            "description": "A CSS selector saying which links on the page (<code>&lt;a&gt;</code> elements with <code>href</code> attribute) shall be followed and added to the request queue. To filter the links added to the queue, use the <b>Pseudo-URLs</b> and/or <b>Glob patterns</b> setting.<br><br>If <b>Link selector</b> is empty, the page links are ignored.<br><br>For details, see <a href='https://apify.com/apify/web-scraper#link-selector' target='_blank' rel='noopener'>Link selector</a> in README.",
             "editor": "textfield",
             "prefill": "a[href]"
         },
@@ -47,7 +47,7 @@
             "prefill": ["https://crawlee.dev/*/*"]
         },
         "pseudoUrls": {
-            "title": "Pseudo-URLs (deprecated)",
+            "title": "Pseudo-URLs",
             "type": "array",
             "description": "Specifies what kind of URLs found by <b>Link selector</b> should be added to the request queue. A pseudo-URL is a URL with regular expressions enclosed in <code>[]</code> brackets, e.g. <code>http://www.example.com/[.*]</code>. <br><br>If <b>Pseudo-URLs</b> are omitted, the actor enqueues all links matched by the <b>Link selector</b>.<br><br>For details, see <a href='https://apify.com/apify/web-scraper#pseudo-urls' target='_blank' rel='noopener'>Pseudo-URLs</a> in README.",
             "editor": "pseudoUrls",

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -689,3 +689,6 @@ v2 introduced several minor breaking changes, you can read about those in the
 
 v3 introduces even more breaking changes.
 This [v3 migration guide](https://sdk.apify.com/docs/upgrading/upgrading-to-v3) should take you through these.
+
+Scraper-specific breaking changes:
+- Proxy usage is now required.

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -481,7 +481,7 @@ proxies that will be used by the scraper in order to prevent its detection by ta
 You can use both [Apify Proxy](https://apify.com/proxy)
 and custom HTTP or SOCKS5 proxy servers.
 
-The following table lists the available options of the proxy configuration setting:
+Proxy is required to run the scraper. The following table lists the available options of the proxy configuration setting:
 
 <table class="table table-bordered table-condensed">
     <tbody>


### PR DESCRIPTION
- Removed `(deprecated)` from `Pseudo-URLs` input option.
- Added required proxy usage to the `Upgrading` section.

Also explicitly mentioned in Readme/Proxy Configuration section that `Proxy is required to run the scraper.` to make it more visible.