### PR TITLE
feat: validate crawlee versions in `Actor.init`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17095,6 +17095,7 @@
                 "@crawlee/types": "^3.9.0",
                 "@crawlee/utils": "^3.9.0",
                 "apify-client": "^2.9.0",
+                "fs-extra": "^11.2.0",
                 "ow": "^0.28.2",
                 "semver": "^7.5.4",
                 "tslib": "^2.6.2",

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -63,6 +63,7 @@
         "@crawlee/types": "^3.9.0",
         "@crawlee/utils": "^3.9.0",
         "apify-client": "^2.9.0",
+        "fs-extra": "^11.2.0",
         "ow": "^0.28.2",
         "semver": "^7.5.4",
         "tslib": "^2.6.2",

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -41,7 +41,7 @@ import { KeyValueStore } from './key_value_store';
 import { PlatformEventManager } from './platform_event_manager';
 import type { ProxyConfigurationOptions } from './proxy_configuration';
 import { ProxyConfiguration } from './proxy_configuration';
-import { logSystemInfo, printOutdatedSdkWarning } from './utils';
+import { checkCrawleeVersion, logSystemInfo, printOutdatedSdkWarning } from './utils';
 
 /**
  * `Actor` class serves as an alternative approach to the static helpers exported from the package. It allows to pass configuration
@@ -193,6 +193,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
         this.initialized = true;
 
+        checkCrawleeVersion();
         logSystemInfo();
         printOutdatedSdkWarning();
 

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -37,6 +37,9 @@ export function checkCrawleeVersion() {
         normalize(`${process.cwd()}/node_modules/crawlee/node_modules/@crawlee/core/package.json`),
         // when users install `@crawlee/cheerio` or other crawler package, we need to check the dependency under basic crawler package
         normalize(`${process.cwd()}/node_modules/@crawlee/basic/node_modules/@crawlee/core/package.json`),
+        // also check paths via `require.resolve` to support pnpm
+        require.resolve('crawlee/package.json'),
+        require.resolve('@crawlee/basic/package.json'),
     ];
 
     for (const path of paths) {

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -6,6 +6,7 @@ import log from '@apify/log';
 import { version as crawleeVersion } from '@crawlee/core/package.json';
 // @ts-expect-error if we enable resolveJsonModule, we end up with `src` folder in `dist`
 import { version as apifyClientVersion } from 'apify-client/package.json';
+import { pathExistsSync, readJSONSync } from 'fs-extra';
 import semver from 'semver';
 
 // @ts-expect-error if we enable resolveJsonModule, we end up with `src` folder in `dist`
@@ -23,6 +24,37 @@ export function logSystemInfo() {
         osType: type(),
         nodeVersion: process.version,
     });
+}
+
+/**
+ * Logs info about system, node version and apify package version.
+ * @internal
+ */
+export function checkCrawleeVersion() {
+    const paths = [
+        // when users install `crawlee` package, we need to check its core dependency
+        `${process.cwd()}/node_modules/crawlee/node_modules/@crawlee/core/package.json`,
+        // when users install `@crawlee/cheerio` or other crawler package, we need to check the dependency under basic crawler package
+        `${process.cwd()}/node_modules/@crawlee/basic/node_modules/@crawlee/core/package.json`,
+    ];
+
+    for (const path of paths) {
+        if (!pathExistsSync(path)) {
+            continue;
+        }
+
+        let version;
+
+        try {
+            version = readJSONSync(path).version;
+        } catch {
+            //
+        }
+
+        if (version != null && version !== crawleeVersion) {
+            throw new Error(`Detected incompatible Crawlee version used by the SDK. User installed ${version} but the SDK uses ${crawleeVersion}.`);
+        }
+    }
 }
 
 /**

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -1,4 +1,5 @@
 import { type } from 'node:os';
+import { normalize } from 'node:path';
 
 import { APIFY_ENV_VARS } from '@apify/consts';
 import log from '@apify/log';
@@ -33,9 +34,9 @@ export function logSystemInfo() {
 export function checkCrawleeVersion() {
     const paths = [
         // when users install `crawlee` package, we need to check its core dependency
-        `${process.cwd()}/node_modules/crawlee/node_modules/@crawlee/core/package.json`,
+        normalize(`${process.cwd()}/node_modules/crawlee/node_modules/@crawlee/core/package.json`),
         // when users install `@crawlee/cheerio` or other crawler package, we need to check the dependency under basic crawler package
-        `${process.cwd()}/node_modules/@crawlee/basic/node_modules/@crawlee/core/package.json`,
+        normalize(`${process.cwd()}/node_modules/@crawlee/basic/node_modules/@crawlee/core/package.json`),
     ];
 
     for (const path of paths) {

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -53,7 +53,9 @@ export function checkCrawleeVersion() {
         }
 
         if (version != null && version !== crawleeVersion) {
-            throw new Error(`Detected incompatible Crawlee version used by the SDK. User installed ${version} but the SDK uses ${crawleeVersion}.`);
+            const details = `User installed version (${version}) found in ${path}.\nSDK uses ${crawleeVersion} from ${require.resolve('@crawlee/core')}`;
+            // eslint-disable-next-line max-len
+            throw new Error(`Detected incompatible Crawlee version used by the SDK. User installed ${version} but the SDK uses ${crawleeVersion}.\n\n${details}`);
         }
     }
 }


### PR DESCRIPTION
The SDK depends on `@crawlee/core`, but if the user installs an incompatible version of crawlee, they might end up with two installations of the `@crawlee/core` which means multiple static registers like the one for the global configuration, which breaks the integration, since the SDK will only touch the global config it sees, but it's a different one than the explicitly installed package.

Closes #237