### PR TITLE
fix: ensure `maxTotalChargeUsd` is correctly mapped to number, consider empty string as infinity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3948,9 +3948,9 @@
             "link": true
         },
         "node_modules/apify-client": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.11.1.tgz",
-            "integrity": "sha512-AqX5njCZv9jcPNXJqIi4KG/XBmLbTwR2wYQRBVLwDva1vhijPR22/lDcNUqYEZqj3Dc8a1xtMC3UScro0GkVeg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.12.0.tgz",
+            "integrity": "sha512-h04rPVft8tNjnwZswqF2k46bdHZWsDsfOE8PkmklZ9+/s/mb/Q/dMOXCx0u2+RTc8QoAkYS9LYs97wZyUWpoag==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/consts": "^2.25.0",
@@ -18412,7 +18412,7 @@
                 "@crawlee/core": "^3.9.0",
                 "@crawlee/types": "^3.9.0",
                 "@crawlee/utils": "^3.9.0",
-                "apify-client": "^2.11.1",
+                "apify-client": "^2.12.0",
                 "fs-extra": "^11.2.0",
                 "ow": "^0.28.2",
                 "semver": "^7.5.4",

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -62,7 +62,7 @@
         "@crawlee/core": "^3.9.0",
         "@crawlee/types": "^3.9.0",
         "@crawlee/utils": "^3.9.0",
-        "apify-client": "^2.11.1",
+        "apify-client": "^2.12.0",
         "fs-extra": "^11.2.0",
         "ow": "^0.28.2",
         "semver": "^7.5.4",

--- a/packages/apify/src/charging.ts
+++ b/packages/apify/src/charging.ts
@@ -26,10 +26,7 @@ export class ChargingManager {
     private apifyClient: ApifyClient;
 
     constructor(configuration: Configuration, apifyClient: ApifyClient) {
-        this.maxTotalChargeUsd = configuration.get('maxTotalChargeUsd') ?? Infinity;
-        if (typeof this.maxTotalChargeUsd === 'string') { // TODO workaround for incorrect Configuration class behavior
-            this.maxTotalChargeUsd = Infinity;
-        }
+        this.maxTotalChargeUsd = configuration.get('maxTotalChargeUsd') || Infinity; // convert `0` to `Infinity` in case the value is an empty string
         this.isAtHome = configuration.get('isAtHome');
         this.actorRunId = configuration.get('actorRunId');
         this.purgeChargingLogDataset = configuration.get('purgeOnStart');

--- a/packages/apify/src/configuration.ts
+++ b/packages/apify/src/configuration.ts
@@ -172,7 +172,7 @@ export class Configuration extends CoreConfiguration {
         ACTOR_USE_CHARGING_LOG_DATASET: 'useChargingLogDataset',
     };
 
-    protected static override INTEGER_VARS = [...super.INTEGER_VARS, 'proxyPort', 'containerPort', 'metamorphAfterSleepMillis'];
+    protected static override INTEGER_VARS = [...super.INTEGER_VARS, 'proxyPort', 'containerPort', 'metamorphAfterSleepMillis', 'maxTotalChargeUsd'];
 
     protected static override BOOLEAN_VARS = [...super.BOOLEAN_VARS, 'isAtHome', 'testPayPerEvent', 'useChargingLogDataset'];
 

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -612,6 +612,7 @@ describe('Actor', () => {
                 expect(openStorageSpy).toBeCalledWith(queueId, sdk.apifyClient);
                 expect(openStorageSpy).toBeCalledTimes(1);
 
+                // @ts-expect-error private prop
                 expect(queue.initialCount).toBe(10);
             });
 
@@ -1028,6 +1029,20 @@ describe('Actor', () => {
             await Actor.pushData({ hello: 'apify' });
 
             expect(pushDataSpy).toHaveBeenCalledWith({ hello: 'apify' });
+        });
+    });
+
+    describe('Actor.config and PPE', () => {
+        test('should work', async () => {
+            await Actor.init();
+            process.env.ACTOR_MAX_TOTAL_CHARGE_USD = '';
+            expect(Actor.config.get('maxTotalChargeUsd')).toBe(0);
+            expect(Actor.getChargingManager().getMaxTotalChargeUsd()).toBe(Infinity);
+
+            // the value in charging manager is cached, so we cant test that here
+            process.env.ACTOR_MAX_TOTAL_CHARGE_USD = '123';
+            expect(Actor.config.get('maxTotalChargeUsd')).toBe(123);
+            await Actor.exit({ exit: false });
         });
     });
 });


### PR DESCRIPTION
The `ACTOR_MAX_TOTAL_CHARGE_USD` env var wasnt properly marked as integer, and the fallback to infinity wasn't working in case the value was an empty string, since `??` fallbacks only for null/undefined values.