### PR TITLE
docs: enable `Run on Apify` buttons on all examples

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,10 +16,10 @@ jobs:
             -   uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
                 with:
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-            -   name: Use Node.js 16
+            -   name: Use Node.js 18
                 uses: actions/setup-node@v2-beta
                 with:
-                    node-version: 16
+                    node-version: 18
 
             -   name: Set git identity
                 run: |
@@ -47,6 +47,7 @@ jobs:
                 env:
                     GIT_USER: "B4nan:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
                     GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                    APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
 
             -   name: Commit the updated package(-lock).json
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
             matrix:
                 # We don't test on Windows as the tests are flaky
                 os: [ ubuntu-latest ]
-                node-version: [ 16, 18 ]
+                node-version: [ 16, 18, 20 ]
 
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -24,7 +24,7 @@ jobs:
                 # tests on windows are extremely unstable
                 # os: [ ubuntu-latest, windows-2019 ]
                 os: [ ubuntu-latest ]
-                node-version: [ 16, 18 ]
+                node-version: [ 16, 18, 20 ]
 
         steps:
             -   name: Cancel Workflow Action
@@ -70,10 +70,10 @@ jobs:
             -   name: Checkout Source code
                 uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
 
-            -   name: Use Node.js 16
+            -   name: Use Node.js 18
                 uses: actions/setup-node@v3
                 with:
-                    node-version: 16
+                    node-version: 18
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
 
@@ -103,10 +103,10 @@ jobs:
             -   name: Checkout repository
                 uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
 
-            -   name: Use Node.js 16
+            -   name: Use Node.js 18
                 uses: actions/setup-node@v3
                 with:
-                    node-version: 16
+                    node-version: 18
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
 
@@ -137,10 +137,10 @@ jobs:
                     fetch-depth: 0 # we need to pull everything to have correct dev version suffix
                     ref: master
 
-            -   name: Use Node.js 16
+            -   name: Use Node.js 18
                 uses: actions/setup-node@v3
                 with:
-                    node-version: 16
+                    node-version: 18
                     cache: 'npm'
                     cache-dependency-path: 'package-lock.json'
 

--- a/docs/examples/add_data_to_dataset.mdx
+++ b/docs/examples/add_data_to_dataset.mdx
@@ -5,14 +5,14 @@ title: Add data to dataset
 
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
-import AddDataToDatasetSource from '!!raw-loader!./add_data_to_dataset.ts';
+import AddDataToDatasetSource from '!!raw-loader!roa-loader!./add_data_to_dataset.ts';
 
 This example saves data to the default dataset. If the dataset doesn't exist, it will be created.
 You can save data to custom datasets by using <ApiLink to="apify/class/Dataset#open">`Actor.openDataset()`</ApiLink>
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{AddDataToDatasetSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 Each item in this dataset will be saved to its own file in the following directory:
 

--- a/docs/examples/basic_crawler.mdx
+++ b/docs/examples/basic_crawler.mdx
@@ -6,7 +6,7 @@ title: Basic crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
+import BasicCrawlerSource from '!!raw-loader!roa-loader!./basic_crawler.ts';
 
 This is the most bare-bones example of the Apify SDK, which demonstrates some of its building blocks such as the <CrawleeApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</CrawleeApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
 like <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink> or <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink>.
@@ -15,6 +15,6 @@ The script simply downloads several web pages with plain HTTP requests using the
 npm package and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in
 `./storage/datasets/default`.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{BasicCrawlerSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/cheerio_crawler.mdx
+++ b/docs/examples/cheerio_crawler.mdx
@@ -6,10 +6,10 @@ title: Cheerio crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CheerioCrawlerSource from '!!raw-loader!./cheerio_crawler.ts';
+import CheerioCrawlerSource from '!!raw-loader!roa-loader!./cheerio_crawler.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink> to crawl a list of URLs from an external file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it: the page title and all `h1` tags.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioCrawlerSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/crawl_all_links.mdx
+++ b/docs/examples/crawl_all_links.mdx
@@ -7,9 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import CheerioSource from '!!raw-loader!./crawl_all_links_cheerio.ts';
-import PuppeteerSource from '!!raw-loader!./crawl_all_links_puppeteer.ts';
-import PlaywrightSource from '!!raw-loader!./crawl_all_links_playwright.ts';
+import CheerioSource from '!!raw-loader!roa-loader!./crawl_all_links_cheerio.ts';
+import PuppeteerSource from '!!raw-loader!roa-loader!./crawl_all_links_puppeteer.ts';
+import PlaywrightSource from '!!raw-loader!roa-loader!./crawl_all_links_playwright.ts';
 
 This example uses the `enqueueLinks()` method to add new links to the `RequestQueue` as the crawler navigates from page to page. If only the
 required parameters are defined, all links will be crawled.
@@ -20,9 +20,9 @@ required parameters are defined, all links will be crawled.
 
 Using `CheerioCrawler`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -36,9 +36,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -52,9 +52,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{PlaywrightSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/docs/examples/crawl_multiple_urls.mdx
+++ b/docs/examples/crawl_multiple_urls.mdx
@@ -7,9 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import CheerioSource from '!!raw-loader!./crawl_multiple_urls_cheerio.ts';
-import PuppeteerSource from '!!raw-loader!./crawl_multiple_urls_puppeteer.ts';
-import PlaywrightSource from '!!raw-loader!./crawl_multiple_urls_playwright.ts';
+import CheerioSource from '!!raw-loader!roa-loader!./crawl_multiple_urls_cheerio.ts';
+import PuppeteerSource from '!!raw-loader!roa-loader!./crawl_multiple_urls_puppeteer.ts';
+import PlaywrightSource from '!!raw-loader!roa-loader!./crawl_multiple_urls_playwright.ts';
 
 This example crawls the specified list of URLs.
 
@@ -19,9 +19,9 @@ This example crawls the specified list of URLs.
 
 Using `CheerioCrawler`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -35,9 +35,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -51,9 +51,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{PlaywrightSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/docs/examples/crawl_relative_links.mdx
+++ b/docs/examples/crawl_relative_links.mdx
@@ -9,9 +9,9 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
 
-import AllLinksSource from '!!raw-loader!./crawl_relative_links_all.ts';
-import SameHostnameSource from '!!raw-loader!./crawl_relative_links_same_hostname.ts';
-import SameSubdomainSource from '!!raw-loader!./crawl_relative_links_same_subdomain.ts';
+import AllLinksSource from '!!raw-loader!roa-loader!./crawl_relative_links_all.ts';
+import SameHostnameSource from '!!raw-loader!roa-loader!./crawl_relative_links_same_hostname.ts';
+import SameSubdomainSource from '!!raw-loader!roa-loader!./crawl_relative_links_same_subdomain.ts';
 
 When crawling a website, you may encounter different types of links present that you may want to crawl.
 To facilitate the easy crawling of such links, we provide the `enqueueLinks()` method on the crawler context, which will
@@ -45,9 +45,9 @@ Any urls found will be matched by this strategy, even if they go off of the site
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{AllLinksSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -63,9 +63,9 @@ or `./relative/example` will all be matched by this strategy.
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{SameHostnameSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -87,9 +87,9 @@ will all be matched by this strategy, while `https://other-subdomain.example.com
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{SameSubdomainSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/docs/examples/crawl_single_url.mdx
+++ b/docs/examples/crawl_single_url.mdx
@@ -5,13 +5,13 @@ title: Crawl a single URL
 
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
-import CrawlSource from '!!raw-loader!./crawl_single_url.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./crawl_single_url.ts';
 
 This example uses the [`got-scraping`](https://github.com/apify/got-scraping) npm package
 to grab the HTML of a web page.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 If you don't want to hard-code the URL into the script, refer to the [Accept User Input](./accept-user-input) example.

--- a/docs/examples/crawl_sitemap.mdx
+++ b/docs/examples/crawl_sitemap.mdx
@@ -7,9 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import CheerioSource from '!!raw-loader!./crawl_sitemap_cheerio.ts';
-import PuppeteerSource from '!!raw-loader!./crawl_sitemap_puppeteer.ts';
-import PlaywrightSource from '!!raw-loader!./crawl_sitemap_playwright.ts';
+import CheerioSource from '!!raw-loader!roa-loader!./crawl_sitemap_cheerio.ts';
+import PuppeteerSource from '!!raw-loader!roa-loader!./crawl_sitemap_puppeteer.ts';
+import PlaywrightSource from '!!raw-loader!roa-loader!./crawl_sitemap_playwright.ts';
 
 This example downloads and crawls the URLs from a sitemap.
 
@@ -19,9 +19,9 @@ This example downloads and crawls the URLs from a sitemap.
 
 Using `CheerioCrawler`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -35,9 +35,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -51,9 +51,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{PlaywrightSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/docs/examples/crawl_sitemap_playwright.ts
+++ b/docs/examples/crawl_sitemap_playwright.ts
@@ -1,5 +1,5 @@
 import { PlaywrightCrawler, downloadListOfUrls } from 'crawlee';
-import { Actor } from 'apify/src';
+import { Actor } from 'apify';
 
 await Actor.init();
 

--- a/docs/examples/crawl_some_links.mdx
+++ b/docs/examples/crawl_some_links.mdx
@@ -6,10 +6,10 @@ title: Crawl some links on a website
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./crawl_some_links.ts';
 
 This <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink> example uses the <CrawleeApiLink to="core/class/PseudoUrl">`pseudoUrls`</CrawleeApiLink> property in the <CrawleeApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</CrawleeApiLink> method to only add links to the <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/forms.mdx
+++ b/docs/examples/forms.mdx
@@ -6,7 +6,7 @@ title: Forms
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./forms.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./forms.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink> to
 automatically fill and submit a search form to look up repositories on [GitHub](https://github.com) using headless Chrome / Puppeteer.
@@ -20,6 +20,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/map_and_reduce.mdx
+++ b/docs/examples/map_and_reduce.mdx
@@ -5,8 +5,8 @@ title: Dataset Map and Reduce methods
 
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
-import MapSource from '!!raw-loader!./map.ts';
-import ReduceSource from '!!raw-loader!./reduce.ts';
+import MapSource from '!!raw-loader!roa-loader!./map.ts';
+import ReduceSource from '!!raw-loader!roa-loader!./reduce.ts';
 
 This example shows an easy use-case of the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> <ApiLink to="apify/class/Dataset#map">`map`</ApiLink>
 and <ApiLink to="apify/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
@@ -46,9 +46,9 @@ array through a transformation function and an options parameter.
 
 The `map` method used to check if are there more than 5 header elements on each page:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{MapSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 The `moreThan5headers` variable is an array of `headingCount` attributes where the number of headers is greater than 5.
 
@@ -66,9 +66,9 @@ calculation, the `memo` is sent to the next iteration, while the item just proce
 
 Using the `reduce` method to get the total number of headers scraped (all items in the dataset):
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{ReduceSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 The original dataset will be reduced to a single value, `pagesHeadingCount`, which contains the count of all headers for all scraped pages (all
 dataset items).

--- a/docs/examples/playwright_crawler.mdx
+++ b/docs/examples/playwright_crawler.mdx
@@ -6,7 +6,7 @@ title: Playwright crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./playwright_crawler.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./playwright_crawler.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink>
 in combination with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> to
@@ -21,6 +21,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/puppeteer_capture_screenshot.mdx
+++ b/docs/examples/puppeteer_capture_screenshot.mdx
@@ -7,10 +7,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import PuppeteerPageScreenshotSource from '!!raw-loader!./puppeteer_page_screenshot.ts';
-import PuppeteerCrawlerUtilsSnapshotSource from '!!raw-loader!./puppeteer_crawler_utils_snapshot.ts';
-import PuppeteerCrawlerPageScreenshotSource from '!!raw-loader!./puppeteer_crawler_page_screenshot.ts';
-import PuppeteerCrawlerCrawlerUtilsSnapshotSource from '!!raw-loader!./puppeteer_crawler_crawler_utils_snapshot.ts';
+import PuppeteerPageScreenshotSource from '!!raw-loader!roa-loader!./puppeteer_page_screenshot.ts';
+import PuppeteerCrawlerUtilsSnapshotSource from '!!raw-loader!roa-loader!./puppeteer_crawler_utils_snapshot.ts';
+import PuppeteerCrawlerPageScreenshotSource from '!!raw-loader!roa-loader!./puppeteer_crawler_page_screenshot.ts';
+import PuppeteerCrawlerCrawlerUtilsSnapshotSource from '!!raw-loader!roa-loader!./puppeteer_crawler_crawler_utils_snapshot.ts';
 
 :::tip
 
@@ -25,9 +25,9 @@ This example captures a screenshot of a web page using `Puppeteer`. It would loo
 
 Using `page.screenshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerPageScreenshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -35,9 +35,9 @@ Using `page.screenshot()`:
 
 Using `puppeteerUtils.saveSnapshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerCrawlerUtilsSnapshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 </Tabs>
@@ -49,9 +49,9 @@ This example captures a screenshot of multiple web pages when using `PuppeteerCr
 
 Using `page.screenshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerCrawlerPageScreenshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -59,9 +59,9 @@ Using `page.screenshot()`:
 
 Using `puppeteerUtils.saveSnapshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerCrawlerCrawlerUtilsSnapshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 </Tabs>

--- a/docs/examples/puppeteer_crawler.mdx
+++ b/docs/examples/puppeteer_crawler.mdx
@@ -6,7 +6,7 @@ title: Puppeteer crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./puppeteer_crawler.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./puppeteer_crawler.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink> in combination
 with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink>
@@ -21,6 +21,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/puppeteer_recursive_crawl.mdx
+++ b/docs/examples/puppeteer_recursive_crawl.mdx
@@ -6,7 +6,7 @@ title: Puppeteer recursive crawl
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./puppeteer_recursive_crawl.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./puppeteer_recursive_crawl.ts';
 
 Run the following example to perform a recursive crawl of a website using <CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>.
 
@@ -16,6 +16,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/docs/examples/puppeteer_with_proxy.mdx
+++ b/docs/examples/puppeteer_with_proxy.mdx
@@ -5,7 +5,7 @@ title: Puppeteer with proxy
 
 import CodeBlock from '@theme/CodeBlock';
 
-import CrawlSource from '!!raw-loader!./puppeteer_with_proxy.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./puppeteer_with_proxy.ts';
 
 This example demonstrates how to load pages in headless Chrome / Puppeteer over [Apify Proxy](https://docs.apify.com/proxy).
 
@@ -17,6 +17,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
-                "@apify/docs-theme": "^1.0.85",
+                "@apify/docs-theme": "^1.0.97",
                 "@docusaurus/core": "^2.4.1",
                 "@docusaurus/plugin-client-redirects": "^2.4.1",
                 "@docusaurus/preset-classic": "^2.4.1",
@@ -255,9 +255,9 @@
             }
         },
         "node_modules/@apify/docs-theme": {
-            "version": "1.0.95",
-            "resolved": "https://registry.npmjs.org/@apify/docs-theme/-/docs-theme-1.0.95.tgz",
-            "integrity": "sha512-Y0Li8wZVw9ScPs1H6kwVg3r8Oxrwv1YTpzH7gh9YwUY1tooJKOds7r6piPKaFl9BzqdsDlfsmdsq9t/Zf+9AEg==",
+            "version": "1.0.97",
+            "resolved": "https://registry.npmjs.org/@apify/docs-theme/-/docs-theme-1.0.97.tgz",
+            "integrity": "sha512-N25xuAMN+bMPd+FOa0Ee74htz6A0WUC+cLntHLWEtBKpPNBimxp5aki/UHzQiKLwP1Rdz+qn2mx0edl0DcrzYQ==",
             "dependencies": {
                 "@apify/docs-search-modal": "^1.0.23",
                 "@docusaurus/theme-common": "^2.4.1",
@@ -16815,9 +16815,9 @@
             }
         },
         "@apify/docs-theme": {
-            "version": "1.0.95",
-            "resolved": "https://registry.npmjs.org/@apify/docs-theme/-/docs-theme-1.0.95.tgz",
-            "integrity": "sha512-Y0Li8wZVw9ScPs1H6kwVg3r8Oxrwv1YTpzH7gh9YwUY1tooJKOds7r6piPKaFl9BzqdsDlfsmdsq9t/Zf+9AEg==",
+            "version": "1.0.97",
+            "resolved": "https://registry.npmjs.org/@apify/docs-theme/-/docs-theme-1.0.97.tgz",
+            "integrity": "sha512-N25xuAMN+bMPd+FOa0Ee74htz6A0WUC+cLntHLWEtBKpPNBimxp5aki/UHzQiKLwP1Rdz+qn2mx0edl0DcrzYQ==",
             "requires": {
                 "@apify/docs-search-modal": "^1.0.23",
                 "@docusaurus/theme-common": "^2.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,7 @@
         "rimraf": "^5.0.0"
     },
     "dependencies": {
-        "@apify/docs-theme": "^1.0.85",
+        "@apify/docs-theme": "^1.0.97",
         "@docusaurus/core": "^2.4.1",
         "@docusaurus/plugin-client-redirects": "^2.4.1",
         "@docusaurus/preset-classic": "^2.4.1",

--- a/website/versioned_docs/version-3.1/examples/add_data_to_dataset.mdx
+++ b/website/versioned_docs/version-3.1/examples/add_data_to_dataset.mdx
@@ -5,14 +5,14 @@ title: Add data to dataset
 
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
-import AddDataToDatasetSource from '!!raw-loader!./add_data_to_dataset.ts';
+import AddDataToDatasetSource from '!!raw-loader!roa-loader!./add_data_to_dataset.ts';
 
 This example saves data to the default dataset. If the dataset doesn't exist, it will be created.
 You can save data to custom datasets by using <ApiLink to="apify/class/Dataset#open">`Actor.openDataset()`</ApiLink>
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{AddDataToDatasetSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 Each item in this dataset will be saved to its own file in the following directory:
 

--- a/website/versioned_docs/version-3.1/examples/basic_crawler.mdx
+++ b/website/versioned_docs/version-3.1/examples/basic_crawler.mdx
@@ -6,7 +6,7 @@ title: Basic crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import BasicCrawlerSource from '!!raw-loader!./basic_crawler.ts';
+import BasicCrawlerSource from '!!raw-loader!roa-loader!./basic_crawler.ts';
 
 This is the most bare-bones example of the Apify SDK, which demonstrates some of its building blocks such as the <CrawleeApiLink to="basic-crawler/class/BasicCrawler">`BasicCrawler`</CrawleeApiLink>. You probably don't need to go this deep though, and it would be better to start with one of the full-featured crawlers
 like <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink> or <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink>.
@@ -15,6 +15,6 @@ The script simply downloads several web pages with plain HTTP requests using the
 npm package and stores their raw HTML and URL in the default dataset. In local configuration, the data will be stored as JSON files in
 `./storage/datasets/default`.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{BasicCrawlerSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/cheerio_crawler.mdx
+++ b/website/versioned_docs/version-3.1/examples/cheerio_crawler.mdx
@@ -6,10 +6,10 @@ title: Cheerio crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CheerioCrawlerSource from '!!raw-loader!./cheerio_crawler.ts';
+import CheerioCrawlerSource from '!!raw-loader!roa-loader!./cheerio_crawler.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink> to crawl a list of URLs from an external file, load each URL using a plain HTTP request, parse the HTML using the [Cheerio library](https://www.npmjs.com/package/cheerio) and extract some data from it: the page title and all `h1` tags.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioCrawlerSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/crawl_all_links.mdx
+++ b/website/versioned_docs/version-3.1/examples/crawl_all_links.mdx
@@ -7,9 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import CheerioSource from '!!raw-loader!./crawl_all_links_cheerio.ts';
-import PuppeteerSource from '!!raw-loader!./crawl_all_links_puppeteer.ts';
-import PlaywrightSource from '!!raw-loader!./crawl_all_links_playwright.ts';
+import CheerioSource from '!!raw-loader!roa-loader!./crawl_all_links_cheerio.ts';
+import PuppeteerSource from '!!raw-loader!roa-loader!./crawl_all_links_puppeteer.ts';
+import PlaywrightSource from '!!raw-loader!roa-loader!./crawl_all_links_playwright.ts';
 
 This example uses the `enqueueLinks()` method to add new links to the `RequestQueue` as the crawler navigates from page to page. If only the
 required parameters are defined, all links will be crawled.
@@ -20,9 +20,9 @@ required parameters are defined, all links will be crawled.
 
 Using `CheerioCrawler`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -36,9 +36,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -52,9 +52,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{PlaywrightSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/website/versioned_docs/version-3.1/examples/crawl_multiple_urls.mdx
+++ b/website/versioned_docs/version-3.1/examples/crawl_multiple_urls.mdx
@@ -7,9 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import CheerioSource from '!!raw-loader!./crawl_multiple_urls_cheerio.ts';
-import PuppeteerSource from '!!raw-loader!./crawl_multiple_urls_puppeteer.ts';
-import PlaywrightSource from '!!raw-loader!./crawl_multiple_urls_playwright.ts';
+import CheerioSource from '!!raw-loader!roa-loader!./crawl_multiple_urls_cheerio.ts';
+import PuppeteerSource from '!!raw-loader!roa-loader!./crawl_multiple_urls_puppeteer.ts';
+import PlaywrightSource from '!!raw-loader!roa-loader!./crawl_multiple_urls_playwright.ts';
 
 This example crawls the specified list of URLs.
 
@@ -19,9 +19,9 @@ This example crawls the specified list of URLs.
 
 Using `CheerioCrawler`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -35,9 +35,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -51,9 +51,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{PlaywrightSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/website/versioned_docs/version-3.1/examples/crawl_relative_links.mdx
+++ b/website/versioned_docs/version-3.1/examples/crawl_relative_links.mdx
@@ -9,9 +9,9 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
 
-import AllLinksSource from '!!raw-loader!./crawl_relative_links_all.ts';
-import SameHostnameSource from '!!raw-loader!./crawl_relative_links_same_hostname.ts';
-import SameSubdomainSource from '!!raw-loader!./crawl_relative_links_same_subdomain.ts';
+import AllLinksSource from '!!raw-loader!roa-loader!./crawl_relative_links_all.ts';
+import SameHostnameSource from '!!raw-loader!roa-loader!./crawl_relative_links_same_hostname.ts';
+import SameSubdomainSource from '!!raw-loader!roa-loader!./crawl_relative_links_same_subdomain.ts';
 
 When crawling a website, you may encounter different types of links present that you may want to crawl.
 To facilitate the easy crawling of such links, we provide the `enqueueLinks()` method on the crawler context, which will
@@ -45,9 +45,9 @@ Any urls found will be matched by this strategy, even if they go off of the site
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{AllLinksSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -63,9 +63,9 @@ or `./relative/example` will all be matched by this strategy.
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{SameHostnameSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -87,9 +87,9 @@ will all be matched by this strategy, while `https://other-subdomain.example.com
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{SameSubdomainSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/website/versioned_docs/version-3.1/examples/crawl_single_url.mdx
+++ b/website/versioned_docs/version-3.1/examples/crawl_single_url.mdx
@@ -5,13 +5,13 @@ title: Crawl a single URL
 
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
-import CrawlSource from '!!raw-loader!./crawl_single_url.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./crawl_single_url.ts';
 
 This example uses the [`got-scraping`](https://github.com/apify/got-scraping) npm package
 to grab the HTML of a web page.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 If you don't want to hard-code the URL into the script, refer to the [Accept User Input](./accept-user-input) example.

--- a/website/versioned_docs/version-3.1/examples/crawl_sitemap.mdx
+++ b/website/versioned_docs/version-3.1/examples/crawl_sitemap.mdx
@@ -7,9 +7,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import CheerioSource from '!!raw-loader!./crawl_sitemap_cheerio.ts';
-import PuppeteerSource from '!!raw-loader!./crawl_sitemap_puppeteer.ts';
-import PlaywrightSource from '!!raw-loader!./crawl_sitemap_playwright.ts';
+import CheerioSource from '!!raw-loader!roa-loader!./crawl_sitemap_cheerio.ts';
+import PuppeteerSource from '!!raw-loader!roa-loader!./crawl_sitemap_puppeteer.ts';
+import PlaywrightSource from '!!raw-loader!roa-loader!./crawl_sitemap_playwright.ts';
 
 This example downloads and crawls the URLs from a sitemap.
 
@@ -19,9 +19,9 @@ This example downloads and crawls the URLs from a sitemap.
 
 Using `CheerioCrawler`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CheerioSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -35,9 +35,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -51,9 +51,9 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{PlaywrightSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 

--- a/website/versioned_docs/version-3.1/examples/crawl_sitemap_playwright.ts
+++ b/website/versioned_docs/version-3.1/examples/crawl_sitemap_playwright.ts
@@ -1,5 +1,5 @@
 import { PlaywrightCrawler, downloadListOfUrls } from 'crawlee';
-import { Actor } from 'apify/src';
+import { Actor } from 'apify';
 
 await Actor.init();
 

--- a/website/versioned_docs/version-3.1/examples/crawl_some_links.mdx
+++ b/website/versioned_docs/version-3.1/examples/crawl_some_links.mdx
@@ -6,10 +6,10 @@ title: Crawl some links on a website
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./crawl_some_links.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./crawl_some_links.ts';
 
 This <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink> example uses the <CrawleeApiLink to="core/class/PseudoUrl">`pseudoUrls`</CrawleeApiLink> property in the <CrawleeApiLink to="cheerio-crawler/interface/CheerioRequestHandlerInputs#enqueueLinks">`enqueueLinks()`</CrawleeApiLink> method to only add links to the <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> queue if they match the specified regular expression.
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/forms.mdx
+++ b/website/versioned_docs/version-3.1/examples/forms.mdx
@@ -6,7 +6,7 @@ title: Forms
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./forms.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./forms.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink> to
 automatically fill and submit a search form to look up repositories on [GitHub](https://github.com) using headless Chrome / Puppeteer.
@@ -20,6 +20,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/map_and_reduce.mdx
+++ b/website/versioned_docs/version-3.1/examples/map_and_reduce.mdx
@@ -5,8 +5,8 @@ title: Dataset Map and Reduce methods
 
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
-import MapSource from '!!raw-loader!./map.ts';
-import ReduceSource from '!!raw-loader!./reduce.ts';
+import MapSource from '!!raw-loader!roa-loader!./map.ts';
+import ReduceSource from '!!raw-loader!roa-loader!./reduce.ts';
 
 This example shows an easy use-case of the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> <ApiLink to="apify/class/Dataset#map">`map`</ApiLink>
 and <ApiLink to="apify/class/Dataset#reduce">`reduce`</ApiLink> methods. Both methods can be used to simplify
@@ -46,9 +46,9 @@ array through a transformation function and an options parameter.
 
 The `map` method used to check if are there more than 5 header elements on each page:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{MapSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 The `moreThan5headers` variable is an array of `headingCount` attributes where the number of headers is greater than 5.
 
@@ -66,9 +66,9 @@ calculation, the `memo` is sent to the next iteration, while the item just proce
 
 Using the `reduce` method to get the total number of headers scraped (all items in the dataset):
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="cheerio">
 	{ReduceSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 The original dataset will be reduced to a single value, `pagesHeadingCount`, which contains the count of all headers for all scraped pages (all
 dataset items).

--- a/website/versioned_docs/version-3.1/examples/playwright_crawler.mdx
+++ b/website/versioned_docs/version-3.1/examples/playwright_crawler.mdx
@@ -6,7 +6,7 @@ title: Playwright crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./playwright_crawler.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./playwright_crawler.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink>
 in combination with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink> to
@@ -21,6 +21,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-playwrig
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="playwright">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/puppeteer_capture_screenshot.mdx
+++ b/website/versioned_docs/version-3.1/examples/puppeteer_capture_screenshot.mdx
@@ -7,10 +7,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-import PuppeteerPageScreenshotSource from '!!raw-loader!./puppeteer_page_screenshot.ts';
-import PuppeteerCrawlerUtilsSnapshotSource from '!!raw-loader!./puppeteer_crawler_utils_snapshot.ts';
-import PuppeteerCrawlerPageScreenshotSource from '!!raw-loader!./puppeteer_crawler_page_screenshot.ts';
-import PuppeteerCrawlerCrawlerUtilsSnapshotSource from '!!raw-loader!./puppeteer_crawler_crawler_utils_snapshot.ts';
+import PuppeteerPageScreenshotSource from '!!raw-loader!roa-loader!./puppeteer_page_screenshot.ts';
+import PuppeteerCrawlerUtilsSnapshotSource from '!!raw-loader!roa-loader!./puppeteer_crawler_utils_snapshot.ts';
+import PuppeteerCrawlerPageScreenshotSource from '!!raw-loader!roa-loader!./puppeteer_crawler_page_screenshot.ts';
+import PuppeteerCrawlerCrawlerUtilsSnapshotSource from '!!raw-loader!roa-loader!./puppeteer_crawler_crawler_utils_snapshot.ts';
 
 :::tip
 
@@ -25,9 +25,9 @@ This example captures a screenshot of a web page using `Puppeteer`. It would loo
 
 Using `page.screenshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerPageScreenshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -35,9 +35,9 @@ Using `page.screenshot()`:
 
 Using `puppeteerUtils.saveSnapshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerCrawlerUtilsSnapshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 </Tabs>
@@ -49,9 +49,9 @@ This example captures a screenshot of multiple web pages when using `PuppeteerCr
 
 Using `page.screenshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerCrawlerPageScreenshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 
@@ -59,9 +59,9 @@ Using `page.screenshot()`:
 
 Using `puppeteerUtils.saveSnapshot()`:
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{PuppeteerCrawlerCrawlerUtilsSnapshotSource}
-</CodeBlock>
+</RunnableCodeBlock>
 
 </TabItem>
 </Tabs>

--- a/website/versioned_docs/version-3.1/examples/puppeteer_crawler.mdx
+++ b/website/versioned_docs/version-3.1/examples/puppeteer_crawler.mdx
@@ -6,7 +6,7 @@ title: Puppeteer crawler
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./puppeteer_crawler.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./puppeteer_crawler.ts';
 
 This example demonstrates how to use <CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink> in combination
 with <ApiLink to="apify/class/RequestQueue">`RequestQueue`</ApiLink>
@@ -21,6 +21,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/puppeteer_recursive_crawl.mdx
+++ b/website/versioned_docs/version-3.1/examples/puppeteer_recursive_crawl.mdx
@@ -6,7 +6,7 @@ title: Puppeteer recursive crawl
 import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
-import CrawlSource from '!!raw-loader!./puppeteer_recursive_crawl.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./puppeteer_recursive_crawl.ts';
 
 Run the following example to perform a recursive crawl of a website using <CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>.
 
@@ -16,6 +16,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>

--- a/website/versioned_docs/version-3.1/examples/puppeteer_with_proxy.mdx
+++ b/website/versioned_docs/version-3.1/examples/puppeteer_with_proxy.mdx
@@ -5,7 +5,7 @@ title: Puppeteer with proxy
 
 import CodeBlock from '@theme/CodeBlock';
 
-import CrawlSource from '!!raw-loader!./puppeteer_with_proxy.ts';
+import CrawlSource from '!!raw-loader!roa-loader!./puppeteer_with_proxy.ts';
 
 This example demonstrates how to load pages in headless Chrome / Puppeteer over [Apify Proxy](https://docs.apify.com/proxy).
 
@@ -17,6 +17,6 @@ To run this example on the Apify Platform, select the `apify/actor-node-puppetee
 
 :::
 
-<CodeBlock className="language-js">
+<RunnableCodeBlock className="language-js" type="puppeteer">
 	{CrawlSource}
-</CodeBlock>
+</RunnableCodeBlock>


### PR DESCRIPTION
Also adds node 20 to the CI and uses 18 to do things like docs deployment.

Closes #232