### PR TITLE
feat: add `Actor.getInputOrThrow()` method

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,9 @@ module.exports = {
     collectCoverage: false,
     testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
     transform: {
-        '^.+\\.ts$': 'ts-jest',
+        '^.+\\.ts$': ['ts-jest', {
+            tsconfig: 'test/tsconfig.json',
+        }],
     },
     collectCoverageFrom: [
         '<rootDir>/packages/*/src/**/*.[jt]s',
@@ -19,9 +21,4 @@ module.exports = {
         'dist/package.json',
         '<rootDir>/package.json',
     ],
-    globals: {
-        'ts-jest': {
-            tsconfig: 'test/tsconfig.json',
-        },
-    },
 };

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -727,6 +727,20 @@ export class Actor<Data extends Dictionary = Dictionary> {
     }
 
     /**
+     * Gets the actor input value just like the {@apilink Actor.getInput} method,
+     * but throws if it is not found.
+     */
+    async getInputOrThrow<T = Dictionary | string | Buffer>(): Promise<T> {
+        const input = await this.getInput<T>();
+
+        if (input == null) {
+            throw new Error('Input does not exist');
+        }
+
+        return input;
+    }
+
+    /**
      * Opens a key-value store and returns a promise resolving to an instance of the {@apilink KeyValueStore} class.
      *
      * Key-value stores are used to store records or files, along with their MIME content type.
@@ -1321,6 +1335,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
      */
     static async getInput<T = Dictionary | string | Buffer>(): Promise<T | null> {
         return Actor.getDefaultInstance().getInput();
+    }
+
+    /**
+     * Gets the actor input value just like the {@apilink Actor.getInput} method,
+     * but throws if it is not found.
+     */
+    static async getInputOrThrow<T = Dictionary | string | Buffer>(): Promise<T> {
+        return Actor.getDefaultInstance().getInputOrThrow<T>();
     }
 
     /**

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -950,6 +950,9 @@ describe('Actor', () => {
         const TestingActor = new Actor();
 
         test('should work', async () => {
+            await expect(TestingActor.getInput()).resolves.toBeNull();
+            await expect(TestingActor.getInputOrThrow()).rejects.toThrowError('Input does not exist');
+
             const mockGetValue = jest.spyOn(TestingActor, 'getValue');
             mockGetValue.mockImplementation(async (key) => expect(key).toEqual(KEY_VALUE_STORE_KEYS.INPUT));
 


### PR DESCRIPTION
The `Actor.getInput()` method can return `null` if the INPUT key is not present in the `KeyValueStorage`, which often forced people to check for the null value and throw. Now users can use `Actor.getInputOrThrow()` shortcut which does exactly that. The difference is in the return type, as instead of `T | null` you get just `T`.