### PR TITLE
chore: align generic scraper defaults with new `crawlee.dev` structure

### DIFF
--- a/packages/actor-scraper/camoufox-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/camoufox-scraper/INPUT_SCHEMA.json
@@ -10,7 +10,7 @@
             "title": "Start URLs",
             "type": "array",
             "description": "URLs to start with",
-            "prefill": [{ "url": "https://crawlee.dev" }],
+            "prefill": [{ "url": "https://crawlee.dev/js" }],
             "editor": "requestListSources"
         },
         "globs": {
@@ -21,7 +21,7 @@
             "default": [],
             "prefill": [
                 {
-                    "glob": "https://crawlee.dev/*/*"
+                    "glob": "https://crawlee.dev/js/*/*"
                 }
             ]
         },

--- a/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
@@ -9,7 +9,7 @@
             "title": "Start URLs",
             "type": "array",
             "description": "A static list of URLs to scrape. <br><br>For details, see the <a href='https://apify.com/apify/cheerio-scraper#start-urls' target='_blank' rel='noopener'>Start URLs</a> section in the README.",
-            "prefill": [{ "url": "https://crawlee.dev" }],
+            "prefill": [{ "url": "https://crawlee.dev/js" }],
             "editor": "requestListSources"
         },
         "keepUrlFragments": {
@@ -34,7 +34,7 @@
             "default": [],
             "prefill": [
                 {
-                    "glob": "https://crawlee.dev/*/*"
+                    "glob": "https://crawlee.dev/js/*/*"
                 }
             ]
         },

--- a/packages/actor-scraper/jsdom-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/jsdom-scraper/INPUT_SCHEMA.json
@@ -9,7 +9,7 @@
             "title": "Start URLs",
             "type": "array",
             "description": "A static list of URLs to scrape. <br><br>For details, see the <a href='https://apify.com/apify/jsdom-scraper#start-urls' target='_blank' rel='noopener'>Start URLs</a> section in the README.",
-            "prefill": [{ "url": "https://crawlee.dev" }],
+            "prefill": [{ "url": "https://crawlee.dev/js" }],
             "editor": "requestListSources"
         },
         "keepUrlFragments": {
@@ -34,7 +34,7 @@
             "default": [],
             "prefill": [
                 {
-                    "glob": "https://crawlee.dev/*/*"
+                    "glob": "https://crawlee.dev/js/*/*"
                 }
             ]
         },

--- a/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
@@ -9,7 +9,7 @@
             "title": "Start URLs",
             "type": "array",
             "description": "URLs to start with",
-            "prefill": [{ "url": "https://crawlee.dev" }],
+            "prefill": [{ "url": "https://crawlee.dev/js" }],
             "editor": "requestListSources"
         },
         "globs": {
@@ -20,7 +20,7 @@
             "default": [],
             "prefill": [
                 {
-                    "glob": "https://crawlee.dev/*/*"
+                    "glob": "https://crawlee.dev/js/*/*"
                 }
             ]
         },

--- a/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
@@ -9,7 +9,7 @@
             "title": "Start URLs",
             "type": "array",
             "description": "URLs to start with",
-            "prefill": [{ "url": "https://crawlee.dev" }],
+            "prefill": [{ "url": "https://crawlee.dev/js" }],
             "editor": "requestListSources"
         },
         "globs": {
@@ -20,7 +20,7 @@
             "default": [],
             "prefill": [
                 {
-                    "glob": "https://crawlee.dev/*/*"
+                    "glob": "https://crawlee.dev/js/*/*"
                 }
             ]
         },

--- a/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
@@ -18,7 +18,7 @@
             "title": "Start URLs",
             "type": "array",
             "description": "A static list of URLs to scrape. <br><br>For details, see <a href='https://apify.com/apify/web-scraper#start-urls' target='_blank' rel='noopener'>Start URLs</a> in README.",
-            "prefill": [{ "url": "https://crawlee.dev" }],
+            "prefill": [{ "url": "https://crawlee.dev/js" }],
             "editor": "requestListSources"
         },
         "keepUrlFragments": {
@@ -50,7 +50,7 @@
             "default": [],
             "prefill": [
                 {
-                    "glob": "https://crawlee.dev/*/*"
+                    "glob": "https://crawlee.dev/js/*/*"
                 }
             ]
         },


### PR DESCRIPTION
Because of the recent Crawlee homepage redesign, the generic Actors only scrape one webpage (`crawlee.dev`) and stop now. This PR appends `/js/` to the respective input options and restores the original behaviour.

| ![image](https://github.com/user-attachments/assets/f14ce62d-1544-4b89-90f4-200d85dcb117) |
|--|
| *Default behaviour now* |
