### PR TITLE
feat: add SDK and Crawlee version to the `ApifyClient`'s user agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3986,9 +3986,9 @@
             "link": true
         },
         "node_modules/apify-client": {
-            "version": "2.9.7",
-            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.9.7.tgz",
-            "integrity": "sha512-bI7sRCIlyt9M1qv2N0tCIui/jVQqf5FG6pZIfAUZrfWmHuE15QHp92kSjBK5aL+Iv5FDZ4zoondrCZNQSYFB/w==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.10.0.tgz",
+            "integrity": "sha512-ykprsM0VjM8xAFnS1Tqv8tOUPl43TINaxm3nVdSxBlXDcPDQ6pS4ztv084me5LOeccMxm79GjU9k7nj4cEgppw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/consts": "^2.25.0",
@@ -18425,7 +18425,7 @@
                 "@crawlee/core": "^3.9.0",
                 "@crawlee/types": "^3.9.0",
                 "@crawlee/utils": "^3.9.0",
-                "apify-client": "^2.9.0",
+                "apify-client": "^2.10.0",
                 "fs-extra": "^11.2.0",
                 "ow": "^0.28.2",
                 "semver": "^7.5.4",

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -62,7 +62,7 @@
         "@crawlee/core": "^3.9.0",
         "@crawlee/types": "^3.9.0",
         "@crawlee/utils": "^3.9.0",
-        "apify-client": "^2.9.0",
+        "apify-client": "^2.10.0",
         "fs-extra": "^11.2.0",
         "ow": "^0.28.2",
         "semver": "^7.5.4",

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -41,7 +41,7 @@ import { KeyValueStore } from './key_value_store';
 import { PlatformEventManager } from './platform_event_manager';
 import type { ProxyConfigurationOptions } from './proxy_configuration';
 import { ProxyConfiguration } from './proxy_configuration';
-import { checkCrawleeVersion, logSystemInfo, printOutdatedSdkWarning } from './utils';
+import { checkCrawleeVersion, getSystemInfo, printOutdatedSdkWarning } from './utils';
 
 /**
  * `Actor` class serves as an alternative approach to the static helpers exported from the package. It allows to pass configuration
@@ -191,7 +191,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         this.initialized = true;
 
         checkCrawleeVersion();
-        logSystemInfo();
+        log.info('System info', getSystemInfo());
         printOutdatedSdkWarning();
 
         // reset global config instance to respect APIFY_ prefixed env vars
@@ -938,9 +938,11 @@ export class Actor<Data extends Dictionary = Dictionary> {
      */
     newClient(options: ApifyClientOptions = {}): ApifyClient {
         const { storageDir, ...storageClientOptions } = this.config.get('storageClientOptions') as Dictionary;
+        const { apifyVersion, crawleeVersion } = getSystemInfo();
         return new ApifyClient({
             baseUrl: this.config.get('apiBaseUrl'),
             token: this.config.get('token'),
+            userAgentSuffix: [`SDK/${apifyVersion}`, `Crawlee/${crawleeVersion}`],
             ...storageClientOptions,
             ...options, // allow overriding the instance configuration
         });

--- a/packages/apify/src/utils.ts
+++ b/packages/apify/src/utils.ts
@@ -14,21 +14,20 @@ import semver from 'semver';
 import { version as apifyVersion } from '../package.json';
 
 /**
- * Logs info about system, node version and apify package version.
+ * Gets info about system, node version and apify package version.
  * @internal
  */
-export function logSystemInfo() {
-    log.info('System info', {
+export function getSystemInfo() {
+    return {
         apifyVersion,
         apifyClientVersion,
         crawleeVersion,
         osType: type(),
         nodeVersion: process.version,
-    });
+    };
 }
 
 /**
- * Logs info about system, node version and apify package version.
  * @internal
  */
 export function checkCrawleeVersion() {


### PR DESCRIPTION
The support for this was added in client v2.10 (https://github.com/apify/apify-client-js/pull/602/files#diff-c33bae26ce4a7b3559aef1321052b4e22c099a786ae6d660d9409bee032c7fa8R44), user agent looks like this:

```
ApifyClient/2.9.8 (Darwin; Node/v22.11.0); isAtHome/false; SDK/3.1.1; Crawlee/3.11.5
```

Closes #331