### PR TITLE
fix: remove zwsp characters from markdown docs

### DIFF
--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -103,7 +103,7 @@ When you use only what you need, you'll be rewarded with reasonable build and st
 
 This is the smallest image we have based on Alpine Linux. It does not include any browsers, and it's therefore best used with <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink>. It benefits from lightning fast builds and container startups.
 
-&#8203;<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
+<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
 FROM apify/actor-node:16

--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -80,7 +80,7 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-&#8203;<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
+<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
 

--- a/docs/guides/session_management.mdx
+++ b/docs/guides/session_management.mdx
@@ -6,7 +6,7 @@ title: Session Management
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
 
-&#8203;<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.

--- a/website/versioned_docs/version-3.0/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.0/guides/docker_images.mdx
@@ -103,7 +103,7 @@ When you use only what you need, you'll be rewarded with reasonable build and st
 
 This is the smallest image we have based on Alpine Linux. It does not include any browsers, and it's therefore best used with <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink>. It benefits from lightning fast builds and container startups.
 
-&#8203;<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
+<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
 FROM apify/actor-node:16

--- a/website/versioned_docs/version-3.0/guides/proxy_management.mdx
+++ b/website/versioned_docs/version-3.0/guides/proxy_management.mdx
@@ -80,7 +80,7 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-&#8203;<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
+<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
 

--- a/website/versioned_docs/version-3.0/guides/session_management.mdx
+++ b/website/versioned_docs/version-3.0/guides/session_management.mdx
@@ -6,7 +6,7 @@ title: Session Management
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
 
-&#8203;<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.

--- a/website/versioned_docs/version-3.1/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.1/guides/docker_images.mdx
@@ -103,7 +103,7 @@ When you use only what you need, you'll be rewarded with reasonable build and st
 
 This is the smallest image we have based on Alpine Linux. It does not include any browsers, and it's therefore best used with <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink>. It benefits from lightning fast builds and container startups.
 
-&#8203;<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
+<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
 FROM apify/actor-node:16

--- a/website/versioned_docs/version-3.1/guides/proxy_management.mdx
+++ b/website/versioned_docs/version-3.1/guides/proxy_management.mdx
@@ -80,7 +80,7 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-&#8203;<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
+<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
 

--- a/website/versioned_docs/version-3.1/guides/session_management.mdx
+++ b/website/versioned_docs/version-3.1/guides/session_management.mdx
@@ -6,7 +6,7 @@ title: Session Management
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
 
-&#8203;<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your Actor does not retry requests over known blocked/non-working proxies.

--- a/website/versioned_docs/version-3.2/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.2/guides/docker_images.mdx
@@ -103,7 +103,7 @@ When you use only what you need, you'll be rewarded with reasonable build and st
 
 This is the smallest image we have based on Alpine Linux. It does not include any browsers, and it's therefore best used with <CrawleeApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</CrawleeApiLink>. It benefits from lightning fast builds and container startups.
 
-&#8203;<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
+<CrawleeApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</CrawleeApiLink>, <CrawleeApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</CrawleeApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
 FROM apify/actor-node:16

--- a/website/versioned_docs/version-3.2/guides/proxy_management.mdx
+++ b/website/versioned_docs/version-3.2/guides/proxy_management.mdx
@@ -80,7 +80,7 @@ Your crawlers will now use the selected proxies for all connections.
 
 ### IP Rotation and session management
 
-&#8203;<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
+<ApiLink to="apify/class/ProxyConfiguration#newUrl">`proxyConfiguration.newUrl()`</ApiLink> allows you to pass a `sessionId` parameter. It will then be used to create a `sessionId`-`proxyUrl` pair, and subsequent `newUrl()` calls with the same `sessionId` will always return the same `proxyUrl`. This is extremely useful in scraping, because you want to create the impression of a real user. See the [session management guide](../guides/session-management) and <CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> class for more information on how keeping a real session helps you avoid blocking.
 
 When no `sessionId` is provided, your proxy URLs are rotated round-robin, whereas Apify Proxy manages their rotation using black magic to get the best performance.
 

--- a/website/versioned_docs/version-3.2/guides/session_management.mdx
+++ b/website/versioned_docs/version-3.2/guides/session_management.mdx
@@ -6,7 +6,7 @@ title: Session Management
 import ApiLink from '@site/src/components/ApiLink';
 import { CrawleeApiLink } from '@site/src/components/CrawleeLinks';
 
-&#8203;<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
+<CrawleeApiLink to="core/class/SessionPool">`SessionPool`</CrawleeApiLink> is a class that allows you to handle the rotation of proxy IP addresses along with cookies and other custom settings in Apify SDK.
 
 The main benefit of a Session pool is that you can filter out blocked or non-working proxies,
 so your actor does not retry requests over known blocked/non-working proxies.


### PR DESCRIPTION
Removes unnecessary `zero-width space` characters from the `mdx` files. The source of those is unclear - git blame says that they have been there since > 2 years ago. The on-page rendering remains the same with or without those characters.

Closes https://github.com/apify/apify-docs/issues/1262