### PR TITLE
fix: only print status message when explicitly provided in `Actor.exit()`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,4 @@
 # See: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # To keep eye on new functions added to Actor specification
-/packages/apify/src/            @jancurn
-/packages/apify/src/            @mnmkng
+/packages/apify/src/            @jancurn @mnmkng

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -248,13 +248,9 @@ export class Actor<Data extends Dictionary = Dictionary> {
             finished = true;
         }
 
-        if (options.exitCode > 0) {
-            options.statusMessage ??= `Actor finished with an error (exit code ${options.exitCode})`;
-        } else {
-            options.statusMessage ??= `Actor finished successfully (exit code ${options.exitCode})`;
+        if (options.statusMessage != null) {
+            await this.setStatusMessage(options.statusMessage, { isStatusMessageTerminal: true, level: options.exitCode > 0 ? LogLevel.ERROR : LogLevel.INFO });
         }
-
-        await this.setStatusMessage(options.statusMessage, { isStatusMessageTerminal: true, level: options.exitCode > 0 ? LogLevel.ERROR : LogLevel.INFO });
 
         if (!options.exit) {
             return;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5,10 +5,10 @@
     "packages": {
         "": {
             "dependencies": {
-                "@apify/docs-theme": "^1.0.78",
-                "@docusaurus/core": "^2.3.0",
-                "@docusaurus/plugin-client-redirects": "^2.3.0",
-                "@docusaurus/preset-classic": "^2.3.0",
+                "@apify/docs-theme": "^1.0.85",
+                "@docusaurus/core": "^2.4.1",
+                "@docusaurus/plugin-client-redirects": "^2.4.1",
+                "@docusaurus/preset-classic": "^2.4.1",
                 "clsx": "^1.2.1",
                 "docusaurus-gtm-plugin": "^0.0.2",
                 "docusaurus-plugin-typedoc-api": "^3.0.0",
@@ -16,21 +16,21 @@
                 "raw-loader": "^4.0.2",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
-                "unist-util-visit": "^4.1.1"
+                "unist-util-visit": "^4.1.2"
             },
             "devDependencies": {
                 "@apify/eslint-config-ts": "^0.3.0",
                 "@apify/tsconfig": "^0.1.0",
-                "@types/react": "^17.0.39",
-                "@typescript-eslint/eslint-plugin": "^5.13.0",
-                "@typescript-eslint/parser": "^5.13.0",
-                "eslint": "^8.10.0",
-                "eslint-plugin-react": "^7.29.3",
-                "eslint-plugin-react-hooks": "^4.3.0",
-                "fs-extra": "^11.0.0",
+                "@types/react": "^18.2.8",
+                "@typescript-eslint/eslint-plugin": "^5.59.9",
+                "@typescript-eslint/parser": "^5.59.9",
+                "eslint": "^8.42.0",
+                "eslint-plugin-react": "^7.32.2",
+                "eslint-plugin-react-hooks": "^4.6.0",
+                "fs-extra": "^11.1.1",
                 "got": "^11.8.2",
                 "path-browserify": "^1.0.1",
-                "prettier": "^2.5.1",
+                "prettier": "^2.8.8",
                 "rimraf": "^5.0.0"
             }
         },
@@ -4212,9 +4212,9 @@
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "node_modules/@types/react": {
-            "version": "17.0.60",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.60.tgz",
-            "integrity": "sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==",
+            "version": "18.2.9",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.9.tgz",
+            "integrity": "sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -19644,9 +19644,9 @@
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "@types/react": {
-            "version": "17.0.60",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.60.tgz",
-            "integrity": "sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==",
+            "version": "18.2.9",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.9.tgz",
+            "integrity": "sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",

--- a/website/package.json
+++ b/website/package.json
@@ -15,23 +15,23 @@
     "devDependencies": {
         "@apify/eslint-config-ts": "^0.3.0",
         "@apify/tsconfig": "^0.1.0",
-        "@types/react": "^17.0.39",
-        "@typescript-eslint/eslint-plugin": "^5.13.0",
-        "@typescript-eslint/parser": "^5.13.0",
-        "eslint": "^8.10.0",
-        "eslint-plugin-react": "^7.29.3",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "fs-extra": "^11.0.0",
+        "@types/react": "^18.2.8",
+        "@typescript-eslint/eslint-plugin": "^5.59.9",
+        "@typescript-eslint/parser": "^5.59.9",
+        "eslint": "^8.42.0",
+        "eslint-plugin-react": "^7.32.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "fs-extra": "^11.1.1",
         "got": "^11.8.2",
         "path-browserify": "^1.0.1",
-        "prettier": "^2.5.1",
+        "prettier": "^2.8.8",
         "rimraf": "^5.0.0"
     },
     "dependencies": {
-        "@apify/docs-theme": "^1.0.78",
-        "@docusaurus/core": "^2.3.0",
-        "@docusaurus/plugin-client-redirects": "^2.3.0",
-        "@docusaurus/preset-classic": "^2.3.0",
+        "@apify/docs-theme": "^1.0.85",
+        "@docusaurus/core": "^2.4.1",
+        "@docusaurus/plugin-client-redirects": "^2.4.1",
+        "@docusaurus/preset-classic": "^2.4.1",
         "clsx": "^1.2.1",
         "docusaurus-gtm-plugin": "^0.0.2",
         "docusaurus-plugin-typedoc-api": "^3.0.0",
@@ -39,6 +39,6 @@
         "raw-loader": "^4.0.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "unist-util-visit": "^4.1.1"
+        "unist-util-visit": "^4.1.2"
     }
 }


### PR DESCRIPTION
The default (generic) status message from `Actor.exit` was always overriding the final status message from basic crawler (that has much more information). This removes the default messages from there, keeping the one from basic crawler.

Sidenote: maybe we should also add current concurrency to the status messages?