### PR TITLE
docs: add monetization webinar banner

### DIFF
--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -1,3 +1,4 @@
+[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
 # Cheerio Scraper
 
 Cheerio Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [Cheerio](https://cheerio.js.org) Node.js library and lets you extract any data from them. Fast.

--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Cheerio Scraper
 
 Cheerio Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [Cheerio](https://cheerio.js.org) Node.js library and lets you extract any data from them. Fast.

--- a/packages/actor-scraper/jsdom-scraper/README.md
+++ b/packages/actor-scraper/jsdom-scraper/README.md
@@ -1,3 +1,4 @@
+[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
 ## What is JSDOM Scraper?
 
 JSDOM Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [JSDOM](https://github.com/jsdom/jsdom) Node.js library and lets you extract any data from them using the Window API you know from browsers. Fast.

--- a/packages/actor-scraper/jsdom-scraper/README.md
+++ b/packages/actor-scraper/jsdom-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 ## What is JSDOM Scraper?
 
 JSDOM Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [JSDOM](https://github.com/jsdom/jsdom) Node.js library and lets you extract any data from them using the Window API you know from browsers. Fast.

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -1,3 +1,4 @@
+[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
 # Playwright Scraper
 
 Playwright Scraper is the most powerful scraper tool in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Playwright Scraper
 
 Playwright Scraper is the most powerful scraper tool in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Puppeteer Scraper
 
 Puppeteer Scraper is one of the most powerful scraper tools in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -1,3 +1,4 @@
+[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
 # Puppeteer Scraper
 
 Puppeteer Scraper is one of the most powerful scraper tools in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -1,3 +1,4 @@
+[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
 # Web Scraper
 
 Web Scraper is a generic easy-to-use actor for crawling arbitrary web pages

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Web Scraper
 
 Web Scraper is a generic easy-to-use actor for crawling arbitrary web pages


### PR DESCRIPTION
The marketing team wants to promote the Actor monetization webinar in the READMEs of the generic actors. This PR adds a single banner on top of each of the READMEs.