### PR TITLE
fix: add `standbyPort` to `ConfigurationOptions`

### DIFF
--- a/packages/apify/src/configuration.ts
+++ b/packages/apify/src/configuration.ts
@@ -21,6 +21,7 @@ export interface ConfigurationOptions extends CoreConfigurationOptions {
     proxyPassword?: string;
     proxyPort?: number;
     proxyStatusUrl?: string;
+    standbyPort?: number;
     isAtHome?: boolean;
     userId?: string;
     inputSecretsPrivateKeyPassphrase?: string;


### PR DESCRIPTION
This PR adds the `standbyPort` to `ConfigurationOptions` so that calling `get` with it won't fail with a TS error.