### PR TITLE
chore: try to fix the puppeteer download in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release @latest
 
+env:
+    PUPPETEER_DOWNLOAD_BASE_URL: https://storage.googleapis.com/chrome-for-testing-public
+
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -1,5 +1,8 @@
 name: Check & Release
 
+env:
+    PUPPETEER_DOWNLOAD_BASE_URL: https://storage.googleapis.com/chrome-for-testing-public
+
 on:
     # Push to master will deploy a dev version
     push:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,5 +1,8 @@
 name: E2E scraper tests
 
+env:
+    PUPPETEER_DOWNLOAD_BASE_URL: https://storage.googleapis.com/chrome-for-testing-public
+
 on:
     workflow_dispatch:
     schedule:


### PR DESCRIPTION
Telling puppeteer to download the binaries from the (current|alternative)? server.

This should get fixed with puppeteer v22, but I'd like to release before that (WCC release waiting for this and I'm leaving on vacation on Sunday 😄 )