### PR TITLE
fix: don't process `null` / `undefined` pageFunction results

### DIFF
--- a/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
@@ -470,6 +470,8 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         pageFunctionResult?: Dictionary,
         isError?: boolean,
     ) {
+        if (!pageFunctionResult) return;
+
         const payload = tools.createDatasetPayload(
             request,
             response,

--- a/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
@@ -442,6 +442,8 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         pageFunctionResult?: Dictionary,
         isError?: boolean,
     ) {
+        if (!pageFunctionResult) return;
+
         const payload = tools.createDatasetPayload(
             request,
             response,

--- a/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
@@ -437,6 +437,8 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         pageFunctionResult?: Dictionary,
         isError?: boolean,
     ) {
+        if (!pageFunctionResult) return;
+
         const payload = tools.createDatasetPayload(
             request,
             response,

--- a/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
@@ -514,6 +514,8 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         pageFunctionResult?: Dictionary,
         isError?: boolean,
     ) {
+        if (!pageFunctionResult) return;
+
         const payload = tools.createDatasetPayload(
             request,
             response,

--- a/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
@@ -518,6 +518,8 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         pageFunctionResult?: Dictionary,
         isError?: boolean,
     ) {
+        if (!pageFunctionResult) return;
+
         const payload = tools.createDatasetPayload(
             request,
             response,

--- a/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
@@ -728,6 +728,8 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         pageFunctionResult?: Dictionary,
         isError?: boolean,
     ) {
+        if (!pageFunctionResult) return;
+
         const start = process.hrtime();
         const payload = tools.createDatasetPayload(
             request,


### PR DESCRIPTION
Early returns from `_handleResult` on a nullish result. Saves Dataset API calls.

Closes #353. 