### PR TITLE
docs: remove the monetization banner and h1 from actors

### DIFF
--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -1,5 +1,4 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Cheerio Scraper
 
 Cheerio Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [Cheerio](https://cheerio.js.org) Node.js library and lets you extract any data from them. Fast.

--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -1,5 +1,3 @@
-# Cheerio Scraper
-
 Cheerio Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [Cheerio](https://cheerio.js.org) Node.js library and lets you extract any data from them. Fast.
 
 Cheerio is a server-side version of the popular [jQuery](https://jquery.com) library. It does not require a

--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -1,5 +1,3 @@
-[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Cheerio Scraper
 
 Cheerio Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [Cheerio](https://cheerio.js.org) Node.js library and lets you extract any data from them. Fast.

--- a/packages/actor-scraper/cheerio-scraper/README.md
+++ b/packages/actor-scraper/cheerio-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Cheerio Scraper
 
 Cheerio Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [Cheerio](https://cheerio.js.org) Node.js library and lets you extract any data from them. Fast.

--- a/packages/actor-scraper/jsdom-scraper/README.md
+++ b/packages/actor-scraper/jsdom-scraper/README.md
@@ -1,5 +1,3 @@
-## What is JSDOM Scraper?
-
 JSDOM Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [JSDOM](https://github.com/jsdom/jsdom) Node.js library and lets you extract any data from them using the Window API you know from browsers. Fast.
 
 JSDOM is a server-side emulation of the standard browser Window API. It does not require a browser; instead, it constructs a DOM tree from a provided HTML string. The user is then presented with an API to work with that DOM tree.

--- a/packages/actor-scraper/jsdom-scraper/README.md
+++ b/packages/actor-scraper/jsdom-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 ## What is JSDOM Scraper?
 
 JSDOM Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [JSDOM](https://github.com/jsdom/jsdom) Node.js library and lets you extract any data from them using the Window API you know from browsers. Fast.

--- a/packages/actor-scraper/jsdom-scraper/README.md
+++ b/packages/actor-scraper/jsdom-scraper/README.md
@@ -1,5 +1,3 @@
-[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 ## What is JSDOM Scraper?
 
 JSDOM Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [JSDOM](https://github.com/jsdom/jsdom) Node.js library and lets you extract any data from them using the Window API you know from browsers. Fast.

--- a/packages/actor-scraper/jsdom-scraper/README.md
+++ b/packages/actor-scraper/jsdom-scraper/README.md
@@ -1,5 +1,4 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 ## What is JSDOM Scraper?
 
 JSDOM Scraper is a ready-made solution for crawling websites using plain HTTP requests. It retrieves the HTML pages, parses them using the [JSDOM](https://github.com/jsdom/jsdom) Node.js library and lets you extract any data from them using the Window API you know from browsers. Fast.

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -1,5 +1,3 @@
-# Playwright Scraper
-
 Playwright Scraper is the most powerful scraper tool in our arsenal (aside from developing your own actors).
 
 It uses the Playwright library to programmatically control a headless Chromium or Firefox browser, and it can make it do almost anything. If using [Web Scraper](https://apify.com/apify/web-scraper) doesn't cut it for your use case, then Playwright Scraper is what you need.

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -1,5 +1,3 @@
-[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Playwright Scraper
 
 Playwright Scraper is the most powerful scraper tool in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -1,5 +1,4 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Playwright Scraper
 
 Playwright Scraper is the most powerful scraper tool in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/playwright-scraper/README.md
+++ b/packages/actor-scraper/playwright-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Playwright Scraper
 
 Playwright Scraper is the most powerful scraper tool in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -1,5 +1,3 @@
-# Puppeteer Scraper
-
 Puppeteer Scraper is one of the most powerful scraper tools in our arsenal (aside from developing your own actors).
 
 It uses the Puppeteer library to programmatically control a headless Chrome browser, and it can make it do almost anything. If using [Web Scraper](https://apify.com/apify/web-scraper) doesn't cut it for your use case, then Puppeteer Scraper is what you need.

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -1,5 +1,3 @@
-[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Puppeteer Scraper
 
 Puppeteer Scraper is one of the most powerful scraper tools in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -1,5 +1,4 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Puppeteer Scraper
 
 Puppeteer Scraper is one of the most powerful scraper tools in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/puppeteer-scraper/README.md
+++ b/packages/actor-scraper/puppeteer-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Puppeteer Scraper
 
 Puppeteer Scraper is one of the most powerful scraper tools in our arsenal (aside from developing your own actors).

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -1,5 +1,3 @@
-[![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Web Scraper
 
 Web Scraper is a generic easy-to-use actor for crawling arbitrary web pages

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -1,4 +1,5 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
+
 # Web Scraper
 
 Web Scraper is a generic easy-to-use actor for crawling arbitrary web pages

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -1,5 +1,4 @@
 [![Webinar on Building and Monetization of Actors](https://raw.githubusercontent.com/apify-projects/actor-readme-images/master/Build%20and%20monetize_Webinar%20Store%20banner.jpg)](https://apify.com/resources/build-monetize-actors)
-
 # Web Scraper
 
 Web Scraper is a generic easy-to-use actor for crawling arbitrary web pages

--- a/packages/actor-scraper/web-scraper/README.md
+++ b/packages/actor-scraper/web-scraper/README.md
@@ -1,5 +1,3 @@
-# Web Scraper
-
 Web Scraper is a generic easy-to-use actor for crawling arbitrary web pages
 and extracting structured data from them using a few lines of JavaScript code.
 The actor loads web pages in the Chromium browser and renders dynamic content.


### PR DESCRIPTION
merge this to remove the Actor monetization banner after the event has passed.

Note that to propagate this change to the Console, the actors have to be rebuilt (one by one, manually 🙃)