### PR TITLE
chore: bump client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3987,9 +3987,9 @@
             "link": true
         },
         "node_modules/apify-client": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.9.0.tgz",
-            "integrity": "sha512-QyTyDjGXQV5Aey3Jbs5pxDIaJmzTSkByYGf6JambHkKHuO/qR+3zXH6ENABzcleeGAkc73PCg24F3nYFXqhNHw==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.9.4.tgz",
+            "integrity": "sha512-Cot4fXspaTVne2CHIQoMNePGUxeMPGQkSRSWOSnQwycbfyFJJ73gdgTlyh5PhmwVz9EXmwp9xw2wgSKeULZHUg==",
             "dependencies": {
                 "@apify/consts": "^2.25.0",
                 "@apify/log": "^2.2.6",
@@ -17095,7 +17095,7 @@
                 "@crawlee/core": "^3.9.0",
                 "@crawlee/types": "^3.9.0",
                 "@crawlee/utils": "^3.9.0",
-                "apify-client": "^2.9.0",
+                "apify-client": "^2.9.4",
                 "fs-extra": "^11.2.0",
                 "ow": "^0.28.2",
                 "semver": "^7.5.4",

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -62,7 +62,7 @@
         "@crawlee/core": "^3.9.0",
         "@crawlee/types": "^3.9.0",
         "@crawlee/utils": "^3.9.0",
-        "apify-client": "^2.9.0",
+        "apify-client": "^2.9.4",
         "fs-extra": "^11.2.0",
         "ow": "^0.28.2",
         "semver": "^7.5.4",


### PR DESCRIPTION
Following the latest [Apify client release](https://github.com/apify/apify-client-js/releases/tag/v2.9.4), we want to ensure we get the new [API error fields](https://github.com/apify/apify-client-js/commit/3b7c4b73607f40a74f31f39491025c63bc92e40e) via the SDK.
I don't know the details, this is mostly on @gippy 's request. 

It also made me realize that I made a small semver mistake with the latest Apify client release (there are new "features"(?), it should have probably been a `minor` version). Do we want to address this somehow?