### PR TITLE
feat: add Camoufox-based generic Actor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,6 +1480,13 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@gar/promisify": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+            "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2173,6 +2180,84 @@
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@npmcli/move-file": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+            "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+            "deprecated": "This functionality has been moved to @npmcli/fs",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "mkdirp": "^1.0.4",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@npmcli/move-file/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@npmcli/move-file/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/move-file/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@npmcli/move-file/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@npmcli/name-from-folder": {
@@ -3197,6 +3282,16 @@
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "license": "MIT"
         },
+        "node_modules/@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -3326,6 +3421,16 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.8"
+            }
+        },
+        "node_modules/@types/node-fetch": {
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "form-data": "^4.0.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -3798,6 +3903,10 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/actor-camoufox-scraper": {
+            "resolved": "packages/actor-scraper/camoufox-scraper",
+            "link": true
+        },
         "node_modules/actor-cheerio-scraper": {
             "resolved": "packages/actor-scraper/cheerio-scraper",
             "link": true
@@ -3859,7 +3968,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "clean-stack": "^2.0.0",
@@ -3969,8 +4078,23 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
             "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
+        },
+        "node_modules/are-we-there-yet": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+            "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -4411,6 +4535,15 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -4667,6 +4800,50 @@
                 "node": ">=8"
             }
         },
+        "node_modules/camoufox-js": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/camoufox-js/-/camoufox-js-0.1.3.tgz",
+            "integrity": "sha512-5fkaIBUuP0jx/1bDgNNFnydZyZ56O71NgQdPtbXf/jW4xvKmJfgV2Lm8YevJJV46SpB606NNq1gRpfo++a50Dg==",
+            "license": "ISC",
+            "dependencies": {
+                "adm-zip": "^0.5.16",
+                "commander": "^13.1.0",
+                "fingerprint-generator": "^2.1.62",
+                "impit": "^0.2.1",
+                "js-yaml": "^4.1.0",
+                "language-tags": "^2.0.1",
+                "maxmind": "^4.3.24",
+                "playwright": "^1.50.1",
+                "progress": "^2.0.3",
+                "sqlite3": "^5.1.7",
+                "ua-parser-js": "^2.0.2",
+                "xml2js": "^0.6.2"
+            },
+            "bin": {
+                "camoufox-js": "dist/__main__.js"
+            }
+        },
+        "node_modules/camoufox-js/node_modules/commander": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/camoufox-js/node_modules/language-tags": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-2.0.1.tgz",
+            "integrity": "sha512-SzHyV6XDLTS7TSQipSaywM+QOB9PqiNhd/nWPgVwzpZqfeoIMee+Avj4F82QP6m/hMtIvUCS8UEFIlBV5vq7Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "language-subtag-registry": "^0.3.20"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001684",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
@@ -4794,7 +4971,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
             "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -4833,7 +5009,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5058,7 +5234,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "bin": {
                 "color-support": "bin.js"
@@ -5146,7 +5322,7 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/concat-stream": {
@@ -5176,7 +5352,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/content-type": {
@@ -6609,6 +6785,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6716,12 +6901,39 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/deprecation": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
             "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/detect-europe-js": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+            "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/faisalman"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/detect-indent": {
             "version": "5.0.0",
@@ -6731,6 +6943,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/detect-node": {
@@ -6936,7 +7157,6 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -7030,7 +7250,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
             "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/error-ex": {
@@ -8075,6 +8295,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/expect-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
@@ -8301,6 +8530,12 @@
                 "url": "https://github.com/sindresorhus/file-type?sponsor=1"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "license": "MIT"
+        },
         "node_modules/filelist": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -8356,13 +8591,13 @@
             }
         },
         "node_modules/fingerprint-generator": {
-            "version": "2.1.57",
-            "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.57.tgz",
-            "integrity": "sha512-KDpFexkGywR9pWsx/XnzzB5BKeyfdC6pA16mCj5WalwxBmKciIXuqJwSq9LHN/DFLxmnPgDMDWKUw7SEc/j8xQ==",
+            "version": "2.1.62",
+            "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.62.tgz",
+            "integrity": "sha512-Bhx2Cxm0l2xYhO1KAPs9orozlONdQzm6qC+UrLk7Np3TjMS8OuHNK6LQOGIuCZnAoP3ZMLl85WaCqI2nH5m01w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "generative-bayesian-network": "^2.1.57",
-                "header-generator": "^2.1.57",
+                "generative-bayesian-network": "^2.1.62",
+                "header-generator": "^2.1.62",
                 "tslib": "^2.4.0"
             },
             "engines": {
@@ -8623,7 +8858,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fs-extra": {
@@ -8657,7 +8891,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/fsevents": {
@@ -8712,6 +8946,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/gauge": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+            "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/gen-esm-wrapper": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/gen-esm-wrapper/-/gen-esm-wrapper-1.1.3.tgz",
@@ -8726,9 +8981,9 @@
             }
         },
         "node_modules/generative-bayesian-network": {
-            "version": "2.1.57",
-            "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.57.tgz",
-            "integrity": "sha512-o6UqR+j/oQnG5imsdaYwSqcVVWLuVBjYI3jE+z+aRZ6RqAFnHPK3uV+y4HEOnCokbFhgq9x+TKcBMAoKagT9TQ==",
+            "version": "2.1.62",
+            "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.62.tgz",
+            "integrity": "sha512-+zq1/AHdxb+0MXF34krM/IUu/N9gI6llzQg2gf7WMfuzh0nv6xbhb8QyfL48MOJihum7wSE90+/hMXK60X+Kpw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "adm-zip": "^0.5.9",
@@ -9308,6 +9563,12 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
+        },
         "node_modules/glob": {
             "version": "10.4.5",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -9709,7 +9970,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/hasown": {
@@ -9725,13 +9986,13 @@
             }
         },
         "node_modules/header-generator": {
-            "version": "2.1.57",
-            "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.57.tgz",
-            "integrity": "sha512-QmFzEd5fw1PrLztvJT7JBtNRt7MYskE8basiAjxGX5MNcS//JaiNsMyk7b12IJG7yppO5pJzg3zAa0UFfcNIvA==",
+            "version": "2.1.62",
+            "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.62.tgz",
+            "integrity": "sha512-L4y1Fush4bkC/3zEurWjiwzeuekAH3HMYA508EZDmvk1wPmcbpV/mq3u3d3fxq7v4oPmaCfsRm1T5DUH19uikA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "browserslist": "^4.21.1",
-                "generative-bayesian-network": "^2.1.57",
+                "generative-bayesian-network": "^2.1.62",
                 "ow": "^0.28.1",
                 "tslib": "^2.4.0"
             },
@@ -9963,6 +10224,119 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/impit": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit/-/impit-0.2.5.tgz",
+            "integrity": "sha512-zi+It+ky5ER1M0TkO0a6n4cV2s6kDtbfbfY0k/nVeTYkauwdDyk1Gdve2vwV1wkXSMwAtAt56yHI/hI1lWZbQw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "optionalDependencies": {
+                "impit-darwin-arm64": "0.2.5",
+                "impit-darwin-x64": "0.2.5",
+                "impit-linux-x64-gnu": "0.2.5",
+                "impit-linux-x64-musl": "0.2.5",
+                "impit-win32-arm64-msvc": "0.2.5",
+                "impit-win32-x64-msvc": "0.2.5"
+            }
+        },
+        "node_modules/impit-darwin-arm64": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.2.5.tgz",
+            "integrity": "sha512-QictYPl+K3vtQzORod8JWZKBUSZRmAcw07bGyf49rTOCouKGOT57bzDl/MZB7B461XjGPiIaB/lS36u449obKA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/impit-darwin-x64": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.2.5.tgz",
+            "integrity": "sha512-5OaIPbzPG//f4ZhTjZ8SAfMdTvvUZ6zl3csOX4ND/7d3aNci9AqYrj0rpKf3LovBmJPwwdTNh8w6KedeboBWCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/impit-linux-x64-gnu": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.2.5.tgz",
+            "integrity": "sha512-fyqYPK/iSpGC8Iz7JhE7IWVqtVhqJnGQ6P6az1i/Q/01KiYae4zosNn326DVUQ/zgPLaumHRwlPvuaaHEVyvmQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/impit-linux-x64-musl": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.2.5.tgz",
+            "integrity": "sha512-ypHUPbqkdRS1rYFCtxGkt+kkZ/sRQQcMQkWUbWr8LJPJdn8T0YuukwNr6xVcpA3GSlBXnOZ05H1Yiflv1Iyihg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/impit-win32-arm64-msvc": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.2.5.tgz",
+            "integrity": "sha512-h2mNhIxNVzHAidFJuVzWDLqqU3ty5JkoTi2g+dRBQKj91SUJDh41wySSd9vzJL1ZPLlRfC80mRIjZVxMX+1hew==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/impit-win32-x64-msvc": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.2.5.tgz",
+            "integrity": "sha512-9REm5Q26vK5Sbf/zDfBKEud7FuyfbRHisc3rCHf0dOza6iZUvb1aK73AvMi1wABz57At6lH9AETlNmKn7savTQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -10022,7 +10396,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -10032,18 +10406,25 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/infer-owner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -10426,7 +10807,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
             "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/is-map": {
@@ -10581,6 +10962,26 @@
             "dependencies": {
                 "protocols": "^2.0.1"
             }
+        },
+        "node_modules/is-standalone-pwa": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+            "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/faisalman"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "4.0.1",
@@ -10744,7 +11145,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -11168,7 +11569,6 @@
             "version": "0.3.23",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
             "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
-            "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/language-tags": {
@@ -12329,6 +12729,20 @@
             "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
         },
+        "node_modules/maxmind": {
+            "version": "4.3.24",
+            "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-4.3.24.tgz",
+            "integrity": "sha512-dexrLcjfS2xDGOvdV8XcfQYmyQVpGidMwEG2ld19lXlsB+i+lXRWPzQi81HfwRXR4hxzFr5gT0oAIFyqAAb/Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "mmdb-lib": "2.1.1",
+                "tiny-lru": "11.2.11"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
         "node_modules/meow": {
             "version": "12.1.1",
             "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -12457,7 +12871,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -12533,7 +12946,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
             "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -12546,7 +12959,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -12559,7 +12972,7 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
             "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -12572,7 +12985,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -12585,7 +12998,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
             "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -12598,7 +13011,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -12611,7 +13024,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
             "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^3.0.0",
@@ -12625,7 +13037,6 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -12644,7 +13055,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "mkdirp": "bin/cmd.js"
@@ -12652,6 +13062,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT"
         },
         "node_modules/ml-array-max": {
             "version": "1.2.4",
@@ -12699,6 +13115,16 @@
             "dependencies": {
                 "is-any-array": "^2.0.1",
                 "ml-array-rescale": "^1.3.7"
+            }
+        },
+        "node_modules/mmdb-lib": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-2.1.1.tgz",
+            "integrity": "sha512-yx8H/1H5AfnufiLnzzPqPf4yr/dKU9IFT1rPVwSkrKWHsQEeVVd6+X+L0nUbXhlEFTu3y/7hu38CFmEVgzvyeg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
             }
         },
         "node_modules/modify-values": {
@@ -12785,6 +13211,12 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT"
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -12796,7 +13228,7 @@
             "version": "0.6.4",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
             "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -12817,6 +13249,24 @@
             "engines": {
                 "node": ">= 0.4.0"
             }
+        },
+        "node_modules/node-abi": {
+            "version": "3.74.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
+            "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "license": "MIT"
         },
         "node_modules/node-fetch": {
             "version": "2.6.7",
@@ -13083,6 +13533,23 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/npmlog": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+            "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "are-we-there-yet": "^3.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^4.0.3",
+                "set-blocking": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/nth-check": {
@@ -13650,7 +14117,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
             "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "aggregate-error": "^3.0.0"
@@ -13952,7 +14419,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -14169,12 +14636,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-            "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+            "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.49.0"
+                "playwright-core": "1.50.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14190,6 +14657,19 @@
             "version": "1.49.0",
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
             "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/playwright-core": {
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+            "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -14249,6 +14729,75 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
+        },
+        "node_modules/prebuild-install/node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^6.0.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/tar-fs": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+            "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
             }
         },
         "node_modules/prelude-ls": {
@@ -14336,14 +14885,14 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
             "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "err-code": "^2.0.2",
@@ -14596,6 +15145,36 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/react-is": {
@@ -15368,7 +15947,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/set-function-length": {
@@ -15720,6 +16299,370 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/sqlite3": {
+            "version": "5.1.7",
+            "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+            "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "node-addon-api": "^7.0.0",
+                "prebuild-install": "^7.1.1",
+                "tar": "^6.1.11"
+            },
+            "optionalDependencies": {
+                "node-gyp": "8.x"
+            },
+            "peerDependencies": {
+                "node-gyp": "8.x"
+            },
+            "peerDependenciesMeta": {
+                "node-gyp": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/sqlite3/node_modules/@npmcli/fs": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+            "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "@gar/promisify": "^1.0.1",
+                "semver": "^7.3.5"
+            }
+        },
+        "node_modules/sqlite3/node_modules/abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "license": "ISC",
+            "optional": true
+        },
+        "node_modules/sqlite3/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/sqlite3/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/sqlite3/node_modules/cacache": {
+            "version": "15.3.0",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+            "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "@npmcli/fs": "^1.0.0",
+                "@npmcli/move-file": "^1.0.1",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "glob": "^7.1.4",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^6.0.0",
+                "minipass": "^3.1.1",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.2",
+                "mkdirp": "^1.0.3",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^8.0.1",
+                "tar": "^6.0.2",
+                "unique-filename": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/sqlite3/node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/sqlite3/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/sqlite3/node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/sqlite3/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/sqlite3/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/sqlite3/node_modules/make-fetch-happen": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+            "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "agentkeepalive": "^4.1.3",
+                "cacache": "^15.2.0",
+                "http-cache-semantics": "^4.1.0",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^6.0.0",
+                "minipass": "^3.1.3",
+                "minipass-collect": "^1.0.2",
+                "minipass-fetch": "^1.3.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.2",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^6.0.0",
+                "ssri": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/sqlite3/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/sqlite3/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/sqlite3/node_modules/minipass-collect": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+            "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/sqlite3/node_modules/minipass-fetch": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+            "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^3.1.0",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.12"
+            }
+        },
+        "node_modules/sqlite3/node_modules/node-gyp": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+            "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^9.1.0",
+                "nopt": "^5.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": ">= 10.12.0"
+            }
+        },
+        "node_modules/sqlite3/node_modules/nopt": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "abbrev": "1"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/sqlite3/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/sqlite3/node_modules/socks-proxy-agent": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+            "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^6.0.2",
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/sqlite3/node_modules/ssri": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+            "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^3.1.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/sqlite3/node_modules/unique-filename": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+            "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "unique-slug": "^2.0.0"
+            }
+        },
+        "node_modules/sqlite3/node_modules/unique-slug": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+            "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            }
         },
         "node_modules/ssri": {
             "version": "10.0.6",
@@ -16133,7 +17076,6 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
             "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -16176,7 +17118,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bl": "^4.0.3",
@@ -16193,7 +17134,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
             "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -16206,7 +17146,6 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -16219,7 +17158,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
             "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=8"
@@ -16316,6 +17254,15 @@
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/tiny-lru": {
+            "version": "11.2.11",
+            "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.2.11.tgz",
+            "integrity": "sha512-27BIW0dIWTYYoWNnqSmoNMKe5WIbkXsc0xaCQHd3/3xT2XMuMJrzHdrO9QBFR14emBz1Bu0dOAs2sCBBrvgPQA==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/tiny-typed-emitter": {
@@ -16598,6 +17545,18 @@
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/turbo": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.4.2.tgz",
@@ -16828,6 +17787,101 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/ua-is-frozen": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+            "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/faisalman"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/ua-parser-js": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.2.tgz",
+            "integrity": "sha512-NoaPjzMmuUlo5bJ2jrdkzvHL8gpcgVrhUugAqsqsundDO3R8rw7R0OwxLoWhcKtsTb+6u3z9dES8m6+vxEcJog==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/faisalman"
+                }
+            ],
+            "license": "AGPL-3.0-or-later",
+            "dependencies": {
+                "@types/node-fetch": "^2.6.12",
+                "detect-europe-js": "^0.1.2",
+                "is-standalone-pwa": "^0.1.1",
+                "node-fetch": "^2.7.0",
+                "ua-is-frozen": "^0.1.2"
+            },
+            "bin": {
+                "ua-parser-js": "script/cli.js"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/ua-parser-js/node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ua-parser-js/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
+        "node_modules/ua-parser-js/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/ua-parser-js/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/uglify-js": {
@@ -17756,7 +18810,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -17873,7 +18927,7 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
             "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
@@ -18112,6 +19166,28 @@
                 "node": ">=18"
             }
         },
+        "node_modules/xml2js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -18141,7 +19217,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
@@ -18300,6 +19375,27 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "packages/actor-scraper/camoufox-scraper": {
+            "name": "actor-camoufox-scraper",
+            "version": "3.1.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@apify/scraper-tools": "^1.1.4",
+                "@crawlee/core": "^3.11.5",
+                "@crawlee/playwright": "^3.11.5",
+                "@crawlee/utils": "^3.11.5",
+                "apify": "^3.2.6",
+                "camoufox-js": "^0.1.3",
+                "idcac-playwright": "^0.1.3",
+                "playwright": "*"
+            },
+            "devDependencies": {
+                "@apify/tsconfig": "^0.1.0",
+                "@types/node": "^22.7.4",
+                "tsx": "^4.19.1",
+                "typescript": "~5.7.0"
             }
         },
         "packages/actor-scraper/cheerio-scraper": {

--- a/packages/actor-scraper/camoufox-scraper/.actor/actor.json
+++ b/packages/actor-scraper/camoufox-scraper/.actor/actor.json
@@ -1,0 +1,6 @@
+{
+	"actorSpecification": 1,
+	"name": "camoufox-scraper",
+	"version": "0.1",
+	"buildTag": "latest"
+}

--- a/packages/actor-scraper/camoufox-scraper/.dockerignore
+++ b/packages/actor-scraper/camoufox-scraper/.dockerignore
@@ -1,0 +1,12 @@
+# configurations
+.idea
+
+# crawlee and apify storage folders
+apify_storage
+crawlee_storage
+storage
+dist
+!./storage/key_value_stores/default/INPUT.json
+
+# installed files
+node_modules

--- a/packages/actor-scraper/camoufox-scraper/Dockerfile
+++ b/packages/actor-scraper/camoufox-scraper/Dockerfile
@@ -1,0 +1,35 @@
+FROM apify/actor-node-playwright-firefox:20 AS builder
+
+COPY --chown=myuser package*.json ./
+
+RUN npm install --include=dev --audit=false
+
+COPY --chown=myuser . ./
+
+RUN npm run build
+
+FROM apify/actor-node-playwright-firefox:20
+
+COPY --from=builder --chown=myuser /home/myuser/dist ./dist
+
+COPY --chown=myuser package*.json ./
+
+RUN npm --quiet set progress=false \
+    && npm install --omit=dev \
+    && echo "Installed NPM packages:" \
+    && (npm list --omit=dev --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version \
+    && rm -r ~/.npm
+
+RUN npm run get-binaries
+
+COPY --chown=myuser . ./
+
+RUN rm -rf ./pw-browsers/
+
+ENV APIFY_DISABLE_OUTDATED_WARNING=1
+
+CMD ./start_xvfb_and_run_cmd.sh && npm run start:prod --silent

--- a/packages/actor-scraper/camoufox-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/camoufox-scraper/INPUT_SCHEMA.json
@@ -1,0 +1,339 @@
+{
+    "$schema": "https://raw.githubusercontent.com/apify/apify-shared-js/refs/heads/master/packages/input_schema/src/schema.json",
+    "title": "Camoufox Scraper Input",
+    "description": "Use the following form to configure Camoufox Scraper. The Start URLs and Page function are required and all other fields are optional. To learn more about the different options, click on their title or on the nearby question marks. For details about the Page function visit the Actor's README in the ACTOR INFO tab.",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "startUrls": {
+            "sectionCaption": "Basic configuration",
+            "title": "Start URLs",
+            "type": "array",
+            "description": "URLs to start with",
+            "prefill": [{ "url": "https://crawlee.dev" }],
+            "editor": "requestListSources"
+        },
+        "globs": {
+            "title": "Glob Patterns",
+            "type": "array",
+            "description": "Glob patterns to match links in the page that you want to enqueue. Combine with Link selector to tell the scraper where to find links. Omitting the Glob patterns will cause the scraper to enqueue all links matched by the Link selector.",
+            "editor": "globs",
+            "default": [],
+            "prefill": [{
+                "glob": "https://crawlee.dev/*/*"
+            }]
+        },
+        "pseudoUrls": {
+            "title": "Pseudo-URLs",
+            "type": "array",
+            "description": "Pseudo-URLs to match links in the page that you want to enqueue. Combine with Link selector to tell the scraper where to find links. Omitting the Pseudo-URLs will cause the scraper to enqueue all links matched by the Link selector.",
+            "editor": "pseudoUrls",
+            "default": [],
+            "prefill": []
+        },
+        "excludes": {
+            "title": "Exclude Glob Patterns",
+            "type": "array",
+            "description": "Glob patterns to match links in the page that you want to exclude from being enqueued.",
+            "editor": "globs",
+            "default": [],
+            "prefill": [{
+                "glob": "/**/*.{png,jpg,jpeg,pdf}"
+            }]
+        },
+        "linkSelector": {
+            "title": "Link selector",
+            "type": "string",
+            "description": "CSS selector matching elements with 'href' attributes that should be enqueued. To enqueue urls from <code><div class=\"my-class\" href=...></code> tags, you would enter <strong>div.my-class</strong>. Leave empty to ignore all links.",
+            "editor": "textfield",
+            "prefill": "a"
+        },
+        "keepUrlFragments": {
+            "title": "Keep URL fragments",
+            "type": "boolean",
+            "description": "URL fragments (the parts of URL after a <code>#</code>) are not considered when the scraper determines whether a URL has already been visited. This means that when adding URLs such as <code>https://example.com/#foo</code> and <code>https://example.com/#bar</code>, only the first will be visited. Turn this option on to tell the scraper to visit both.",
+            "default": false
+        },
+        "pageFunction": {
+            "title": "Page function",
+            "type": "string",
+            "description": "Function executed for each request",
+            "prefill": "async function pageFunction(context) {\n    const { page, request, log } = context;\n    const title = await page.title();\n    log.info(`URL: ${request.url} TITLE: ${title}`);\n    return {\n        url: request.url,\n        title\n    };\n}",
+            "editor": "javascript"
+        },
+        "proxyConfiguration": {
+            "sectionCaption": "Proxy configuration",
+            "title": "Proxy configuration",
+            "type": "object",
+            "description": "Specifies proxy servers that will be used by the scraper in order to hide its origin.<br><br>For details, see <a href='https://apify.com/apify/camoufox-scraper#proxy-configuration' target='_blank' rel='noopener'>Proxy configuration</a> in README.",
+            "prefill": { "useApifyProxy": true },
+            "default": { "useApifyProxy": true },
+            "editor": "proxy"
+        },
+        "proxyRotation": {
+            "title": "Proxy rotation",
+            "type": "string",
+            "description": "This property indicates the strategy of proxy rotation and can only be used in conjunction with Apify Proxy. The recommended setting automatically picks the best proxies from your available pool and rotates them evenly, discarding proxies that become blocked or unresponsive. If this strategy does not work for you for any reason, you may configure the scraper to either use a new proxy for each request, or to use one proxy as long as possible, until the proxy fails. IMPORTANT: This setting will only use your available Apify Proxy pool, so if you don't have enough proxies for a given task, no rotation setting will produce satisfactory results.",
+            "default": "RECOMMENDED",
+            "editor": "select",
+            "enum": [
+                "RECOMMENDED",
+                "PER_REQUEST",
+                "UNTIL_FAILURE"
+            ],
+            "enumTitles": [
+                "Use recommended settings",
+                "Rotate proxy after each request",
+                "Use one proxy until failure"
+            ]
+        },
+        "sessionPoolName": {
+            "title": "Session pool name",
+            "type": "string",
+            "description": "<b>Use only english alphanumeric characters dashes and underscores.</b> A session is a representation of a user. It has it's own IP and cookies which are then used together to emulate a real user. Usage of the sessions is controlled by the Proxy rotation option. By providing a session pool name, you enable sharing of those sessions across multiple Actor runs. This is very useful when you need specific cookies for accessing the websites or when a lot of your proxies are already blocked. Instead of trying randomly, a list of working sessions will be saved and a new Actor run can reuse those sessions. Note that the IP lock on sessions expires after 24 hours, unless the session is used again in that window.",
+            "editor": "textfield",
+            "minLength": 3,
+            "maxLength": 200,
+            "pattern": "[0-9A-z-]"
+        },
+        "initialCookies": {
+            "title": "Initial cookies",
+            "type": "array",
+            "description": "The provided cookies will be pre-set to all pages the scraper opens.",
+            "default": [],
+            "prefill": [],
+            "editor": "json"
+        },
+        "headless": {
+            "title": "Run browsers in headless mode",
+            "type": "boolean",
+            "description": "By default, browsers run in headless mode. You can toggle this off to run them in headful mode, which can help with certain rare anti-scraping protections but is slower and more costly.",
+            "default": true
+        },
+        "ignoreSslErrors": {
+            "title": "Ignore SSL errors",
+            "type": "boolean",
+            "description": "Scraper will ignore SSL certificate errors.",
+            "default": false,
+            "groupCaption": "Security",
+            "groupDescription": "Various options that help you disable browser security features such as HTTPS certificates and CORS."
+        },
+        "downloadMedia": {
+            "sectionCaption": "Performance and limits",
+            "title": "Download media",
+            "type": "boolean",
+            "description": "Scraper will download media such as images, fonts, videos and sounds. Disabling this may speed up the scrape, but certain websites could stop working correctly.",
+            "default": true,
+            "groupCaption": "Resources",
+            "groupDescription": "Settings that help to disable downloading web page resources."
+        },
+        "maxRequestRetries": {
+            "title": "Max request retries",
+            "type": "integer",
+            "description": "Maximum number of times the request for the page will be retried in case of an error. Setting it to 0 means that the request will be attempted once and will not be retried if it fails.",
+            "minimum": 0,
+            "default": 3,
+            "unit": "retries"
+        },
+        "maxPagesPerCrawl": {
+            "title": "Max pages per run",
+            "type": "integer",
+            "description": "Maximum number of pages that the scraper will open. 0 means unlimited.",
+            "minimum": 0,
+            "default": 0,
+            "unit": "pages"
+        },
+        "maxResultsPerCrawl": {
+            "title": "Max result records",
+            "type": "integer",
+            "description": "Maximum number of results that will be saved to dataset. The scraper will terminate afterwards. 0 means unlimited.",
+            "minimum": 0,
+            "default": 0,
+            "unit": "results"
+        },
+        "maxCrawlingDepth": {
+            "title": "Max crawling depth",
+            "type": "integer",
+            "description": "Defines how many links away from the StartURLs will the scraper descend. 0 means unlimited.",
+            "minimum": 0,
+            "default": 0
+        },
+        "maxConcurrency": {
+            "title": "Max concurrency",
+            "type": "integer",
+            "description": "Defines how many pages can be processed by the scraper in parallel. The scraper automatically increases and decreases concurrency based on available system resources. Use this option to set a hard limit.",
+            "minimum": 1,
+            "default": 50
+        },
+        "pageLoadTimeoutSecs": {
+            "title": "Page load timeout",
+            "type": "integer",
+            "description": "Maximum time the scraper will allow a web page to load in seconds.",
+            "minimum": 1,
+            "default": 60,
+            "unit": "secs"
+        },
+        "pageFunctionTimeoutSecs": {
+            "title": "Page function timeout",
+            "type": "integer",
+            "description": "Maximum time the scraper will wait for the page function to execute in seconds.",
+            "minimum": 1,
+            "default": 60,
+            "unit": "secs"
+        },
+        "waitUntil": {
+            "title": "Navigation wait until",
+            "description": "The scraper will wait until the selected events are triggered in the page before executing the page function. Available events are <code>domcontentloaded</code>, <code>load</code> and <code>networkidle</code> <a href=\"https://playwright.dev/docs/api/class-page#page-goto-option-wait-until\" target=\"_blank\">See Playwright docs</a>.",
+            "type": "string",
+            "editor": "select",
+            "enum": [
+                "networkidle",
+                "load",
+                "domcontentloaded"
+            ],
+            "prefill": "networkidle",
+            "default": "networkidle"
+        },
+        "preNavigationHooks": {
+            "sectionCaption": "Advanced configuration",
+            "title": "Pre-navigation hooks",
+            "type": "string",
+            "description": "Async functions that are sequentially evaluated before the navigation. Good for setting additional cookies or browser properties before navigation. The function accepts two parameters, `crawlingContext` and `gotoOptions`, which are passed to the `page.goto()` function the crawler calls to navigate.",
+            "prefill": "// We need to return array of (possibly async) functions here.\n// The functions accept two arguments: the \"crawlingContext\" object\n// and \"gotoOptions\".\n[\n    async (crawlingContext, gotoOptions) => {\n        const { page } = crawlingContext;\n        // ...\n    },\n]",
+            "editor": "javascript"
+        },
+        "postNavigationHooks": {
+            "title": "Post-navigation hooks",
+            "type": "string",
+            "description": "Async functions that are sequentially evaluated after the navigation. Good for checking if the navigation was successful. The function accepts `crawlingContext` as the only parameter.",
+            "prefill": "// We need to return array of (possibly async) functions here.\n// The functions accept a single argument: the \"crawlingContext\" object.\n[\n    async (crawlingContext) => {\n        const { page } = crawlingContext;\n        // ...\n    },\n]",
+            "editor": "javascript"
+        },
+        "closeCookieModals": {
+            "title": "Dismiss cookie modals",
+            "type": "boolean",
+            "description": "Using the [I don't care about cookies](https://addons.mozilla.org/en-US/firefox/addon/i-dont-care-about-cookies/) browser extension. When on, the crawler will automatically try to dismiss cookie consent modals. This can be useful when crawling European websites that show cookie consent modals.",
+            "default": false
+        },
+        "maxScrollHeightPixels": {
+            "title": "Maximum scrolling distance in pixels",
+            "type": "integer",
+            "description": "The crawler will scroll down the page until all content is loaded or the maximum scrolling distance is reached. Setting this to `0` disables scrolling altogether.",
+            "default": 5000
+        },
+        "debugLog": {
+            "title": "Debug log",
+            "type": "boolean",
+            "description": "Debug messages will be included in the log. Use <code>context.log.debug('message')</code> to log your own debug messages.",
+            "default": false,
+            "groupCaption": "Enable logs",
+            "groupDescription": "Logs settings"
+        },
+        "browserLog": {
+            "title": "Browser log",
+            "type": "boolean",
+            "description": "Console messages from the Browser will be included in the log. This may result in the log being flooded by error messages, warnings and other messages of little value, especially with high concurrency.",
+            "default": false
+        },
+        "customData": {
+            "title": "Custom data",
+            "type": "object",
+            "description": "This object will be available on pageFunction's context as customData.",
+            "default": {},
+            "prefill": {},
+            "editor": "json"
+        },
+        "datasetName": {
+            "title": "Dataset name",
+            "type": "string",
+            "description": "Name or ID of the dataset that will be used for storing results. If left empty, the default dataset of the run will be used.",
+            "editor": "textfield"
+        },
+        "keyValueStoreName": {
+            "title": "Key-value store name",
+            "type": "string",
+            "description": "Name or ID of the key-value store that will be used for storing records. If left empty, the default key-value store of the run will be used.",
+            "editor": "textfield"
+        },
+        "requestQueueName": {
+            "title": "Request queue name",
+            "type": "string",
+            "description": "Name of the request queue that will be used for storing requests. If left empty, the default request queue of the run will be used.",
+            "editor": "textfield"
+        },
+        "os": {
+            "sectionCaption": "Camoufox config",
+            "title": "Emulated operating system",
+            "type": "array",
+            "description": "Operating system to use for the fingerprint generation. Can be 'windows', 'macos', 'linux', or a list to randomly choose from.",
+            "editor": "select",
+            "items": {
+                "type": "string",
+                "enum": ["linux", "windows", "macos"],
+                "enumTitles": ["Linux", "Windows", "MacOS"]
+            }
+        },
+        "block_images": {
+            "title": "Block image loading",
+            "type": "boolean",
+            "description": "Blocks the image loading on the page. Saves bandwidth and speeds up the scraping, but might cause detection of the scraper.",
+            "default": false
+        },
+        "block_webrtc": {
+            "title": "Block WebRTC",
+            "type": "boolean",
+            "description": "Blocks WebRTC capabilities in Camoufox. Note that this might break some web applications.",
+            "default": false
+        },
+        "block_webgl": {
+            "title": "Block WebGL",
+            "type": "boolean",
+            "description": "Blocks WebGL capabilities in Camoufox. Note that this might break some websites."
+        },
+        "disable_coop": {
+            "title": "Disable Cross-Origin-Opener-Policy",
+            "type": "boolean",
+            "description": "Disables the Cross-Origin-Opener-Policy."
+        },
+        "geoip": {
+            "title": "GeoIP (⚠️ might not fully work with Apify Proxy ⚠️).",
+            "description": "Calculate geo-data based on IP address. Might not fully work with Apify Proxy.",
+            "type": "boolean",
+            "default": false
+        },
+        "humanize": {
+            "title": "Humanize cursor movement (speed in seconds)",
+            "type": "string",
+            "editor": "textfield",
+            "description": "Humanize cursor movement."
+        },
+        "locale": {
+            "title": "Locales",
+            "type": "array",
+            "editor": "stringList",
+            "description": "Locales to use in the browser / OS."
+        },
+        "fonts": {
+            "title": "Fonts",
+            "type": "array",
+            "editor": "stringList",
+            "description": "Fonts to load into the browser / OS."
+        },
+        "custom_fonts_only": {
+            "title": "Custom fonts only",
+            "type": "boolean",
+            "description": "If enabled, only custom fonts (from the option `fonts`) are used. This will disable the default OS fonts."
+        },
+        "enable_cache": {
+            "title": "Enable cache",
+            "type": "boolean",
+            "description": "Cache previous pages and requests in Camoufox."
+        },
+        "debug": {
+            "title": "Camoufox debug",
+            "type": "boolean",
+            "description": "Prints the config being sent to Camoufox."
+        }
+    },
+    "required": ["startUrls", "pageFunction", "proxyConfiguration"]
+}

--- a/packages/actor-scraper/camoufox-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/camoufox-scraper/INPUT_SCHEMA.json
@@ -262,7 +262,7 @@
             "editor": "textfield"
         },
         "os": {
-            "sectionCaption": "Camoufox config",
+            "sectionCaption": "Camoufox options",
             "title": "Emulated operating system",
             "type": "array",
             "description": "Operating system to use for the fingerprint generation. Can be 'windows', 'macos', 'linux', or a list to randomly choose from.",

--- a/packages/actor-scraper/camoufox-scraper/README.md
+++ b/packages/actor-scraper/camoufox-scraper/README.md
@@ -1,0 +1,5 @@
+# Camoufox Scraper
+
+This is a port of [Playwright Scraper](https://apify.com/apify/playwright-scraper) that's using [Camoufox](https://camoufox.com/) instead of default Playwright Chromium.
+
+All input options are the same as in Playwright Scraper.

--- a/packages/actor-scraper/camoufox-scraper/README.md
+++ b/packages/actor-scraper/camoufox-scraper/README.md
@@ -18,7 +18,7 @@ To get started with Camoufox Scraper, you only need a few things. First, with `S
 
 The scraper starts by loading pages specified in the [**Start URLs**](#start-urls) input setting. You can make the scraper follow page links on the fly by setting a **[Link selector](#link-selector)**, **[Glob Patterns](#glob-patterns)** and/or **[Pseudo-URLs](#pseudo-urls)** to tell the scraper which links it should add to the crawler's request queue. This is useful for the recursive crawling of entire websites (e.g. finding all products available in an online store).
 
-To tell the scraper how to handle requests and extra data, you need to provide a **[Page function](#page-function)**, and optionally arrays of **[Pre-navigation hooks](#pre-navigation-hooks)** and **[Post-navigation hooks](#post-navigation-hooks)**. This is JavaScript code that is executed in the Node.js environment. Since the scraper uses the full-featured Chromium or Firefox browser, client-side logic to be executed within the context of the web-page can be done using the **[`page`](#page)** object within the Page function's context.
+To tell the scraper how to handle requests and extra data, you need to provide a **[Page function](#page-function)**, and optionally arrays of **[Pre-navigation hooks](#pre-navigation-hooks)** and **[Post-navigation hooks](#post-navigation-hooks)**. This is JavaScript code that is executed in the Node.js environment. Since the scraper uses the full-featured Camoufox browser, client-side logic to be executed within the context of the web-page can be done using the **[`page`](#page)** object within the Page function's context.
 
 In summary, Camoufox Scraper works as follows:
 

--- a/packages/actor-scraper/camoufox-scraper/README.md
+++ b/packages/actor-scraper/camoufox-scraper/README.md
@@ -3,6 +3,12 @@ Camoufox Scraper is the most powerful scraper tool in our arsenal (aside from de
 It uses the Playwright library to programmatically control an instance of [Camoufox](https://github.com/daijro/camoufox) browser, a stealthy fork of Firefox.
 If using [Web Scraper](https://apify.com/apify/web-scraper) doesn't cut it for your use case, then Camoufox Scraper is what you need.
 
+> ⚠️ **Warning**
+>
+> Our experiments showed that Camoufox browser tends to be more resource heavy than other browsers.
+> This means that it might be slower and require larger memory allocation than other similar Actors.
+> Consider using Camoufox Scraper only when you need to scrape websites that are able to detect and block Playwright-controlled Chromium / Firefox.
+
 [Playwright](https://github.com/microsoft/playwright) is a Node.js library, so knowledge of Node.js and its paradigms is expected when working with this Actor.
 
 If you need either a faster, or a simpler tool, check out [Cheerio Scraper](https://apify.com/apify/cheerio-scraper) for optimization and speed, or [Web Scraper](https://apify.com/apify/web-scraper) for simplicity.

--- a/packages/actor-scraper/camoufox-scraper/README.md
+++ b/packages/actor-scraper/camoufox-scraper/README.md
@@ -1,5 +1,645 @@
-# Camoufox Scraper
+Camoufox Scraper is the most powerful scraper tool in our arsenal (aside from developing your own Actors).
 
-This is a port of [Playwright Scraper](https://apify.com/apify/playwright-scraper) that's using [Camoufox](https://camoufox.com/) instead of default Playwright Chromium.
+It uses the Playwright library to programmatically control an instance of [Camoufox](https://github.com/daijro/camoufox) browser, a stealthy fork of Firefox.
+If using [Web Scraper](https://apify.com/apify/web-scraper) doesn't cut it for your use case, then Camoufox Scraper is what you need.
 
-All input options are the same as in Playwright Scraper.
+[Playwright](https://github.com/microsoft/playwright) is a Node.js library, so knowledge of Node.js and its paradigms is expected when working with this Actor.
+
+If you need either a faster, or a simpler tool, check out [Cheerio Scraper](https://apify.com/apify/cheerio-scraper) for optimization and speed, or [Web Scraper](https://apify.com/apify/web-scraper) for simplicity.
+
+If you are having any difficulty deciding which of the four main Apify "Scraper" Actors to use, check out the [Web Scraper vs Puppeteer Scraper](https://help.apify.com/en/articles/3195646-when-to-use-puppeteer-scraper), [Cheerio Scraper](https://blog.apify.com/how-to-super-efficiently-scrape-any-website-for-beginners/) and [Playwright Scraper](https://blog.apify.com/how-to-scrape-the-web-with-playwright-ece1ced75f73/) articles on the Apify blog.
+
+## Cost of usage
+You can find the average usage cost for this Actor on the [pricing page](https://apify.com/pricing) under the `Which plan do I need?` section. Cheerio Scraper is equivalent to `Simple HTML pages` while Web Scraper, Puppeteer Scraper and Camoufox Scraper are equivalent to `Full web pages`. These cost estimates are based on averages and might be lower or higher depending on how heavy the pages you scrape are.
+
+## Usage
+
+To get started with Camoufox Scraper, you only need a few things. First, with `Start URLs`, tell the scraper which web pages it should load. Then, tell it how to handle each request and extract data from each page.
+
+The scraper starts by loading pages specified in the [**Start URLs**](#start-urls) input setting. You can make the scraper follow page links on the fly by setting a **[Link selector](#link-selector)**, **[Glob Patterns](#glob-patterns)** and/or **[Pseudo-URLs](#pseudo-urls)** to tell the scraper which links it should add to the crawler's request queue. This is useful for the recursive crawling of entire websites (e.g. finding all products available in an online store).
+
+To tell the scraper how to handle requests and extra data, you need to provide a **[Page function](#page-function)**, and optionally arrays of **[Pre-navigation hooks](#pre-navigation-hooks)** and **[Post-navigation hooks](#post-navigation-hooks)**. This is JavaScript code that is executed in the Node.js environment. Since the scraper uses the full-featured Chromium or Firefox browser, client-side logic to be executed within the context of the web-page can be done using the **[`page`](#page)** object within the Page function's context.
+
+In summary, Camoufox Scraper works as follows:
+
+1. Adds each URL from [Start URLs](#start-urls) to the request queue.
+2. For each request:
+    - Evaluates all hooks in [Pre-navigation hooks](#pre-navigation-hooks)
+    - Executes the [Page function](#page-function) on the loaded page
+    - Optionally, finds all links from the page using [Link selector](#link-selector). If a link matches any of the **[Glob Patterns](#glob-patterns)** and/or **[Pseudo-URLs](#pseudo-urls)** and has not yet been requested, it is added to the queue.
+    - Evaluates [Post-navigation hooks](#post-navigation-hooks)
+3. If there are more items in the queue, repeats step 2. Otherwise, finishes the crawl.
+
+Camoufox Scraper has a number of other configuration settings to improve performance, set cookies for login to websites, mask the web browser, etc... See [Advanced configuration](#advanced-configuration) below for the complete list of settings.
+
+## Limitations
+
+The Actor employs a fully-featured web browser, which is resource-intensive and might be an overkill for websites that do not render the content dynamically using client-side JavaScript. To achieve better performance for scraping such sites, you might prefer to use [**Cheerio Scraper**](https://apify.com/apify/cheerio-scraper), which downloads and processes raw HTML pages without the overheads of a web browser.
+
+For non-seasoned developers, Camoufox Scraper may be too complex. For a simpler setup process check out [Web Scraper](https://apify.com/apify/web-scraper), which uses Puppeteer and Chromium browser under the hood.
+
+## Input Configuration
+
+On input, the Camoufox Scraper Actor accepts a number of configuration settings. These can be entered either manually in the user interface in [Apify Console](https://console.apify.com), or programmatically in a JSON object using the [Apify API](https://apify.com/docs/api/v2#/reference/actors/run-collection/run-actor). For a complete list of input fields and their types, please see the outline of the Actor's [Input-schema](https://apify.com/apify/playwright-scraper/input-schema).
+
+### Start URLs
+
+The **Start URLs** (`startUrls`) field represent the initial list of URLs of pages that the scraper will visit. You can either enter these URLs manually one by one, upload them in a CSV file or [link URLs from a Google Sheet](https://help.apify.com/en/articles/2906022-scraping-a-list-of-urls-from-google-spreadsheet) document. Note that each URL must start with either a `http://` or `https://` protocol prefix.
+
+The scraper supports adding new URLs to scrape on the fly, either using the **[Link selector](#link-selector)** and **[Glob Patterns](#glob-patterns)**/**[Pseudo-URLs](#pseudo-urls)** options, or by calling `await context.enqueueRequest()`inside the **[Page function](#page-function)**.
+
+Optionally, each URL can be associated with custom user data - a JSON object that can be referenced from your JavaScript code in **[Page function](#page-function)** under `context.request.userData`. This is useful for determining which start URL is currently loaded, allowing the ability to perform some page-specific actions. For example, when crawling an online store, you might want to perform different actions on a page listing the products vs. a product detail page. For details, refer to **[Web scraping tutorial](https://docs.apify.com/tutorials/apify-scrapers/getting-started#the-start-url)** within the Apify documentation.
+
+<!-- TODO: Describe how the queue works, unique key etc. plus link -->
+
+### Link selector
+
+The **Link selector** (`linkSelector`) field contains a CSS selector that is used to find links to other web pages (items with `href` attributes, e.g. `<div class="my-class" href="...">`).
+
+On every page loaded, the scraper looks for all links matching **Link selector**, and checks that the target URL matches one of the [**Glob Patterns**](#glob-patterns)/[**Pseudo-URLs**](#pseudo-urls). If it is a match, it then adds the URL to the request queue so that it's loaded by the scraper later on.
+
+By default, new scrapers are created with the following selector that matches all links on any page:
+
+```
+a[href]
+```
+
+If **Link selector** is empty, the page links are ignored, and the scraper only loads pages that were specified in **[Start URLs](#start-urls)** or that were manually added to the request queue by calling `await context.enqueueRequest()` in **[Page function](#page-function)**.
+
+### Glob Patterns
+
+The **Glob Patterns** (`globs`) field specifies which types of URLs found by **[Link selector](#link-selector)** should be added to the request queue.
+
+A glob pattern is simply a string with wildcard characters.
+
+For example, a glob pattern `http://www.example.com/pages/**/*` will match all the
+following URLs:
+
+-   `http://www.example.com/pages/deeper-level/page`
+-   `http://www.example.com/pages/my-awesome-page`
+-   `http://www.example.com/pages/something`
+
+Note that you don't need to use the **Glob Patterns** setting at all, because you can completely control which pages the scraper will access by calling `await context.enqueueRequest()` from the **[Page function](#page-function)**.
+
+### Pseudo-URLs
+
+The **Pseudo-URLs** (`pseudoUrls`) field specifies which types of URLs found by **[Link selector](#link-selector)** should be added to the request queue.
+
+A pseudo-URL is simply a URL with special directives enclosed in `[]` brackets.
+Currently, the only supported directive is `[regexp]`, which defines
+a JavaScript-style regular expression to match against the URL.
+
+For example, a pseudo-URL `http://www.example.com/pages/[(\w|-)*]` will match all the
+following URLs:
+
+-   `http://www.example.com/pages/`
+-   `http://www.example.com/pages/my-awesome-page`
+-   `http://www.example.com/pages/something`
+
+If either "`[`" or "`]`" are part of the normal query string, the symbol must be encoded as `[\x5B]` or `[\x5D]`, respectively. For example, the following pseudo-URL:
+
+```
+http://www.example.com/search?do[\x5B]load[\x5D]=1
+```
+
+will match the URL:
+
+```
+http://www.example.com/search?do[load]=1
+```
+
+Optionally, each pseudo-URL can be associated with user data that can be referenced from your **[Page function](#page-function)** using `context.request.label` to determine which kind of page is currently loaded in the browser.
+
+Note that you don't need to use the **Pseudo-URLs** setting at all,
+because you can completely control which pages the scraper will access by calling `await context.enqueueRequest()`
+from the **[Page function](#page-function)**.
+
+### Clickable elements selector
+
+For pages where the links you want to add to the crawler's request queue aren't included in elements with `href` attributes, you can pass a CSS Selector to the **Clickable elements selector**. This CSS selector should match elements that lead to the URL you want to queue up.
+
+The scraper will mouse click the specified CSS selector after the page function finishes. Any triggered requests, navigations, or open tabs will be intercepted, and the target URLs will be filtered using Globs and/or Pseudo URLs. Finally, these filtered URLs will be added to the request queue. Leave this field empty to prevent the scraper from clicking in the page.
+
+It's important to note that _using this setting can impact performance._
+
+### Page function
+
+Page function `context` as it appears within `Page function`:
+
+```JavaScript
+const context = {
+    // USEFUL DATA
+    input, // Input data in JSON format.
+    env, // Contains information about the run, such as actorId and runId.
+    customData, // Value of the 'Custom data' scraper option.
+
+    // EXPOSED OBJECTS
+    page, // Playwright.Page object.
+    request, // Crawlee.Request object.
+    response, // Response object holding the status code and headers.
+    session, // Reference to the currently used session.
+    proxyInfo, // Object holding the url and other information about currently used Proxy.
+    crawler, // Reference to the crawler object, with access to `browserPool`, `autoscaledPool`, and more.
+    globalStore, // Represents an in memory store that can be used to share data across pageFunction invocations.
+    log, // Reference to Crawlee.utils.log.
+    Actor, // Reference to the Actor class of Apify SDK.
+    Apify, // Alias to the Actor class for back compatibility.
+
+    // EXPOSED FUNCTIONS
+    setValue, // Reference to the Actor.setValue() function.
+    getValue, // Reference to the Actor.getValue() function.
+    saveSnapshot, // Saves a screenshot and full HTML of the current page to the key value store.
+    skipLinks, // Prevents enqueueing more links via Glob patterns/Pseudo URLs on the current page.
+    enqueueRequest, // Adds a page to the request queue.
+
+    // PLAYWRIGHT CONTEXT-AWARE UTILITY FUNCTIONS
+    injectJQuery, // Injects the jQuery library into a Playwright page.
+    sendRequest, // Sends request using got-scraping.
+    parseWithCheerio, // Returns Cheerio handle for page.content(), allowing to work with the data same way as with CheerioCrawler.
+};
+```
+
+#### **`input`**
+
+| Type   | Arguments | Returns      |
+| ------ | --------- | ------------ |
+| Object | -         | Input object |
+
+The Actor's input as it was received from the UI. Each `pageFunction` invocation gets a fresh copy. Note that the Actor's input cannot be modified by changing the values in this object.
+
+#### **`env`**
+
+| Type   | Arguments | Returns                                                                                |
+| ------ | --------- |----------------------------------------------------------------------------------------|
+| Object | -         | Return value of [`Actor.getEnv()`](https://sdk.apify.com/api/apify/class/Actor#getEnv) |
+
+A map of all the relevant environment variables that you may want to use.
+
+#### **`customData`**
+
+| Type   | Arguments | Returns            |
+| ------ | --------- | ------------------ |
+| Object | -         | Custom data object |
+
+Since the input UI is fixed, it does not support adding of other fields that may be needed for all specific use cases. If you need to pass arbitrary data to the scraper, use the [Custom data](#custom-data) input field within [Advanced configuration](#advanced-configuration) and its contents will be available under the `customData` context key as an object.
+
+#### **`page`**
+
+| Type   | Arguments | Returns                                                              |
+| ------ | --------- |----------------------------------------------------------------------|
+| Object | -         | [Playwright Page](https://playwright.dev/docs/api/class-page) object |
+
+This is a reference to the Playwright Page object, which enables you to use the full power of Playwright in your Page functions. If you are not familiar with the Page API already, you can refer to [their documentation](https://playwright.dev/docs/api/class-page).
+
+#### **`request`**
+
+| Type   | Arguments | Returns                                                      |
+| ------ | --------- |--------------------------------------------------------------|
+| Object | -         | [Request](https://crawlee.dev/api/core/class/Request) object |
+
+An object with metadata about the currently crawled page, such as its URL, headers, and the number of retries.
+
+```JavaScript
+const request = {
+    id,
+    url,
+    loadedUrl,
+    uniqueKey,
+    method,
+    payload,
+    noRetry,
+    retryCount,
+    errorMessages,
+    headers,
+    userData,
+    handledAt
+}
+```
+
+See the [Request class](https://crawlee.dev/api/core/class/Request) for a preview of the structure and full documentation.
+
+#### **`response`**
+
+| Type   | Arguments | Returns         |
+| ------ | --------- | --------------- |
+| Object | -         | Response object |
+
+The response object is produced by Playwright. Currently, we only pass the response's HTTP status code and headers to the `response` object.
+
+#### **`session`**
+
+| Type   | Arguments | Returns                                                       |
+| ------ | --------- |---------------------------------------------------------------|
+| Object | -         | [Session](https://crawlee.dev/api/core/class/Session) object  |
+
+Reference to the currently used session. See the [official documentation](https://crawlee.dev/api/core/class/Session) for more information.
+
+#### **`proxyInfo`**
+
+| Type   | Arguments | Returns                                                              |
+| ------ | --------- |----------------------------------------------------------------------|
+| Object | -         | [ProxyInfo](https://crawlee.dev/api/core/interface/ProxyInfo) object |
+
+Object holding the url and other information about currently used Proxy. See the [official documentation](https://crawlee.dev/api/core/interface/ProxyInfo) for more information.
+
+#### **`crawler`**
+
+| Type   | Arguments | Returns                                                                                        |
+| ------ | --------- |------------------------------------------------------------------------------------------------|
+| Object | -         | [PlaywrightCrawler](https://crawlee.dev/api/playwright-crawler/class/PlaywrightCrawler) object |
+
+To access the current `AutoscaledPool` or `BrowserPool` instance, we can use the `crawler` object. This object includes the following properties:
+
+```JavaScript
+const crawler = {
+    stats,
+    requestList,
+    requestQueue,
+    sessionPool,
+    proxyConfiguration,
+    browserPool,
+    autoscaledPool
+}
+```
+
+Refer to the [official documentation](https://crawlee.dev/api/playwright-crawler/class/PlaywrightCrawler) for more information.
+
+#### **`globalStore`**
+
+| Type   | Arguments | Returns               |
+| ------ | --------- | --------------------- |
+| Object | -         | Global store contents |
+
+`globalStore` represents an instance of a very simple in-memory store that is not scoped to the individual `pageFunction` invocation. This enables you to easily share global data such as API responses and tokens between all requests. Since the stored data needs to cross from the browser to the Node.js process, it must be formatted into JSON stringifiable objects. You cannot store DOM objects, functions, circular objects, etc.
+
+#### **`log`**
+
+| Type   | Arguments | Returns                                                            |
+| ------ | --------- |--------------------------------------------------------------------|
+| Object | -         | [Crawlee.utils.log](https://crawlee.dev/api/core/class/Log) object |
+
+This should be used instead of JavaScript's built in `console.log` when logging in the Node.js context, as it automatically color-tags your logs, as well as allows the toggling of the visibility of log messages using options such as [Debug log](#debug-log) in [Advanced configuration](#advanced-configuration).
+
+The most common `log` methods include:
+
+-   `context.log.info()`
+-   `context.log.debug()`
+-   `context.log.warning()`
+-   `context.log.error()`
+-   `context.log.exception()`
+
+#### **`Actor`**
+
+| Type   | Arguments | Returns                                                           |
+| ------ | --------- |-------------------------------------------------------------------|
+| Object | -         | [Actor class](https://sdk.apify.com/api/apify/class/Actor) object |
+
+A reference to the full power of the Actor class of Apify SDK. See [the docs](https://sdk.apify.com/api/apify/class/Actor) for more information.
+
+> Caution: Since we're making the Actor class available with this option, and Playwright Scraper already runs using the Actor class, some edge case manipulations may lead to inconsistencies. Use `Actor` class with caution, and avoid making global changes unless you know what you're doing.
+
+#### **`Apify`**
+
+An alias for [`Actor`](#actor) class for back compatibility.
+
+#### **`setValue`**
+
+| Type     | Arguments                                          | Returns          |
+| -------- | -------------------------------------------------- | ---------------- |
+| Function | (key: _string_, data: _object_, options: _object_) | _Promise\<void>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+Allows you to save data to the default key-value store. The `key` is the name of the item in the store (which can later be used to retrieve this stored data), and the `data` is an object containing all the data you want to store.
+
+Usage:
+
+```JavaScript
+await context.setValue('my-value', { message: 'hello' })
+```
+
+Refer to [Key-Value store documentation](https://crawlee.dev/api/core/class/KeyValueStore#setValue) for more information.
+
+#### **`getValue`**
+
+| Type     | Arguments       | Returns            |
+| -------- | --------------- | ------------------ |
+| Function | (key: _string_) | _Promise\<object>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+Retrieve previously saved data in the key-value store via the `key` specified when using the [`setValue`](#setvalue) function.
+
+Usage:
+
+```JavaScript
+const { message } = await context.getValue('my-value')
+```
+
+Refer to [Key-Value store documentation](https://crawlee.dev/api/core/class/KeyValueStore#getValue) for more information.
+
+#### **`saveSnapshot`**
+
+| Type     | Arguments | Returns          |
+| -------- | --------- | ---------------- |
+| Function | ()        | _Promise\<void>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+A helper function that enables saving a snapshot of the current page's HTML and a screenshot of the current page into the default key-value store. Each snapshot overwrites the previous one, and the `pageFunction`'s invocations will also be throttled if `saveSnapshot` is invoked more than once in 2 seconds (this is a measure put in place to prevent abuse). _Make sure you don't call it for every single request._
+
+Usage:
+
+```JavaScript
+await context.saveSnapshot()
+```
+
+You can find the latest screenshot under the `SNAPSHOT-SCREENSHOT` key and the HTML under the `SNAPSHOT-BODY` key.
+
+#### **`skipLinks`**
+
+| Type     | Arguments | Returns          |
+| -------- | --------- | ---------------- |
+| Function | ()        | _Promise\<void>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+With each invocation of the pageFunction, the scraper attempts to extract new URLs from the page using the Link selector and Glob patterns/Pseudo-URLs provided in the input UI. If you want to prevent this behavior in certain cases, call the `skipLinks` function, and no URLs will be added to the queue for the given page.
+
+Usage:
+
+```JavaScript
+await context.skipLinks()
+```
+
+#### **`enqueueRequest`**
+
+| Type     | Arguments                    | Returns          |
+| -------- | ---------------------------- | ---------------- |
+| Function | (request: _Request\|object_) | _Promise\<void>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+To enqueue a specific URL manually instead of automatically by a combination of a Link selector and a Pseudo URL/Glob pattern, use the enqueueRequest function. It accepts a plain object as argument that needs to have the structure to construct a [Request object](https://crawlee.dev/api/core/class/Request), but frankly, you just need an object with a `url` key.
+
+Usage:
+
+```JavaScript
+await context.enqueueRequest({ url: 'https://www.example.com' })
+```
+
+This method is a nice shorthand for
+
+```JavaScript
+await context.crawler.requestQueue.addRequest({ url: 'https://foo.bar/baz' })
+```
+
+#### **`injectJQuery`**
+
+| Type     | Arguments | Returns          |
+| -------- |-----------|------------------|
+| Function | ()        | _Promise\<void>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+Injects the [jQuery](https://jquery.com/) library into a Playwright page. The injected jQuery will be set to the `window.$` variable, and will survive page navigations and reloads. Note that `injectJQuery()` does not affect the Playwright [`page.$()`](https://playwright.dev/docs/api/class-page#page-query-selector) function in any way.
+
+Usage:
+
+```JavaScript
+await context.injectJQuery();
+```
+
+#### **`sendRequest`**
+
+| Type     | Arguments                                    | Returns          |
+| -------- |----------------------------------------------|------------------|
+| Function | (overrideOptions?: Partial\<GotOptionsInit>) | _Promise\<void>_ |
+
+> This function is async! Don't forget the `await` keyword!
+
+This is a helper function that allows processing the context bound `Request` object through [`got-scraping`](https://github.com/apify/got-scraping). Some options, such as `url` or `method` could be overridden by providing `overrideOptions`. See the [official documentation](https://crawlee.dev/docs/guides/got-scraping#sendrequest-api) for full list of possible `overrideOptions` and more information.
+
+Usage:
+
+```JavaScript
+// Without overrideOptions
+await context.sendRequest();
+// With overrideOptions.url
+await context.sendRequest({ url: 'https://www.example.com' });
+```
+
+#### **`parseWithCheerio`**
+
+| Type     | Arguments | Returns                 |
+| -------- |-----------|-------------------------|
+| Function | ()        | _Promise\<CheerioRoot>_ |
+
+Returns Cheerio handle for `page.content()`, allowing to work with the data same way as with CheerioCrawler.
+
+Usage:
+
+```JavaScript
+const $ = await context.parseWithCheerio();
+```
+
+## Proxy Configuration
+
+The **Proxy configuration** (`proxyConfiguration`) option enables you to set proxies
+that will be used by the scraper in order to prevent its detection by target websites.
+You can use both [Apify Proxy](https://apify.com/proxy)
+and custom HTTP or SOCKS5 proxy servers.
+
+Proxy is required to run the scraper. The following table lists the available options of the proxy configuration setting:
+
+| Option                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Apify Proxy (automatic)       | The scraper will load all web pages using [Apify Proxy](https://apify.com/proxy) in the automatic mode. In this mode, the proxy uses all proxy groups that are available to the user, and for each new web page it automatically selects the proxy that hasn't been used in the longest time for the specific hostname, in order to reduce the chance of detection by the website. You can view the list of available proxy groups on the [Proxy](https://console.apify.com/proxy) page in Apify Console. |
+| Apify Proxy (selected groups) | The scraper will load all web pages using [Apify Proxy](https://apify.com/proxy) with specific groups of target proxy servers.                                                                                                                                                                                                                                                                                                                                                                            |
+| Custom proxies                | The scraper will use a custom list of proxy servers. The proxies must be specified in the `scheme://user:password@host:port` format, and multiple proxies should be separated by a space of a new line. The URL scheme can be either `http` or `socks5`. Username and password can be omitted if the proxy doesn't require authorization, but the port must always be present.                                                                                                                            |
+
+Custom proxy example:
+
+```
+http://bob:password@proxy1.example.com:8000
+http://bobby:password123@proxy2.example.com:3001
+```
+
+The proxy configuration can be set programmatically when calling the Actor using the API by setting the `proxyConfiguration` field. It accepts a JSON object with the following structure:
+
+```JavaScript
+{
+    // Indicates whether to use Apify Proxy or not.
+    "useApifyProxy": Boolean,
+
+    // Array of Apify Proxy groups, only used if "useApifyProxy" is true.
+    // If missing or null, Apify Proxy will use the automatic mode.
+    "apifyProxyGroups": String[],
+
+    // Array of custom proxy URLs, in "scheme://user:password@host:port" format.
+    // If missing or null, custom proxies are not used.
+    "proxyUrls": String[],
+}
+```
+
+## Advanced Configuration
+
+### Camoufox options
+
+#### Emulated operating system
+
+Operating system to use for the fingerprint generation. Can be `windows`, `macos`, `linux`, or a list to randomly choose from.
+
+#### Block image loading
+
+Blocks the image loading on the browser level to save bandwidth and speed up the scraping process. This option is useful when you don't need to extract data from images.
+Note that some antibot systems may detect this behavior and block the scraper.
+
+#### Block WebRTC
+
+Blocks WebRTC capabilities in Camoufox. Note that this might break some web applications.
+
+
+#### Block WebGL
+
+Blocks WebGL capabilities in Camoufox. Note that this might break some websites.
+
+#### Disable Cross-Origin-Opener-Policy
+
+Disables the Cross-Origin-Opener-Policy header in Camoufox. Note that some websites may use this header for security reasons.
+
+#### GeoIP (⚠️ might not fully work with Apify Proxy ⚠️).
+
+Calculates geo-data (location, timezone) for injection into the browser based on the proxy IP address. Might not fully work with Apify Proxy.
+
+#### Humanize cursor movement (speed in seconds)
+
+Humanizes the cursor movement by continuously moving it to random positions on the page. The speed of the movement can be set in seconds.
+
+#### Locales
+
+Sets the locale of the browser. Can be a single locale or a list to randomly choose from.
+
+#### Fonts
+
+Sets the additional custom fonts to be available in the browser.
+
+#### Custom fonts only
+
+If enabled, only the custom fonts will be available in the browser.
+Note that this might break designs on some websites and might cause detection by some antibot systems.
+
+#### Enable cache
+
+Enables internal browser caching. This saves bandwidth and speeds up the scraping process.
+
+#### Camoufox debug
+
+Enables debug mode in Camoufox. This will log additional information about the browser's behavior.
+
+### Pre-navigation hooks
+
+This is an array of functions that will be executed **BEFORE** the main `pageFunction` is run. A similar `context` object is passed into each of these functions as is passed into the `pageFunction`; however, a second "[DirectNavigationOptions](https://crawlee.dev/api/playwright-crawler/namespace/playwrightUtils#DirectNavigationOptions)" object is also passed in. `Apify` is an alias for `Actor` class in this case.
+
+The available options can be seen here:
+
+```JavaScript
+preNavigationHooks: [
+    async ({ id, request, session, proxyInfo, customData, Actor, Apify }, { timeout, waitUntil, referer }) => {}
+]
+```
+
+Check out the docs for [Pre-navigation hooks](https://crawlee.dev/api/playwright-crawler/interface/PlaywrightCrawlerOptions#preNavigationHooks) and the [PlaywrightHook type](https://crawlee.dev/api/playwright-crawler/interface/PlaywrightHook) for more info regarding the objects passed into these functions. The available properties are extended with `Actor` (previously `Apify`) class and `customData` in this scraper.
+
+### Post-navigation hooks
+
+An array of functions that will be executed **AFTER** the main `pageFunction` is run. The only available parameter is the [PlaywrightCrawlingContext](https://crawlee.dev/api/playwright-crawler/interface/PlaywrightCrawlingContext) object. The available properties are extended with `Actor` (previously `Apify`) class and `customData` in this scraper. `Apify` is an alias for `Actor` class in this case.
+
+```JavaScript
+postNavigationHooks: [
+    async ({ id, request, session, proxyInfo, response, customData, Actor, Apify }) => {}
+]
+```
+
+Check out the docs for [Post-navigation hooks](https://crawlee.dev/api/playwright-crawler/interface/PlaywrightCrawlerOptions#postNavigationHooks) and the [PlaywrightHook type](https://crawlee.dev/api/playwright-crawler/interface/PlaywrightHook) for more info regarding the objects passed into these functions.
+
+### Debug log
+
+_boolean_
+
+When set to true, debug messages will be included in the log. Use `context.log.debug('message')` to log your own debug messages.
+
+### Browser log
+
+_boolean_
+
+When set to true, console messages from the browser will be included in the Actor's log. This may result in the log being flooded by error messages, warnings and other messages of little value (especially with a high concurrency).
+
+### Custom data
+
+Since the input UI is fixed, it does not support adding of other fields that may be needed for all specific use cases. If you need to pass arbitrary data to the scraper, use the [Custom data](#custom-data) input field within [Advanced configuration](#advanced-configuration) and its contents will be available under the `customData` context key as an object within the [pageFunction](#page-function).
+
+### Custom namings
+
+With the final three options in the **Advanced configuration**, you can set custom names for the following:
+
+-   Dataset
+-   Key-value store
+-   Request queue
+
+Leave the storage unnamed if you only want the data within it to be persisted on the Apify platform for a number of days corresponding to your [plan](https://apify.com/pricing) (after which it will expire). Named storages are retained indefinitely. Additionally, using a named storage allows you to share it across multiple runs (e.g. instead of having 10 different unnamed datasets for 10 different runs, all the data from all 10 runs can be accumulated into a single named dataset). Learn more [here](https://docs.apify.com/storage#named-and-unnamed-storages).
+
+## Results
+
+The scraping results returned by **[Page function](#page-function)** are stored in the default dataset associated with the Actor run, from which you can export them to formats such as JSON, XML, CSV or Excel.
+For each object returned by the **[Page function](#page-function)**, Camoufox Scraper pushes one record into the dataset, and extends it with metadata such as the URL of the web page where the results come from.
+
+For example, if you were scraping the HTML `<title>` of [Apify](https://apify.com) and returning the following object from the `pageFunction`:
+
+```JavaScript
+return {
+  title: "Web Scraping, Data Extraction and Automation - Apify"
+}
+```
+
+The full object stored in the dataset would look as follows (in JSON format, including the metadata fields `#error` and `#debug`):
+
+```JSON
+{
+  "title": "Web Scraping, Data Extraction and Automation - Apify",
+  "#error": false,
+  "#debug": {
+    "requestId": "fvwscO2UJLdr10B",
+    "url": "https://apify.com",
+    "loadedUrl": "https://apify.com/",
+    "method": "GET",
+    "retryCount": 0,
+    "errorMessages": null,
+    "statusCode": 200
+  }
+}
+```
+
+To download the results, call the [Get dataset items](https://docs.apify.com/api/v2#/reference/datasets/item-collection) API endpoint:
+
+```
+https://api.apify.com/v2/datasets/[DATASET_ID]/items?format=json
+```
+
+`[DATASET_ID]` is the ID of the Actor's run dataset, in which you can find the Run object returned when starting the Actor. Alternatively, you'll find the download links for the results in Apify Console.
+
+To skip the `#error` and `#debug` metadata fields from the results and not include empty result records, simply add the `clean=true` query parameter to the API URL, or select the **Clean items** option when downloading the dataset in Apify Console.
+
+To get the results in other formats, set the `format` query parameter to `xml`, `xlsx`, `csv`, `html`, etc.
+For more information, see [Datasets](https://apify.com/docs/storage#dataset) in documentation or the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection) endpoint in the Apify API reference.
+
+## Additional Resources
+
+That's it! You might also want to check out these other resources:
+
+-   [Actors documentation](https://apify.com/docs/actor) - Documentation for the Apify Actors cloud computing platform.
+-   [Apify SDK documentation](https://sdk.apify.com) - Learn more about the tools required to run your own Apify Actors.
+-   [Crawlee documentation](https://crawlee.dev) - Learn how to build a new web scraping project from scratch using the world's most popular web crawling and scraping library for Node.js.
+-   [Cheerio Scraper](https://apify.com/apify/cheerio-scraper) - Another web scraping Actor that downloads and processes pages in raw HTML for much higher performance.
+-   [Puppeteer Scraper](https://apify.com/apify/puppeteer-scraper) - A similar web scraping Actor to Camoufox Scraper, but using the [Puppeteer](https://github.com/puppeteer/puppeteer) library instead.
+-   [Web Scraper](https://apify.com/apify/web-scraper) - A similar web scraping Actor to Camoufox Scraper, but is simpler to use and only runs in the context of the browser. Uses the [Puppeteer](https://github.com/puppeteer/puppeteer) library.

--- a/packages/actor-scraper/camoufox-scraper/package.json
+++ b/packages/actor-scraper/camoufox-scraper/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "actor-camoufox-scraper",
+    "version": "3.1.0",
+    "private": true,
+    "description": "Crawl web pages using Apify, headless browser and Playwright with Camoufox",
+    "type": "module",
+    "dependencies": {
+        "@apify/scraper-tools": "^1.1.4",
+        "@crawlee/core": "^3.11.5",
+        "@crawlee/playwright": "^3.11.5",
+        "@crawlee/utils": "^3.11.5",
+        "apify": "^3.2.6",
+        "camoufox-js": "^0.1.3",
+        "idcac-playwright": "^0.1.3",
+        "playwright": "*"
+    },
+    "devDependencies": {
+        "@apify/tsconfig": "^0.1.0",
+        "@types/node": "^22.7.4",
+        "tsx": "^4.19.1",
+        "typescript": "~5.7.0"
+    },
+    "scripts": {
+        "start": "npm run start:dev",
+        "start:prod": "node dist/main.js",
+        "start:dev": "tsx src/main.ts",
+        "build": "tsc",
+        "get-binaries": "camoufox-js fetch"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/apify/apify-sdk-js"
+    },
+    "author": {
+        "name": "Apify Technologies",
+        "email": "support@apify.com",
+        "url": "https://apify.com"
+    },
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/apify/apify-sdk-js"
+}

--- a/packages/actor-scraper/camoufox-scraper/src/internals/consts.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/internals/consts.ts
@@ -1,0 +1,49 @@
+import { Session, ProxyConfigurationOptions, GlobInput, RegExpInput, PseudoUrlInput, RequestOptions } from '@crawlee/core';
+import { Dictionary } from '@crawlee/utils';
+
+/**
+ * Replicates the INPUT_SCHEMA with TypeScript types for quick reference
+ * and IDE type check integration.
+ */
+export interface Input {
+    startUrls: RequestOptions[];
+    globs: GlobInput[];
+    regexps: RegExpInput[];
+    pseudoUrls: PseudoUrlInput[];
+    excludes: GlobInput[];
+    linkSelector?: string;
+    keepUrlFragments: boolean;
+    pageFunction: string;
+    preNavigationHooks?: string;
+    postNavigationHooks?: string;
+    proxyConfiguration: ProxyConfigurationOptions;
+    proxyRotation: ProxyRotation;
+    sessionPoolName?: string;
+    initialCookies: Parameters<Session['setCookies']>[0];
+    maxScrollHeightPixels: number;
+    ignoreSslErrors: boolean;
+    ignoreCorsAndCsp: boolean;
+    closeCookieModals: boolean;
+    downloadMedia: boolean;
+    maxRequestRetries: number;
+    maxPagesPerCrawl: number;
+    maxResultsPerCrawl: number;
+    maxCrawlingDepth: number;
+    maxConcurrency: number;
+    pageLoadTimeoutSecs: number;
+    pageFunctionTimeoutSecs: number;
+    waitUntil: 'networkidle' | 'load' | 'domcontentloaded';
+    debugLog: boolean;
+    browserLog: boolean;
+    customData: Dictionary;
+    datasetName?: string;
+    keyValueStoreName?: string;
+    requestQueueName?: string;
+    headless: boolean;
+}
+
+export const enum ProxyRotation {
+    Recommended = 'RECOMMENDED',
+    PerRequest = 'PER_REQUEST',
+    UntilFailure = 'UNTIL_FAILURE',
+}

--- a/packages/actor-scraper/camoufox-scraper/src/internals/consts.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/internals/consts.ts
@@ -40,6 +40,18 @@ export interface Input {
     keyValueStoreName?: string;
     requestQueueName?: string;
     headless: boolean;
+    os: string[];
+    blockImages: boolean;
+    blockWebrtc: boolean;
+    blockWebgl: boolean;
+    disableCoop: boolean;
+    geoip: boolean;
+    humanize: string;
+    locale: string[];
+    fonts: string[];
+    customFontsOnly: boolean;
+    enableCache: boolean;
+    debug: boolean;
 }
 
 export const enum ProxyRotation {

--- a/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
@@ -171,6 +171,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 launcher: firefox,
                 launchOptions: await launchOptions({
                     ...this.input,
+                    humanize: this.input.humanize ? Number(this.input.humanize) : 0,
                 }),
             } as PlaywrightLaunchContext,
             useSessionPool: true,

--- a/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
@@ -1,0 +1,362 @@
+import { readFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
+
+import { browserTools, constants as scraperToolsConstants, CrawlerSetupOptions, createContext, RequestMetadata, tools } from '@apify/scraper-tools';
+import {
+    AutoscaledPool,
+    Dataset,
+    KeyValueStore,
+    Request,
+    RequestList,
+    RequestQueueV2,
+    PlaywrightCrawlingContext,
+    PlaywrightCrawler,
+    PlaywrightCrawlerOptions,
+    PlaywrightLaunchContext,
+    EnqueueLinksOptions,
+    log,
+    ProxyConfiguration,
+} from '@crawlee/playwright';
+import { Awaitable, Dictionary, sleep } from '@crawlee/utils';
+import { Actor, ApifyEnv } from 'apify';
+import { launchOptions } from 'camoufox-js';
+import { getInjectableScript } from 'idcac-playwright';
+import { firefox, Response } from 'playwright';
+
+import { Input, ProxyRotation } from './consts.js';
+
+const SESSION_STORE_NAME = 'APIFY-PLAYWRIGHT-SCRAPER-SESSION-STORE';
+
+const { META_KEY, DEVTOOLS_TIMEOUT_SECS, SESSION_MAX_USAGE_COUNTS } = scraperToolsConstants;
+const SCHEMA = JSON.parse(await readFile(new URL('../../INPUT_SCHEMA.json', import.meta.url), 'utf8'));
+
+/**
+ * Holds all the information necessary for constructing a crawler
+ * instance and creating a context for a pageFunction invocation.
+ */
+export class CrawlerSetup implements CrawlerSetupOptions {
+    name = 'Playwright Scraper';
+    rawInput: string;
+    env: ApifyEnv;
+    /**
+     * Used to store data that persist navigations
+     */
+    globalStore = new Map();
+    requestQueue: RequestQueueV2;
+    keyValueStore: KeyValueStore;
+    customData: unknown;
+    input: Input;
+    maxSessionUsageCount: number;
+    evaledPageFunction: (...args: unknown[]) => unknown;
+    evaledPreNavigationHooks: ((...args: unknown[]) => Awaitable<void>)[];
+    evaledPostNavigationHooks: ((...args: unknown[]) => Awaitable<void>)[];
+    devtools: boolean;
+    datasetName?: string;
+    keyValueStoreName?: string;
+    requestQueueName?: string;
+
+    crawler!: PlaywrightCrawler;
+    requestList!: RequestList;
+    dataset!: Dataset;
+    pagesOutputted!: number;
+    private initPromise: Promise<void>;
+
+    constructor(input: Input) {
+        // Set log level early to prevent missed messages.
+        if (input.debugLog) log.setLevel(log.LEVELS.DEBUG);
+
+        // Keep this as string to be immutable.
+        this.rawInput = JSON.stringify(input);
+
+        // Attempt to load page function from disk if not present on input.
+        tools.maybeLoadPageFunctionFromDisk(input, dirname(fileURLToPath(import.meta.url)));
+
+        // Validate INPUT if not running on Apify Cloud Platform.
+        if (!Actor.isAtHome()) tools.checkInputOrThrow(input, SCHEMA);
+
+        this.input = input;
+        this.env = Actor.getEnv();
+
+        // Validations
+        this.input.pseudoUrls.forEach((purl) => {
+            if (!tools.isPlainObject(purl)) throw new Error('The pseudoUrls Array must only contain Objects.');
+            if (purl.userData && !tools.isPlainObject(purl.userData)) throw new Error('The userData property of a pseudoUrl must be an Object.');
+        });
+
+        this.input.initialCookies.forEach((cookie) => {
+            if (!tools.isPlainObject(cookie)) throw new Error('The initialCookies Array must only contain Objects.');
+        });
+
+        if (!/^(domcontentloaded|load|networkidle)$/.test(this.input.waitUntil)) {
+            throw new Error('Navigation wait until event must be valid. See tooltip.');
+        }
+
+        // solving proxy rotation settings
+        this.maxSessionUsageCount = SESSION_MAX_USAGE_COUNTS[this.input.proxyRotation];
+
+        // Functions need to be evaluated.
+        this.evaledPageFunction = tools.evalFunctionOrThrow(this.input.pageFunction);
+
+        if (this.input.preNavigationHooks) {
+            this.evaledPreNavigationHooks = tools.evalFunctionArrayOrThrow(this.input.preNavigationHooks, 'preNavigationHooks');
+        } else {
+            this.evaledPreNavigationHooks = [];
+        }
+
+        if (this.input.postNavigationHooks) {
+            this.evaledPostNavigationHooks = tools.evalFunctionArrayOrThrow(this.input.postNavigationHooks, 'postNavigationHooks');
+        } else {
+            this.evaledPostNavigationHooks = [];
+        }
+
+        // Start Chromium with Debugger any time the page function includes the keyword.
+        this.devtools = this.input.pageFunction.includes('debugger;');
+
+        // Named storages
+        this.datasetName = this.input.datasetName;
+        this.keyValueStoreName = this.input.keyValueStoreName;
+        this.requestQueueName = this.input.requestQueueName;
+
+        // Initialize async operations.
+        this.crawler = null!;
+        this.requestList = null!;
+        this.requestQueue = null!;
+        this.dataset = null!;
+        this.keyValueStore = null!;
+        this.initPromise = this._initializeAsync();
+    }
+
+    private async _initializeAsync() {
+        // RequestList
+        const startUrls = this.input.startUrls.map((req) => {
+            req.useExtendedUniqueKey = true;
+            req.keepUrlFragment = this.input.keepUrlFragments;
+            return req;
+        });
+
+        this.requestList = await RequestList.open('PLAYWRIGHT_SCRAPER', startUrls);
+
+        // RequestQueue
+        this.requestQueue = await RequestQueueV2.open(this.requestQueueName);
+
+        // Dataset
+        this.dataset = await Dataset.open(this.datasetName);
+        const info = await this.dataset.getInfo();
+        this.pagesOutputted = info?.itemCount ?? 0;
+
+        // KeyValueStore
+        this.keyValueStore = await KeyValueStore.open(this.keyValueStoreName);
+    }
+
+    /**
+     * Resolves to a `PlaywrightCrawler` instance.
+     */
+    async createCrawler() {
+        await this.initPromise;
+
+        const options: PlaywrightCrawlerOptions = {
+            requestHandler: this._requestHandler.bind(this),
+            requestList: this.requestList,
+            requestQueue: this.requestQueue,
+            requestHandlerTimeoutSecs: this.devtools ? DEVTOOLS_TIMEOUT_SECS : this.input.pageFunctionTimeoutSecs,
+            preNavigationHooks: [],
+            postNavigationHooks: [],
+            failedRequestHandler: this._failedRequestHandler.bind(this),
+            maxConcurrency: this.input.maxConcurrency,
+            maxRequestRetries: this.input.maxRequestRetries,
+            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            proxyConfiguration: await Actor.createProxyConfiguration(this.input.proxyConfiguration) as any as ProxyConfiguration,
+            launchContext: {
+                launcher: firefox,
+                launchOptions: await launchOptions({
+                    ...this.input,
+                }),
+            } as PlaywrightLaunchContext,
+            useSessionPool: true,
+            persistCookiesPerSession: true,
+            sessionPoolOptions: {
+                persistStateKeyValueStoreId: this.input.sessionPoolName ? SESSION_STORE_NAME : undefined,
+                persistStateKey: this.input.sessionPoolName,
+                sessionOptions: {
+                    maxUsageCount: this.maxSessionUsageCount,
+                },
+            },
+            experiments: {
+                requestLocking: true,
+            },
+        };
+
+        this._createNavigationHooks(options);
+
+        if (this.input.proxyRotation === ProxyRotation.UntilFailure) {
+            options.sessionPoolOptions!.maxPoolSize = 1;
+        }
+
+        this.crawler = new PlaywrightCrawler(options);
+
+        return this.crawler;
+    }
+
+    private _createNavigationHooks(options: PlaywrightCrawlerOptions) {
+        options.preNavigationHooks!.push(async ({ request, page, session }, gotoOptions) => {
+            // Attach a console listener to get all logs from Browser context.
+            if (this.input.browserLog) browserTools.dumpConsole(page);
+
+            // Add initial cookies, if any.
+            if (this.input.initialCookies && this.input.initialCookies.length) {
+                const cookiesToSet = session
+                    ? tools.getMissingCookiesFromSession(session, this.input.initialCookies, request.url)
+                    : this.input.initialCookies;
+
+                if (cookiesToSet?.length) {
+                    // setting initial cookies that are not already in the session and page
+                    session?.setCookies(cookiesToSet, request.url);
+                    await page.context().addCookies(cookiesToSet);
+                }
+            }
+
+            if (gotoOptions) {
+                gotoOptions.timeout = (this.devtools ? DEVTOOLS_TIMEOUT_SECS : this.input.pageLoadTimeoutSecs) * 1000;
+                gotoOptions.waitUntil = this.input.waitUntil;
+            }
+        });
+
+        options.preNavigationHooks!.push(...this._runHookWithEnhancedContext(this.evaledPreNavigationHooks));
+        options.postNavigationHooks!.push(...this._runHookWithEnhancedContext(this.evaledPostNavigationHooks));
+    }
+
+    private _runHookWithEnhancedContext(hooks: ((...args: unknown[]) => Awaitable<void>)[]) {
+        return hooks.map((hook) => (ctx: Dictionary, ...args: unknown[]) => {
+            const { customData } = this.input;
+            return hook({ ...ctx, Apify: Actor, Actor, customData }, ...args);
+        });
+    }
+
+    private async _failedRequestHandler({ request }: PlaywrightCrawlingContext) {
+        const lastError = request.errorMessages[request.errorMessages.length - 1];
+        const errorMessage = lastError ? lastError.split('\n')[0] : 'no error';
+        log.error(`Request ${request.url} failed and will not be retried anymore. Marking as failed.\nLast Error Message: ${errorMessage}`);
+        return this._handleResult(request, undefined, undefined, true);
+    }
+
+    /**
+     * First of all, it initializes the state that is exposed to the user via
+     * `pageFunction` context.
+     *
+     * Then it invokes the user provided `pageFunction` with the prescribed context
+     * and saves its return value.
+     *
+     * Finally, it makes decisions based on the current state and post-processes
+     * the data returned from the `pageFunction`.
+     */
+    private async _requestHandler(crawlingContext: PlaywrightCrawlingContext) {
+        const { request, response, crawler } = crawlingContext;
+
+        /**
+         * PRE-PROCESSING
+         */
+        // Make sure that an object containing internal metadata
+        // is present on every request.
+        tools.ensureMetaData(request);
+
+        // Abort the crawler if the maximum number of results was reached.
+        const aborted = await this._handleMaxResultsPerCrawl(crawler.autoscaledPool);
+        if (aborted) return;
+
+        const pageFunctionArguments: Dictionary = {};
+
+        // We must use properties and descriptors not to trigger getters / setters.
+        Object.defineProperties(pageFunctionArguments, Object.getOwnPropertyDescriptors(crawlingContext));
+
+        pageFunctionArguments.response = {
+            status: response && response.status(),
+            headers: response && response.headers(),
+        };
+
+        // Setup and create Context.
+        const contextOptions = {
+            crawlerSetup: {
+                rawInput: this.rawInput,
+                env: this.env,
+                globalStore: this.globalStore,
+                requestQueue: this.requestQueue,
+                keyValueStore: this.keyValueStore,
+                customData: this.input.customData,
+            },
+            pageFunctionArguments,
+        };
+        const { context, state } = createContext(contextOptions);
+
+        if (this.input.closeCookieModals) {
+            await sleep(500);
+            await crawlingContext.page.evaluate(getInjectableScript());
+            await sleep(2000);
+        }
+
+        if (this.input.maxScrollHeightPixels > 0) {
+            await crawlingContext.infiniteScroll({ maxScrollHeight: this.input.maxScrollHeightPixels });
+        }
+
+        /**
+         * USER FUNCTION INVOCATION
+         */
+        const pageFunctionResult = await this.evaledPageFunction(context);
+
+        /**
+         * POST-PROCESSING
+         */
+        // Enqueue more links if Pseudo URLs and a link selector are available,
+        // unless the user invoked the `skipLinks()` context function
+        // or maxCrawlingDepth would be exceeded.
+        if (!state.skipLinks) await this._handleLinks(crawlingContext);
+
+        // Save the `pageFunction`s result to the default dataset.
+        await this._handleResult(request, response, pageFunctionResult as Dictionary);
+    }
+
+    private async _handleMaxResultsPerCrawl(autoscaledPool?: AutoscaledPool) {
+        if (!this.input.maxResultsPerCrawl || this.pagesOutputted < this.input.maxResultsPerCrawl) return false;
+        if (!autoscaledPool) return false;
+        log.info(`User set limit of ${this.input.maxResultsPerCrawl} results was reached. Finishing the crawl.`);
+        await autoscaledPool.abort();
+        return true;
+    }
+
+    private async _handleLinks({ request, enqueueLinks }: PlaywrightCrawlingContext) {
+        if (!this.requestQueue) return;
+        const currentDepth = (request.userData![META_KEY] as RequestMetadata).depth;
+        const hasReachedMaxDepth = this.input.maxCrawlingDepth && currentDepth >= this.input.maxCrawlingDepth;
+        if (hasReachedMaxDepth) {
+            log.debug(`Request ${request.url} reached the maximum crawling depth of ${currentDepth}.`);
+            return;
+        }
+
+        const enqueueOptions: EnqueueLinksOptions = {
+            globs: this.input.globs,
+            pseudoUrls: this.input.pseudoUrls,
+            exclude: this.input.excludes,
+            transformRequestFunction: (requestOptions) => {
+                requestOptions.userData ??= {};
+                requestOptions.userData[META_KEY] = {
+                    parentRequestId: request.id || request.uniqueKey,
+                    depth: currentDepth + 1,
+                };
+
+                requestOptions.useExtendedUniqueKey = true;
+                requestOptions.keepUrlFragment = this.input.keepUrlFragments;
+                return requestOptions;
+            },
+        };
+
+        if (this.input.linkSelector) {
+            await enqueueLinks({ ...enqueueOptions, selector: this.input.linkSelector });
+        }
+    }
+
+    private async _handleResult(request: Request, response?: Response, pageFunctionResult?: Dictionary, isError?: boolean) {
+        const payload = tools.createDatasetPayload(request, response, pageFunctionResult, isError);
+        await this.dataset.pushData(payload);
+        this.pagesOutputted++;
+    }
+}

--- a/packages/actor-scraper/camoufox-scraper/src/main.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/main.ts
@@ -1,0 +1,5 @@
+import { runActor } from '@apify/scraper-tools';
+
+import { CrawlerSetup } from './internals/crawler_setup.js';
+
+runActor(CrawlerSetup);

--- a/packages/actor-scraper/camoufox-scraper/tsconfig.json
+++ b/packages/actor-scraper/camoufox-scraper/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@apify/tsconfig",
+	"compilerOptions": {
+		"outDir": "dist",
+		"module": "ESNext",
+		"allowJs": true,
+		"skipLibCheck": true
+	},
+	"include": ["src"]
+}


### PR DESCRIPTION
Adds a Playwright Scraper port that uses Camoufox as the browser backend [via Camoufox JS](https://github.com/apify/camoufox-js/)).

This PR removes the original `useChrome` and `browserLauncher` options from the new input schema (as the only available browser is now Camoufox) and adds a `Camoufox options` input section, which maps to the [options that can be passed to Camoufox](https://github.com/apify/camoufox-js/blob/286debe0171ad2b1870ac23869b68b1e4f16e47a/src/utils.ts#L300).