### PR TITLE
docs: remove hint to abort the run during migration

### DIFF
--- a/packages/apify/src/platform_event_manager.ts
+++ b/packages/apify/src/platform_event_manager.ts
@@ -27,7 +27,8 @@ import { Configuration } from './configuration';
  *   For example, this event is used by the {@apilink AutoscaledPool} class.
  * - `migrating`: `void`
  *   Emitted when the actor running on the Apify platform is going to be migrated to another worker server soon.
- *   You can use it to persist the state of the actor and abort the run, to speed up migration.
+ *   You can use it to persist the state of the actor and gracefully stop your in-progress tasks,
+ *   so that they are not interrupted by the migration.
  *   For example, this is used by the {@apilink RequestList} class.
  * - `aborting`: `void`
  *   When a user aborts an actor run on the Apify platform, they can choose to abort gracefully to allow

--- a/website/versioned_docs/version-1.3/api/Apify.md
+++ b/website/versioned_docs/version-1.3/api/Apify.md
@@ -277,8 +277,8 @@ The following events are emitted:
     maximum of available CPU resources. If that's the case, the actor should not add more workload. For example, this event is used by the
     [`AutoscaledPool`](../api/autoscaled-pool) class.
 -   `migrating`: `void` Emitted when the actor running on the Apify platform is going to be migrated to another worker server soon. You can use it to
-    persist the state of the actor and abort the run, to speed up migration. For example, this is used by the [`RequestList`](../api/request-list)
-    class.
+    persist the state of the actor and gracefully stop your in-progress tasks, so that they are not interrupted by the migration. For example, this is
+    used by the [`RequestList`](../api/request-list) class.
 -   `persistState`: `{ "isMigrating": Boolean }` Emitted in regular intervals (by default 60 seconds) to notify all components of Apify SDK that it is
     time to persist their state, in order to avoid repeating all work when the actor restarts. This event is automatically emitted together with the
     `migrating` event, in which case the `isMigrating` flag is set to `true`. Otherwise the flag is `false`. Note that the `persistState` event is

--- a/website/versioned_docs/version-2.3/api/Apify.md
+++ b/website/versioned_docs/version-2.3/api/Apify.md
@@ -277,8 +277,8 @@ The following events are emitted:
     maximum of available CPU resources. If that's the case, the actor should not add more workload. For example, this event is used by the
     [`AutoscaledPool`](../api/autoscaled-pool) class.
 -   `migrating`: `void` Emitted when the actor running on the Apify platform is going to be migrated to another worker server soon. You can use it to
-    persist the state of the actor and abort the run, to speed up migration. For example, this is used by the [`RequestList`](../api/request-list)
-    class.
+    persist the state of the actor and gracefully stop your in-progress tasks, so that they are not interrupted by the migration. For example, this is
+    used by the [`RequestList`](../api/request-list) class.
 -   `aborting`: `void` When a user aborts an actor run on the Apify platform, they can choose to abort gracefully to allow the actor some time before
     getting killed. This graceful abort emits the `aborting` event which the SDK uses to gracefully stop running crawls and you can use it to do your
     own cleanup as well.

--- a/website/versioned_docs/version-3.0/api-typedoc.json
+++ b/website/versioned_docs/version-3.0/api-typedoc.json
@@ -9391,7 +9391,7 @@
 					},
 					{
 						"kind": "text",
-						"text": "\n  Emitted when the actor running on the Apify platform is going to be migrated to another worker server soon.\n  You can use it to persist the state of the actor and abort the run, to speed up migration.\n  For example, this is used by the "
+						"text": "\n  Emitted when the actor running on the Apify platform is going to be migrated to another worker server soon.\n  You can use it to persist the state of the actor and gracefully stop your in-progress tasks, so that they are not interrupted by the migration.\n  For example, this is used by the "
 					},
 					{
 						"kind": "inline-tag",


### PR DESCRIPTION
Based on the discussion on Slack, the hint to abort the run during migration is wrong, and it actually completely aborts the run.

@B4nan Should I also update the versioned docs?