### PR TITLE
fix: prefer proxy password from env var

### DIFF
--- a/packages/apify/src/proxy_configuration.ts
+++ b/packages/apify/src/proxy_configuration.ts
@@ -418,52 +418,47 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * Checks if Apify Token is provided in env and gets the password via API and sets it to env
      */
     protected async _setPasswordIfToken(): Promise<void> {
-        const token = this.config.get('token');
+        if (!this.password) {
+            const token = this.config.get('token');
 
-        if (token) {
-            let proxy: UserProxy;
+            if (token) {
+                let proxy: UserProxy;
 
-            try {
-                const user = await Actor.apifyClient.user().get();
-                proxy = user.proxy!;
-            } catch (error) {
-                if (Actor.isAtHome()) {
-                    throw error;
-                } else {
-                    this.log.warning(
-                        `Failed to fetch user data based on token, disabling proxy.`,
-                        { error },
-                    );
-                    return;
+                try {
+                    const user = await Actor.apifyClient.user().get();
+                    proxy = user.proxy!;
+                } catch (error) {
+                    if (Actor.isAtHome()) {
+                        throw error;
+                    } else {
+                        this.log.warning(
+                            `Failed to fetch user data based on token, disabling proxy.`,
+                            { error },
+                        );
+                        return;
+                    }
                 }
-            }
 
-            const { password } = proxy!;
+                const { password } = proxy!;
 
-            if (this.password) {
-                if (this.password !== password) {
-                    this.log.warning(
-                        'The Apify Proxy password you provided belongs to' +
-                            ' a different user than the Apify token you are using. Are you sure this is correct?',
-                    );
-                }
-            } else {
                 this.password = password;
             }
-        }
 
-        if (!this.password) {
-            if (Actor.isAtHome()) {
-                throw new Error(
-                    `Apify Proxy password must be provided using options.password or the "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
-                        `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, the password will be automatically inferred.`,
-                );
-            } else {
-                this.log.warning(
-                    `No proxy password or token detected, running without proxy. To use Apify Proxy locally, ` +
-                        `provide options.password or "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
-                        `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, the password will be automatically inferred.`,
-                );
+            if (!this.password) {
+                if (Actor.isAtHome()) {
+                    throw new Error(
+                        `Apify Proxy password must be provided using options.password or the "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
+                            `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
+                            `while not providing "${APIFY_ENV_VARS.PROXY_PASSWORD}", the password will be automatically inferred.`,
+                    );
+                } else {
+                    this.log.warning(
+                        `No proxy password or token detected, running without proxy. To use Apify Proxy locally, ` +
+                            `provide options.password or "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
+                            `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
+                            `while not providing "${APIFY_ENV_VARS.PROXY_PASSWORD}", the password will be automatically inferred.`,
+                    );
+                }
             }
         }
     }

--- a/packages/apify/src/proxy_configuration.ts
+++ b/packages/apify/src/proxy_configuration.ts
@@ -418,47 +418,46 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * Checks if Apify Token is provided in env and gets the password via API and sets it to env
      */
     protected async _setPasswordIfToken(): Promise<void> {
-        if (!this.password) {
-            const token = this.config.get('token');
+        if (this.password) return;
+        const token = this.config.get('token');
 
-            if (token) {
-                let proxy: UserProxy;
+        if (token) {
+            let proxy: UserProxy;
 
-                try {
-                    const user = await Actor.apifyClient.user().get();
-                    proxy = user.proxy!;
-                } catch (error) {
-                    if (Actor.isAtHome()) {
-                        throw error;
-                    } else {
-                        this.log.warning(
-                            `Failed to fetch user data based on token, disabling proxy.`,
-                            { error },
-                        );
-                        return;
-                    }
-                }
-
-                const { password } = proxy!;
-
-                this.password = password;
-            }
-
-            if (!this.password) {
+            try {
+                const user = await Actor.apifyClient.user().get();
+                proxy = user.proxy!;
+            } catch (error) {
                 if (Actor.isAtHome()) {
-                    throw new Error(
-                        `Apify Proxy password must be provided using options.password or the "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
-                            `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
-                            `while not providing "${APIFY_ENV_VARS.PROXY_PASSWORD}", the password will be automatically inferred.`,
-                    );
+                    throw error;
                 } else {
                     this.log.warning(
-                        `No proxy password or token detected, running without proxy. To use Apify Proxy locally, ` +
-                            `provide options.password or "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
-                            `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
-                            `while not providing "${APIFY_ENV_VARS.PROXY_PASSWORD}", the password will be automatically inferred.`,
+                        `Failed to fetch user data based on token, disabling proxy.`,
+                        { error },
                     );
+                    return;
                 }
+            }
+
+            const { password } = proxy!;
+
+            this.password = password;
+        }
+
+        if (!this.password) {
+            if (Actor.isAtHome()) {
+                throw new Error(
+                    `Apify Proxy password must be provided using options.password or the "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
+                        `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
+                        `while not providing "${APIFY_ENV_VARS.PROXY_PASSWORD}", the password will be automatically inferred.`,
+                );
+            } else {
+                this.log.warning(
+                    `No proxy password or token detected, running without proxy. To use Apify Proxy locally, ` +
+                        `provide options.password or "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
+                        `If you add the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
+                        `while not providing "${APIFY_ENV_VARS.PROXY_PASSWORD}", the password will be automatically inferred.`,
+                );
             }
         }
     }

--- a/packages/apify/src/proxy_configuration.ts
+++ b/packages/apify/src/proxy_configuration.ts
@@ -267,14 +267,14 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
                 if (Actor.isAtHome()) {
                     throw new Error(
                         `Apify Proxy password must be provided using options.password or the "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
-                            `You can also provide your Apify token via the "${APIFY_ENV_VARS.TOKEN}" environment variable,` +
+                            `You can also provide your Apify token via the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
                             `so that the SDK can fetch the proxy password from Apify API, when ${APIFY_ENV_VARS.PROXY_PASSWORD} is not defined`,
                     );
                 } else {
                     this.log.warning(
                         `No proxy password or token detected, running without proxy. To use Apify Proxy locally, ` +
                             `provide options.password or "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
-                            `You can also provide your Apify token via the "${APIFY_ENV_VARS.TOKEN}" environment variable,` +
+                            `You can also provide your Apify token via the "${APIFY_ENV_VARS.TOKEN}" environment variable, ` +
                             `so that the SDK can fetch the proxy password from Apify API, when ${APIFY_ENV_VARS.PROXY_PASSWORD} is not defined`,
                     );
                 }

--- a/packages/apify/src/proxy_configuration.ts
+++ b/packages/apify/src/proxy_configuration.ts
@@ -435,7 +435,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
     }
 
     /**
-     * Checks if proxy passowrd is provided in env, if not, fetches it from API using Apify Token
+     * Checks if proxy password is provided in env, if not, fetches it from API using Apify Token
      */
     // TODO: Make this private
     protected async _setPasswordIfToken(): Promise<void> {

--- a/test/apify/proxy_configuration.test.ts
+++ b/test/apify/proxy_configuration.test.ts
@@ -619,7 +619,7 @@ describe('Actor.createProxyConfiguration()', () => {
         getUserSpy.mockRestore();
     });
 
-    test('should show warning log', async () => {
+    test.skip('should show warning log', async () => {
         process.env.APIFY_TOKEN = '123456789';
 
         const getUserSpy = vitest.spyOn(UserClient.prototype, 'get');
@@ -639,6 +639,18 @@ describe('Actor.createProxyConfiguration()', () => {
         logMock.mockRestore();
         getUserSpy.mockRestore();
         gotScrapingSpy.mockRestore();
+    });
+
+    test(`shouldn't request password from API when both PROXY_PASSWORD and TOKEN envs are provided`, async () => {
+        process.env[APIFY_ENV_VARS.TOKEN] = 'some_token';
+        process.env[APIFY_ENV_VARS.PROXY_PASSWORD] = 'proxy_password';
+
+        const getUserSpy = vitest.spyOn(UserClient.prototype, 'get');
+        const proxyConfiguration = new ProxyConfiguration();
+        await proxyConfiguration.initialize();
+        expect(getUserSpy).toBeCalledTimes(0);
+
+        getUserSpy.mockRestore();
     });
 
     // TODO: test that on platform we throw but locally we only print warning

--- a/test/apify/proxy_configuration.test.ts
+++ b/test/apify/proxy_configuration.test.ts
@@ -619,28 +619,6 @@ describe('Actor.createProxyConfiguration()', () => {
         getUserSpy.mockRestore();
     });
 
-    test.skip('should show warning log', async () => {
-        process.env.APIFY_TOKEN = '123456789';
-
-        const getUserSpy = vitest.spyOn(UserClient.prototype, 'get');
-        const status = { connected: true };
-        const fakeUserData = {
-            proxy: { password: 'some-other-users-password' },
-        };
-        getUserSpy.mockResolvedValueOnce(fakeUserData as any);
-        gotScrapingSpy.mockResolvedValueOnce({ body: status } as any);
-
-        const proxyConfiguration = new ProxyConfiguration(basicOpts);
-        // @ts-expect-error
-        const logMock = vitest.spyOn(proxyConfiguration.log, 'warning');
-        await proxyConfiguration.initialize();
-        expect(logMock).toBeCalledTimes(1);
-
-        logMock.mockRestore();
-        getUserSpy.mockRestore();
-        gotScrapingSpy.mockRestore();
-    });
-
     test(`shouldn't request password from API when both PROXY_PASSWORD and TOKEN envs are provided`, async () => {
         process.env[APIFY_ENV_VARS.TOKEN] = 'some_token';
         process.env[APIFY_ENV_VARS.PROXY_PASSWORD] = 'proxy_password';


### PR DESCRIPTION
- Fetch proxy password from `/user/me` using `APIFY_ENV_VARS.TOKEN` only when `APIFY_ENV_VARS.PROXY_PASSWORD` is not provided
- Proxy init no longer logs when there is a difference between the proxy password from the environmental variable and the one obtained from the API, since only one is going to be taken into consideration. When running on Apify, the passwords will always be different. 
- should solve the second part of: https://console.apify.com/actors/RB9HEZitC8hIUXAha/issues/exVPDR4pOsgqlkE5T

Closes [#20502](https://github.com/apify/apify-core/issues/20502)