### PR TITLE
docs: [web-scraper] add Initial cookies README section

### DIFF
--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -549,9 +549,9 @@ It accepts a JSON object with the following structure:
 ### Logging into websites with Web Scraper
 
 The **Initial cookies** field allows you to set cookies that will be used by the scraper to log into websites.
-Cookies are small text files that are stored on your computer by your web browser. Various websites use cookies to store information about your current session - by transferring this information to the scraper, it will be able to log into websites using your credentials. For more info, check out our [tutorial](https://docs.apify.com/tutorials/log-in-by-transferring-cookies) to learn more about logging into websites by providing cookies.
+Cookies are small text files that are stored on your computer by your web browser. Various websites use cookies to store information about your current session - by transferring this information to the scraper, it will be able to log into websites using your credentials. To learn more about logging into websites by transfering cookies, check out our [tutorial](https://docs.apify.com/tutorials/log-in-by-transferring-cookies).
 
-Be aware that cookies usually have a limited lifetime and will expire after a certain period of time. This means that you will have to update the cookies periodically in order to keep the scraper logged in. Alternative approach is to make the scraper actively log in to the website in the Page function. For more info about this approach, check our [tutorial](https://docs.apify.com/tutorials/log-into-a-website-using-puppeteer) on this topic.
+Be aware that cookies usually have a limited lifetime and will expire after a certain period of time. This means that you will have to update the cookies periodically in order to keep the scraper logged in. Alternative approach is to make the scraper actively log in to the website in the Page function. For more info about this approach, check out our [tutorial](https://docs.apify.com/tutorials/log-into-a-website-using-puppeteer) on logging into websites using Puppeteer.
 
 The scraper expects the cookies in the **Initial cookies** field to be stored as separate JSON objects in a JSON array, see example below:
 

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -546,6 +546,35 @@ It accepts a JSON object with the following structure:
 }
 ```
 
+### Logging into websites with Web Scraper
+
+The **Initial cookies** field allows you to set cookies that will be used by the scraper to log into websites.
+Cookies are small text files that are stored on your computer by your web browser. Various websites use cookies to store information about your current session - by transferring this information to the scraper, it will be able to log into websites using your credentials. For more info, check out our [tutorial](https://docs.apify.com/tutorials/log-in-by-transferring-cookies) to learn more about logging into websites by providing cookies.
+
+Be aware that cookies usually have a limited lifetime and will expire after a certain period of time. This means that you will have to update the cookies periodically in order to keep the scraper logged in. Alternative approach is to make the scraper actively log in to the website in the Page function. For more info about this approach, check our [tutorial](https://docs.apify.com/tutorials/log-into-a-website-using-puppeteer) on this topic.
+
+The scraper expects the cookies in the **Initial cookies** field to be stored as separate JSON objects in a JSON array, see example below:
+
+```json
+[
+    {
+        "name": " ga",
+        "value": "GA1.1.689972112. 1627459041",
+        "domain": ".apify.com",
+        "hostOnly": false,
+        "path": "/",
+        "secure": false,
+        "httpOnly": false,
+        "sameSite": "no_restriction",
+        "session": false,
+        "firstPartyDomain": "",
+        "expirationDate": 1695304183,
+        "storelId": "firefox-default",
+        "id": 1
+    }
+]
+```
+
 ## Advanced Configuration
 
 ### Pre-navigation hooks


### PR DESCRIPTION
Related https://apifier.slack.com/archives/C046DU0E19V/p1674163410623009

The documentation on the proper usage of the Initial cookies fields is hidden behind a tooltip and two links (and Ctrl+F `login` in the README gave nothing interesting).