### PR TITLE
fix: Add workaround for incorrect handling of maxTotalChargeUsd

### DIFF
--- a/packages/apify/src/charging.ts
+++ b/packages/apify/src/charging.ts
@@ -28,7 +28,7 @@ export class ChargingManager {
     constructor(configuration: Configuration, apifyClient: ApifyClient) {
         this.maxTotalChargeUsd = configuration.get('maxTotalChargeUsd') ?? Infinity;
         if (typeof this.maxTotalChargeUsd === 'string') { // TODO workaround for incorrect Configuration class behavior
-            this.maxTotalChargeUsd = Infinity; 
+            this.maxTotalChargeUsd = Infinity;
         }
         this.isAtHome = configuration.get('isAtHome');
         this.actorRunId = configuration.get('actorRunId');

--- a/packages/apify/src/charging.ts
+++ b/packages/apify/src/charging.ts
@@ -27,6 +27,9 @@ export class ChargingManager {
 
     constructor(configuration: Configuration, apifyClient: ApifyClient) {
         this.maxTotalChargeUsd = configuration.get('maxTotalChargeUsd') ?? Infinity;
+        if (typeof this.maxTotalChargeUsd === 'string') { // TODO workaround for incorrect Configuration class behavior
+            this.maxTotalChargeUsd = Infinity; 
+        }
         this.isAtHome = configuration.get('isAtHome');
         this.actorRunId = configuration.get('actorRunId');
         this.purgeChargingLogDataset = configuration.get('purgeOnStart');


### PR DESCRIPTION
`Configuration.get('maxTotalChargeUsd')` seems to return an empty string in some platform runs - this is a workaround for that.
