### PR TITLE
refactor: use RequestQueueV2 for all Actor scrapers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17170,7 +17170,7 @@
         },
         "packages/actor-scraper/cheerio-scraper": {
             "name": "actor-cheerio-scraper",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
@@ -17189,7 +17189,7 @@
         },
         "packages/actor-scraper/jsdom-scraper": {
             "name": "actor-jsdom-scraper",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
@@ -17208,7 +17208,7 @@
         },
         "packages/actor-scraper/playwright-scraper": {
             "name": "actor-playwright-scraper",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
@@ -17228,7 +17228,7 @@
         },
         "packages/actor-scraper/puppeteer-scraper": {
             "name": "actor-puppeteer-scraper",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
@@ -17246,7 +17246,7 @@
         },
         "packages/actor-scraper/web-scraper": {
             "name": "actor-web-scraper",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
@@ -17290,7 +17290,7 @@
         },
         "packages/scraper-tools": {
             "name": "@apify/scraper-tools",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/log": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "@typescript-eslint/eslint-plugin": "^7.0.0",
                 "@typescript-eslint/parser": "^7.0.0",
                 "commitlint": "^18.0.0",
-                "crawlee": "^3.8.0",
+                "crawlee": "^3.8.2",
                 "eslint": "^8.54.0",
                 "fs-extra": "^11.1.1",
                 "gen-esm-wrapper": "^1.1.3",
@@ -648,16 +648,16 @@
             }
         },
         "node_modules/@crawlee/basic": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.8.0.tgz",
-            "integrity": "sha512-Yc00vNVGMGsyFK0DqeNRyjb8+yk9nBbHs6Qh+KARN1ljYo0CmUBYjaTdOAM5LCIe7Num1pakLSAFJpKP26+7EQ==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.8.2.tgz",
+            "integrity": "sha512-GK39H4Sa52+uovSW6UyZcgY0OC4b6DZ5POiF+xsfWnzR8yyH045CUxRJKBQFq+Fx9E87YQllbQvSdf7VThlCDg==",
             "dependencies": {
                 "@apify/log": "^2.4.0",
                 "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.7.10",
-                "@crawlee/core": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/core": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "csv-stringify": "^6.2.0",
                 "fs-extra": "^11.0.0",
                 "got-scraping": "^4.0.0",
@@ -671,15 +671,15 @@
             }
         },
         "node_modules/@crawlee/browser": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.8.0.tgz",
-            "integrity": "sha512-EgEbOhpRnrlOKDxEV4rppyVUJVDVhS0XAehF4LArzBI4zXUboPlHrKi0CxcFSgXim205RbiQAKSJRxdXaADoZQ==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.8.2.tgz",
+            "integrity": "sha512-cmY6jXNLJ6WVr6B1SA/KK3W3IiWSalfapgFJtx/7UzGhf2VkcvlM5XVdsFSqk98fviXCDx4i9Z7LGUCck9nV9Q==",
             "dependencies": {
                 "@apify/timeout": "^0.3.0",
-                "@crawlee/basic": "3.8.0",
-                "@crawlee/browser-pool": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/basic": "3.8.2",
+                "@crawlee/browser-pool": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "ow": "^0.28.1",
                 "tslib": "^2.4.0",
                 "type-fest": "^4.0.0"
@@ -689,14 +689,14 @@
             }
         },
         "node_modules/@crawlee/browser-pool": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.8.0.tgz",
-            "integrity": "sha512-oqTYHOcUKxsiOCKUSqiLkSRD8pRkmOilfHLCymMt+eH49M0P4Zpi9+wo61gYsbch+YixeJ6ACOZzT5YLNgfbhQ==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.8.2.tgz",
+            "integrity": "sha512-p0GZ48/5lB7s/ttLTDV+IV497WoBpSgEKdfy8dUoApiaju0768CMNQ5IqUfjU/rD/Y0OZWU71IIfa4S+HVhG+A==",
             "dependencies": {
                 "@apify/log": "^2.4.0",
                 "@apify/timeout": "^0.3.0",
-                "@crawlee/core": "3.8.0",
-                "@crawlee/types": "3.8.0",
+                "@crawlee/core": "3.8.2",
+                "@crawlee/types": "3.8.2",
                 "fingerprint-generator": "^2.0.6",
                 "fingerprint-injector": "^2.0.5",
                 "lodash.merge": "^4.6.2",
@@ -725,13 +725,13 @@
             }
         },
         "node_modules/@crawlee/cheerio": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.8.0.tgz",
-            "integrity": "sha512-BeIR2Z70UXuBSzEO78f+MVJcgmV4He5lEhRHOmGE2p5/NQ2GNaK6HI1m+OlDbAoj73BYz+89lskjLNk02Kho6Q==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.8.2.tgz",
+            "integrity": "sha512-jXKKlaq30dygvHO9g4GONw1CHlXt2t+oLwTYv2mcuEKZdSqrJY9R6PQYKw+wKfBoY25ECP7vxxVcF/ihEW+yiA==",
             "dependencies": {
-                "@crawlee/http": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/http": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "cheerio": "^1.0.0-rc.12",
                 "htmlparser2": "^9.0.0",
                 "tslib": "^2.4.0"
@@ -741,11 +741,11 @@
             }
         },
         "node_modules/@crawlee/cli": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.8.0.tgz",
-            "integrity": "sha512-J2Tpx8067+ViuUl+7BpUz0f477mXI3LABTIPQIZQVWEK0YqV0RRv+0mNZFkFhTjHL2A7HR99kwGBrOm0X2MgXA==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.8.2.tgz",
+            "integrity": "sha512-XzKQQWxE9TuQIkNiuxFp6uSlACKEe/Q58qJLJZX4WEJSGVDw7QsEBkhFk9s0PnQzWW55H7azD5gUyw2CKBYDjw==",
             "dependencies": {
-                "@crawlee/templates": "3.8.0",
+                "@crawlee/templates": "3.8.2",
                 "ansi-colors": "^4.1.3",
                 "fs-extra": "^11.0.0",
                 "inquirer": "^8.2.4",
@@ -761,9 +761,9 @@
             }
         },
         "node_modules/@crawlee/core": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.8.0.tgz",
-            "integrity": "sha512-10kx1Mrvqv87cE4J2LjPClxHwa5RcJOiOxge4e9CweQjuY5sIc3Z7h+cJ86u27LFqWpbcCMWtNbA5DR8dn8QgQ==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.8.2.tgz",
+            "integrity": "sha512-29UNAPbtOQL/d4gkQXDibAQ+LSYT53MVqG0LZx/ebB4yiRv51BAIfZL//9+umWS/f/F75O706nCscgGb1ZASPQ==",
             "dependencies": {
                 "@apify/consts": "^2.20.0",
                 "@apify/datastructures": "^2.0.0",
@@ -771,9 +771,9 @@
                 "@apify/pseudo_url": "^2.0.30",
                 "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.7.10",
-                "@crawlee/memory-storage": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/memory-storage": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "@sapphire/async-queue": "^1.5.1",
                 "@types/tough-cookie": "^4.0.2",
                 "@vladfrangu/async_event_emitter": "^2.2.2",
@@ -795,15 +795,15 @@
             }
         },
         "node_modules/@crawlee/http": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.8.0.tgz",
-            "integrity": "sha512-wpzvk1PGHduj2m0+eqN1F9+mRu4ZX1A1g7SVLdvywwo1nSCb0aa2i8NRD1uxrCJ+NFDpa7tx/W4+ZTzuLhgYeA==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.8.2.tgz",
+            "integrity": "sha512-3AciBhT8+uBegXhUyeuoc4MMI+CIxnT8M8TIpQRq3H0oGJpBKDmEEYYS+R7O1wHZY1O1YGT6voyPTHlGBnma9g==",
             "dependencies": {
                 "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.7.10",
-                "@crawlee/basic": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/basic": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "@types/content-type": "^1.1.5",
                 "cheerio": "^1.0.0-rc.12",
                 "content-type": "^1.0.4",
@@ -819,14 +819,14 @@
             }
         },
         "node_modules/@crawlee/jsdom": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.8.0.tgz",
-            "integrity": "sha512-jN1U9skIBIDXwqcOdrCf63EL18y/a4lyk6vMV3IPXWwSWxdnlrGmfCl6iCGpYlO48QEqLxtwMxNtyklbHlis6A==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.8.2.tgz",
+            "integrity": "sha512-oAkRzj90QwAJJwOhiJDDXyOoFetgYarAqKgF1jawGwJFfvcclOX+obN7mQnQk52kugNZQIcTeCiM0EMrCVbIZQ==",
             "dependencies": {
                 "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.7.10",
-                "@crawlee/http": "3.8.0",
-                "@crawlee/types": "3.8.0",
+                "@crawlee/http": "3.8.2",
+                "@crawlee/types": "3.8.2",
                 "@types/jsdom": "^21.0.0",
                 "cheerio": "^1.0.0-rc.12",
                 "jsdom": "^24.0.0",
@@ -838,14 +838,14 @@
             }
         },
         "node_modules/@crawlee/linkedom": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/linkedom/-/linkedom-3.8.0.tgz",
-            "integrity": "sha512-8S24JDKSCy6S+UTei9IQdoRdsQiVhXJ/a3zmjTtU+niMqstHijGcsPC5CLNjaPREt9xOcz5XecyhKTRQIwkoYw==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/linkedom/-/linkedom-3.8.2.tgz",
+            "integrity": "sha512-lUw7fuz1pbATe1byjxl21JqfmHQTNCDFeHWzq2xKKoWJU9HBKjIr+5ysap+c/2zXfDgi9jq5+ekiDTAFyl2XzQ==",
             "dependencies": {
                 "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.7.10",
-                "@crawlee/http": "3.8.0",
-                "@crawlee/types": "3.8.0",
+                "@crawlee/http": "3.8.2",
+                "@crawlee/types": "3.8.2",
                 "linkedom": "^0.16.0",
                 "ow": "^0.28.2",
                 "tslib": "^2.4.0"
@@ -855,12 +855,12 @@
             }
         },
         "node_modules/@crawlee/memory-storage": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.8.0.tgz",
-            "integrity": "sha512-dJY5Y0Zxn+cR6m7+CqHF4IwarsSESvVWoTEba5vfnxQPXTVYLren0gnqVCLI4O5Alhid/BwwQJPe7gjGWI/K2w==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.8.2.tgz",
+            "integrity": "sha512-ZJybwdokAKZsOuZ1McB18yImGwRFqHshvYALxuK9wn0DVmZwcSpPfByhO11vZ8sGsqh2STaEJjS/HwGS9Ty6bQ==",
             "dependencies": {
                 "@apify/log": "^2.4.0",
-                "@crawlee/types": "3.8.0",
+                "@crawlee/types": "3.8.2",
                 "@sapphire/async-queue": "^1.5.0",
                 "@sapphire/shapeshift": "^3.0.0",
                 "content-type": "^1.0.4",
@@ -875,18 +875,18 @@
             }
         },
         "node_modules/@crawlee/playwright": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.8.0.tgz",
-            "integrity": "sha512-61VM4MbVyq5vFFwhJDmoMKlfIOA8uJmhaTfJztZb9MupM8H+Cm2KawtTlz7lF8oAZ9Qr1+/vY1YwnDufEV6Rvg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.8.2.tgz",
+            "integrity": "sha512-qvMrgpIunxAL8eG6HIcAGcE+2lRSb8fG76AYn1MjnPFbpBiAnYOLGOjS4ihJJeIQSLcy2VKUWuQph927Rv3QTQ==",
             "dependencies": {
                 "@apify/datastructures": "^2.0.0",
                 "@apify/log": "^2.4.0",
                 "@apify/timeout": "^0.3.1",
-                "@crawlee/browser": "3.8.0",
-                "@crawlee/browser-pool": "3.8.0",
-                "@crawlee/core": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/browser": "3.8.2",
+                "@crawlee/browser-pool": "3.8.2",
+                "@crawlee/core": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "cheerio": "^1.0.0-rc.12",
                 "idcac-playwright": "^0.1.2",
                 "jquery": "^3.6.0",
@@ -909,16 +909,16 @@
             }
         },
         "node_modules/@crawlee/puppeteer": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.8.0.tgz",
-            "integrity": "sha512-gRq7//CZ+K6H4Gzon3ioU5UuOw53GMTPvgGUqyp3B8NWhuRFidvDYHv8GnJjSZbVJGjpeN+CRaiVv59QiORvtg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.8.2.tgz",
+            "integrity": "sha512-Ocf+Srcpy+fOhHlXlpU3j4/rTvoTiQgepiWoRQSIX2D0kjrZPvxxXJYO+z4Aq/+6MFP6n9Y0e6iHv7U+8+fuug==",
             "dependencies": {
                 "@apify/datastructures": "^2.0.0",
                 "@apify/log": "^2.4.0",
-                "@crawlee/browser": "3.8.0",
-                "@crawlee/browser-pool": "3.8.0",
-                "@crawlee/types": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/browser": "3.8.2",
+                "@crawlee/browser-pool": "3.8.2",
+                "@crawlee/types": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "cheerio": "^1.0.0-rc.12",
                 "devtools-protocol": "*",
                 "idcac-playwright": "^0.1.2",
@@ -939,9 +939,9 @@
             }
         },
         "node_modules/@crawlee/templates": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.8.0.tgz",
-            "integrity": "sha512-FCxhJqMrzJM4fR4h5PZmEd88CmoiHix6xFQKS+LzQZMHM9zCoPm9XAPj9a6h3b8uO6Dy5D8uYdqIi7s/b9n2JA==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.8.2.tgz",
+            "integrity": "sha512-SrD8Wlq86/edzVojn9ZPjmfh0oBIQ5wRGsqZzc5vO4FgIhKrCFSwY1pmhHLKb3FS3C02oVYO9/qJZlbs07wdgA==",
             "dependencies": {
                 "ansi-colors": "^4.1.3",
                 "inquirer": "^9.0.0",
@@ -973,11 +973,11 @@
             }
         },
         "node_modules/@crawlee/templates/node_modules/inquirer": {
-            "version": "9.2.15",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.15.tgz",
-            "integrity": "sha512-vI2w4zl/mDluHt9YEQ/543VTCwPKWiHzKtm9dM2V0NdFcqEexDAjUHzO1oA60HRNaVifGXXM1tRRNluLVHa0Kg==",
+            "version": "9.2.16",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.16.tgz",
+            "integrity": "sha512-qzgbB+yNjgSzk2omeqMDtO9IgJet/UL67luT1MaaggRpGK73DBQct5Q4pipwFQcIKK1GbMODYd4UfsRCkSP1DA==",
             "dependencies": {
-                "@ljharb/through": "^2.3.12",
+                "@ljharb/through": "^2.3.13",
                 "ansi-escapes": "^4.3.2",
                 "chalk": "^5.3.0",
                 "cli-cursor": "^3.1.0",
@@ -1014,9 +1014,9 @@
             }
         },
         "node_modules/@crawlee/types": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.8.0.tgz",
-            "integrity": "sha512-NVD5Ay2Gq3E0lZkowea2KgM0HO7Fl8VC28OYstzHH/CQvxvgIQq9ft3txnoy/FfJGP1qcu3dz2G1a/V995Ml4w==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.8.2.tgz",
+            "integrity": "sha512-42Sm9yeRAR1a3p7/PW4OAKk74RYBXRyV3ns3rSm13HC8UVX1vIeEDEifppdgZu80XvJZGD2v8XVN/LokYghcFA==",
             "dependencies": {
                 "tslib": "^2.4.0"
             },
@@ -1025,13 +1025,13 @@
             }
         },
         "node_modules/@crawlee/utils": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.8.0.tgz",
-            "integrity": "sha512-wFuLmJYTpO0baI1/ZpH0k20nEEdl7F8vaa4hcYuNEt6KIJJoXKj3rJbOa4LWEek6ub+jtdHds6lgVJ7h7e9Gaw==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.8.2.tgz",
+            "integrity": "sha512-kHcnmtkOYrmqbyI+SEOeCAxkcOzAMNkvlZoQ/sWd30qG4z0llalS/Tb4MAi9/iL81EU4J90T3nC2h68rs28JOw==",
             "dependencies": {
                 "@apify/log": "^2.4.0",
                 "@apify/ps-tree": "^1.2.0",
-                "@crawlee/types": "3.8.0",
+                "@crawlee/types": "3.8.2",
                 "@types/sax": "^1.2.7",
                 "cheerio": "^1.0.0-rc.12",
                 "got-scraping": "^4.0.3",
@@ -1923,11 +1923,11 @@
             }
         },
         "node_modules/@ljharb/through": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.12.tgz",
-            "integrity": "sha512-ajo/heTlG3QgC8EGP6APIejksVAYt4ayz4tqoP3MolFELzcH1x1fzwEYRJTPO0IELutZ5HQ0c26/GqAYy79u3g==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
+            "integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
             "dependencies": {
-                "call-bind": "^1.0.5"
+                "call-bind": "^1.0.7"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5799,22 +5799,22 @@
             }
         },
         "node_modules/crawlee": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.8.0.tgz",
-            "integrity": "sha512-1jV2MPO1Ji2BHbFo/tNrrqlORfiiSAJ5HzG+ONFynsM+FePCyEs97cVX74vnwLFUGCMH6SxnD8IfFC9jcSS2Gg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.8.2.tgz",
+            "integrity": "sha512-hfFfxJlcJSVo6NJuDmDUZ7nMHZ6YswEgUOW0WKWdOEGIuKpC8HFaCPZTH0CcatD1aBXr7YS3VefenKSjHFGZEA==",
             "dependencies": {
-                "@crawlee/basic": "3.8.0",
-                "@crawlee/browser": "3.8.0",
-                "@crawlee/browser-pool": "3.8.0",
-                "@crawlee/cheerio": "3.8.0",
-                "@crawlee/cli": "3.8.0",
-                "@crawlee/core": "3.8.0",
-                "@crawlee/http": "3.8.0",
-                "@crawlee/jsdom": "3.8.0",
-                "@crawlee/linkedom": "3.8.0",
-                "@crawlee/playwright": "3.8.0",
-                "@crawlee/puppeteer": "3.8.0",
-                "@crawlee/utils": "3.8.0",
+                "@crawlee/basic": "3.8.2",
+                "@crawlee/browser": "3.8.2",
+                "@crawlee/browser-pool": "3.8.2",
+                "@crawlee/cheerio": "3.8.2",
+                "@crawlee/cli": "3.8.2",
+                "@crawlee/core": "3.8.2",
+                "@crawlee/http": "3.8.2",
+                "@crawlee/jsdom": "3.8.2",
+                "@crawlee/linkedom": "3.8.2",
+                "@crawlee/playwright": "3.8.2",
+                "@crawlee/puppeteer": "3.8.2",
+                "@crawlee/utils": "3.8.2",
                 "import-local": "^3.1.0",
                 "tslib": "^2.4.0"
             },
@@ -10557,14 +10557,14 @@
             }
         },
         "node_modules/linkedom": {
-            "version": "0.16.8",
-            "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.8.tgz",
-            "integrity": "sha512-+HtHVHBb3yZKlP9pgcJdi1AIG9tsAuo+Qtlz+79cCTsxgQwDzajsZjYvpp+DEckCK/zoGVhzkADniYZQ57KcFQ==",
+            "version": "0.16.10",
+            "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.10.tgz",
+            "integrity": "sha512-c316CX1FiPMU1v4+ExUzxr/gD5xqyCX2M3qtyL2nuoYQTsk0F5jRRwOFG7jRRxD3w7ONbLTLMrGBvq++Hmzzhg==",
             "dependencies": {
                 "css-select": "^5.1.0",
                 "cssom": "^0.5.0",
                 "html-escaper": "^3.0.3",
-                "htmlparser2": "^9.0.0",
+                "htmlparser2": "^9.1.0",
                 "uhyphen": "^0.2.0"
             }
         },
@@ -17174,7 +17174,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
-                "@crawlee/cheerio": "^3.5.2",
+                "@crawlee/cheerio": "^3.8.2",
                 "apify": "^3.1.8"
             },
             "devDependencies": {
@@ -17193,7 +17193,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
-                "@crawlee/jsdom": "^3.5.2",
+                "@crawlee/jsdom": "^3.8.2",
                 "apify": "^3.1.8"
             },
             "devDependencies": {
@@ -17212,9 +17212,9 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
-                "@crawlee/core": "^3.5.2",
-                "@crawlee/playwright": "^3.5.2",
-                "@crawlee/utils": "^3.5.2",
+                "@crawlee/core": "^3.8.2",
+                "@crawlee/playwright": "^3.8.2",
+                "@crawlee/utils": "^3.8.2",
                 "apify": "^3.1.8",
                 "idcac-playwright": "^0.1.2",
                 "playwright": "*"
@@ -17232,7 +17232,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
-                "@crawlee/puppeteer": "^3.5.2",
+                "@crawlee/puppeteer": "^3.8.2",
                 "apify": "^3.1.8",
                 "idcac-playwright": "^0.1.2",
                 "puppeteer": "*"
@@ -17250,10 +17250,10 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/scraper-tools": "^1.1.1",
-                "@crawlee/puppeteer": "^3.5.2",
+                "@crawlee/puppeteer": "^3.8.2",
                 "apify": "^3.1.8",
                 "content-type": "^1.0.5",
-                "crawlee": "^3.5.2",
+                "crawlee": "^3.8.2",
                 "devtools-server": "^0.0.2",
                 "idcac-playwright": "^0.1.2",
                 "puppeteer": "*"
@@ -17299,17 +17299,17 @@
                 "tslib": "^2.6.1"
             },
             "devDependencies": {
-                "@crawlee/browser-pool": "^3.5.2",
-                "@crawlee/core": "^3.5.2",
-                "@crawlee/types": "^3.5.2",
-                "@crawlee/utils": "^3.5.2",
+                "@crawlee/browser-pool": "^3.8.2",
+                "@crawlee/core": "^3.8.2",
+                "@crawlee/types": "^3.8.2",
+                "@crawlee/utils": "^3.8.2",
                 "apify": "^3.1.8"
             },
             "peerDependencies": {
-                "@crawlee/browser-pool": "^3.5.2",
-                "@crawlee/core": "^3.5.2",
-                "@crawlee/types": "^3.5.2",
-                "@crawlee/utils": "^3.5.2",
+                "@crawlee/browser-pool": "^3.8.2",
+                "@crawlee/core": "^3.8.2",
+                "@crawlee/types": "^3.8.2",
+                "@crawlee/utils": "^3.8.2",
                 "apify": "^3.1.8"
             },
             "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "commitlint": "^18.0.0",
-        "crawlee": "^3.8.0",
+        "crawlee": "^3.8.2",
         "eslint": "^8.54.0",
         "fs-extra": "^11.1.1",
         "gen-esm-wrapper": "^1.1.3",

--- a/packages/actor-scraper/cheerio-scraper/package.json
+++ b/packages/actor-scraper/cheerio-scraper/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "dependencies": {
         "@apify/scraper-tools": "^1.1.1",
-        "@crawlee/cheerio": "^3.5.2",
+        "@crawlee/cheerio": "^3.8.2",
         "apify": "^3.1.8"
     },
     "devDependencies": {

--- a/packages/actor-scraper/cheerio-scraper/package.json
+++ b/packages/actor-scraper/cheerio-scraper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actor-cheerio-scraper",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "private": true,
     "description": "Crawl web pages using HTTP requests and Cheerio",
     "type": "module",

--- a/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
@@ -20,7 +20,7 @@ import {
     ProxyConfiguration,
     Request,
     RequestList,
-    RequestQueue,
+    RequestQueueV2,
     log,
     Dictionary,
     Awaitable,
@@ -48,7 +48,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
      * Used to store data that persist navigations
      */
     globalStore = new Map();
-    requestQueue: RequestQueue;
+    requestQueue: RequestQueueV2;
     keyValueStore: KeyValueStore;
     customData: unknown;
     input: Input;
@@ -137,7 +137,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         this.requestList = await RequestList.open('CHEERIO_SCRAPER', startUrls);
 
         // RequestQueue
-        this.requestQueue = await RequestQueue.open(this.requestQueueName);
+        this.requestQueue = await RequestQueueV2.open(this.requestQueueName);
 
         // Dataset
         this.dataset = await Dataset.open(this.datasetName);
@@ -187,6 +187,9 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 sessionOptions: {
                     maxUsageCount: this.maxSessionUsageCount,
                 },
+            },
+            experiments: {
+                requestLocking: true,
             },
         };
 

--- a/packages/actor-scraper/jsdom-scraper/package.json
+++ b/packages/actor-scraper/jsdom-scraper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actor-jsdom-scraper",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "private": true,
     "description": "Crawl web pages using HTTP requests and JSDOM parser",
     "type": "module",

--- a/packages/actor-scraper/jsdom-scraper/package.json
+++ b/packages/actor-scraper/jsdom-scraper/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "dependencies": {
         "@apify/scraper-tools": "^1.1.1",
-        "@crawlee/jsdom": "^3.5.2",
+        "@crawlee/jsdom": "^3.8.2",
         "apify": "^3.1.8"
     },
     "devDependencies": {

--- a/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
@@ -20,7 +20,7 @@ import {
     ProxyConfiguration,
     Request,
     RequestList,
-    RequestQueue,
+    RequestQueueV2,
     log,
     Dictionary,
     Awaitable,
@@ -47,7 +47,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
      * Used to store data that persist navigations
      */
     globalStore = new Map();
-    requestQueue: RequestQueue;
+    requestQueue: RequestQueueV2;
     keyValueStore: KeyValueStore;
     customData: unknown;
     input: Input;
@@ -136,7 +136,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         this.requestList = await RequestList.open('JSDOM_SCRAPER', startUrls);
 
         // RequestQueue
-        this.requestQueue = await RequestQueue.open(this.requestQueueName);
+        this.requestQueue = await RequestQueueV2.open(this.requestQueueName);
 
         // Dataset
         this.dataset = await Dataset.open(this.datasetName);
@@ -188,6 +188,9 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 sessionOptions: {
                     maxUsageCount: this.maxSessionUsageCount,
                 },
+            },
+            experiments: {
+                requestLocking: true,
             },
         };
 

--- a/packages/actor-scraper/playwright-scraper/package.json
+++ b/packages/actor-scraper/playwright-scraper/package.json
@@ -6,9 +6,9 @@
     "type": "module",
     "dependencies": {
         "@apify/scraper-tools": "^1.1.1",
-        "@crawlee/core": "^3.5.2",
-        "@crawlee/playwright": "^3.5.2",
-        "@crawlee/utils": "^3.5.2",
+        "@crawlee/core": "^3.8.2",
+        "@crawlee/playwright": "^3.8.2",
+        "@crawlee/utils": "^3.8.2",
         "apify": "^3.1.8",
         "idcac-playwright": "^0.1.2",
         "playwright": "*"

--- a/packages/actor-scraper/playwright-scraper/package.json
+++ b/packages/actor-scraper/playwright-scraper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actor-playwright-scraper",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "private": true,
     "description": "Crawl web pages using Apify, headless browser and Playwright",
     "type": "module",

--- a/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
@@ -9,7 +9,7 @@ import {
     KeyValueStore,
     Request,
     RequestList,
-    RequestQueue,
+    RequestQueueV2,
     PlaywrightCrawlingContext,
     PlaywrightCrawler,
     PlaywrightCrawlerOptions,
@@ -42,7 +42,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
      * Used to store data that persist navigations
      */
     globalStore = new Map();
-    requestQueue: RequestQueue;
+    requestQueue: RequestQueueV2;
     keyValueStore: KeyValueStore;
     customData: unknown;
     input: Input;
@@ -152,7 +152,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         this.requestList = await RequestList.open('PLAYWRIGHT_SCRAPER', startUrls);
 
         // RequestQueue
-        this.requestQueue = await RequestQueue.open(this.requestQueueName);
+        this.requestQueue = await RequestQueueV2.open(this.requestQueueName);
 
         // Dataset
         this.dataset = await Dataset.open(this.datasetName);
@@ -204,6 +204,9 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 sessionOptions: {
                     maxUsageCount: this.maxSessionUsageCount,
                 },
+            },
+            experiments: {
+                requestLocking: true,
             },
         };
 

--- a/packages/actor-scraper/puppeteer-scraper/package.json
+++ b/packages/actor-scraper/puppeteer-scraper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actor-puppeteer-scraper",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "private": true,
     "description": "Crawl web pages using Apify, headless Chrome and Puppeteer",
     "type": "module",

--- a/packages/actor-scraper/puppeteer-scraper/package.json
+++ b/packages/actor-scraper/puppeteer-scraper/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "dependencies": {
         "@apify/scraper-tools": "^1.1.1",
-        "@crawlee/puppeteer": "^3.5.2",
+        "@crawlee/puppeteer": "^3.8.2",
         "apify": "^3.1.8",
         "idcac-playwright": "^0.1.2",
         "puppeteer": "*"

--- a/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
@@ -9,7 +9,7 @@ import {
     KeyValueStore,
     Request,
     RequestList,
-    RequestQueue,
+    RequestQueueV2,
     EnqueueLinksByClickingElementsOptions,
     PuppeteerCrawlingContext,
     PuppeteerCrawler,
@@ -42,7 +42,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
      * Used to store data that persist navigations
      */
     globalStore = new Map();
-    requestQueue: RequestQueue;
+    requestQueue: RequestQueueV2;
     keyValueStore: KeyValueStore;
     customData: unknown;
     input: Input;
@@ -150,7 +150,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         this.requestList = await RequestList.open('PUPPETEER_SCRAPER', startUrls);
 
         // RequestQueue
-        this.requestQueue = await RequestQueue.open(this.requestQueueName);
+        this.requestQueue = await RequestQueueV2.open(this.requestQueueName);
 
         // Dataset
         this.dataset = await Dataset.open(this.datasetName);
@@ -200,6 +200,9 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 sessionOptions: {
                     maxUsageCount: this.maxSessionUsageCount,
                 },
+            },
+            experiments: {
+                requestLocking: true,
             },
         };
 

--- a/packages/actor-scraper/web-scraper/package.json
+++ b/packages/actor-scraper/web-scraper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actor-web-scraper",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "private": true,
     "description": "Crawl web pages using Apify, headless Chrome and Puppeteer",
     "main": "dist/main.js",

--- a/packages/actor-scraper/web-scraper/package.json
+++ b/packages/actor-scraper/web-scraper/package.json
@@ -7,10 +7,10 @@
     "type": "module",
     "dependencies": {
         "@apify/scraper-tools": "^1.1.1",
-        "@crawlee/puppeteer": "^3.5.2",
+        "@crawlee/puppeteer": "^3.8.2",
         "apify": "^3.1.8",
         "content-type": "^1.0.5",
-        "crawlee": "^3.5.2",
+        "crawlee": "^3.8.2",
         "devtools-server": "^0.0.2",
         "idcac-playwright": "^0.1.2",
         "puppeteer": "*"

--- a/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
@@ -14,7 +14,7 @@ import {
     puppeteerUtils,
     Request,
     RequestList,
-    RequestQueue,
+    RequestQueueV2,
     log,
     Awaitable,
     Dictionary,
@@ -65,7 +65,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
      * Used to store data that persist navigations
      */
     globalStore = new GlobalStore<unknown>();
-    requestQueue: RequestQueue;
+    requestQueue: RequestQueueV2;
     keyValueStore: KeyValueStore;
     customData: unknown;
     input: Input;
@@ -175,7 +175,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         this.requestList = await RequestList.open('WEB_SCRAPER', startUrls);
 
         // RequestQueue
-        this.requestQueue = await RequestQueue.open(this.requestQueueName);
+        this.requestQueue = await RequestQueueV2.open(this.requestQueueName);
 
         // Dataset
         this.dataset = await Dataset.open(this.datasetName);
@@ -242,6 +242,9 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 sessionOptions: {
                     maxUsageCount: this.maxSessionUsageCount,
                 },
+            },
+            experiments: {
+                requestLocking: true,
             },
         };
 

--- a/packages/scraper-tools/package.json
+++ b/packages/scraper-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apify/scraper-tools",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Tools shared by Apify actor-scrapers.",
     "types": "dist/index.d.ts",
     "exports": {

--- a/packages/scraper-tools/package.json
+++ b/packages/scraper-tools/package.json
@@ -40,17 +40,17 @@
         "tslib": "^2.6.1"
     },
     "devDependencies": {
-        "@crawlee/browser-pool": "^3.5.2",
-        "@crawlee/core": "^3.5.2",
-        "@crawlee/types": "^3.5.2",
-        "@crawlee/utils": "^3.5.2",
+        "@crawlee/browser-pool": "^3.8.2",
+        "@crawlee/core": "^3.8.2",
+        "@crawlee/types": "^3.8.2",
+        "@crawlee/utils": "^3.8.2",
         "apify": "^3.1.8"
     },
     "peerDependencies": {
-        "@crawlee/browser-pool": "^3.5.2",
-        "@crawlee/core": "^3.5.2",
-        "@crawlee/types": "^3.5.2",
-        "@crawlee/utils": "^3.5.2",
+        "@crawlee/browser-pool": "^3.8.2",
+        "@crawlee/core": "^3.8.2",
+        "@crawlee/types": "^3.8.2",
+        "@crawlee/utils": "^3.8.2",
         "apify": "^3.1.8"
     },
     "peerDependenciesMeta": {

--- a/packages/scraper-tools/src/context.ts
+++ b/packages/scraper-tools/src/context.ts
@@ -5,7 +5,7 @@ import type {
     RecordOptions,
     Request,
     RequestOptions,
-    RequestQueue,
+    RequestQueueV2,
     RequestQueueOperationOptions,
 } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
@@ -23,7 +23,7 @@ export interface CrawlerSetupOptions {
     rawInput: string;
     env: ApifyEnv;
     globalStore: Map<string, unknown> | MapLike<string, unknown>;
-    requestQueue: RequestQueue;
+    requestQueue: RequestQueueV2;
     keyValueStore: KeyValueStore;
     customData: unknown;
 }
@@ -124,7 +124,7 @@ class Context<Options extends ContextOptions = ContextOptions, ExtraFields = Opt
     async enqueueRequest(
         requestOpts: RequestOptions = {} as RequestOptions,
         options: RequestQueueOperationOptions = {},
-    ) : ReturnType<RequestQueue['addRequest']> {
+    ) : ReturnType<RequestQueueV2['addRequest']> {
         const defaultRequestOpts = {
             useExtendedUniqueKey: true,
             keepUrlFragment: this.input.keepUrlFragments,


### PR DESCRIPTION
As part of the performance testing of the new request queue. 
We want to migrate all scraper to request queue v2 and see the performance impact on Apify backend.

Before we do that we will inform Apify support to have an idea about these changes and monitor the backend and potentially revert it back to previous version.