### PR TITLE
docs: bump `@apify/docusaurus-plugin-typedoc-api`

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@apify/docs-theme": "^1.0.131",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.2.5",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
                 "@docusaurus/core": "^3.5.2",
                 "@docusaurus/plugin-client-redirects": "^3.5.2",
                 "@docusaurus/preset-classic": "^3.5.2",

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.131",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.5",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/plugin-client-redirects": "^3.5.2",
         "@docusaurus/preset-classic": "^3.5.2",


### PR DESCRIPTION
Solves https://github.com/apify/apify-client-js/issues/591 in SDK documentation. Merges new features from upstream `docusaurus-plugin-typedoc-api`.