### PR TITLE
fix: load `initialCount` in `openRequestQueue()`

### DIFF
--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -818,7 +818,12 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
         this._ensureActorInit('openRequestQueue');
 
-        return this._openStorage(RequestQueue, queueIdOrName, options);
+        const queue = await this._openStorage(RequestQueue, queueIdOrName, options);
+
+        // eslint-disable-next-line dot-notation
+        queue['initialCount'] = (await queue.client.get())?.totalRequestCount ?? 0;
+
+        return queue;
     }
 
     /**

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -604,10 +604,15 @@ describe('Actor', () => {
                 const queueId = 'abc';
                 const options = { forceCloud: true };
                 const openStorageSpy = vitest.spyOn(StorageManager.prototype, 'openStorage');
-                openStorageSpy.mockImplementationOnce(async (i) => i);
-                await sdk.openRequestQueue(queueId, options);
+
+                const mockRQ = { client: { get: () => ({ totalRequestCount: 10 }) } };
+
+                openStorageSpy.mockImplementationOnce(async () => mockRQ);
+                const queue = await sdk.openRequestQueue(queueId, options);
                 expect(openStorageSpy).toBeCalledWith(queueId, sdk.apifyClient);
                 expect(openStorageSpy).toBeCalledTimes(1);
+
+                expect(queue.initialCount).toBe(10);
             });
 
             test('openDataset should open storage', async () => {


### PR DESCRIPTION
Ports the property injection from [Crawlee's `RequestQueue.open()`](https://github.com/apify/crawlee/blob/1e59f1b53176ec45ad42dbc8590d9f3626debacb/packages/core/src/storages/request_provider.ts#L835).

Closes #337 