### PR TITLE
chore: update apify/input_secrets version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
             "devDependencies": {
                 "@apify/consts": "^2.29.0",
                 "@apify/eslint-config": "^1.0.0",
-                "@apify/input_secrets": "^1.1.53",
+                "@apify/input_secrets": "^1.2.0",
                 "@apify/tsconfig": "^0.1.0",
                 "@commitlint/config-conventional": "^19.2.2",
                 "@playwright/browser-chromium": "^1.46.0",
@@ -46,10 +46,9 @@
             }
         },
         "node_modules/@apify/consts": {
-            "version": "2.41.0",
-            "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.41.0.tgz",
-            "integrity": "sha512-qz1/e/VhjSssScWHas4s/1TN7u5Hbizt8K416p7bsWoppO2DDrNqzNNTdcLyXjTnbDpuGSHjkEObs5QyFm8RZg==",
-            "license": "Apache-2.0"
+            "version": "2.43.0",
+            "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.43.0.tgz",
+            "integrity": "sha512-6bhzXeftGa+MrO0XwHLLBJyP9Vc2gZXsbk3d8rcDmiEMJwChA+Qw1WD6BWI9zVazPeXb2OrjzOwfe05f59RD4g=="
         },
         "node_modules/@apify/datastructures": {
             "version": "2.0.3",
@@ -86,23 +85,21 @@
             }
         },
         "node_modules/@apify/input_secrets": {
-            "version": "1.1.72",
-            "resolved": "https://registry.npmjs.org/@apify/input_secrets/-/input_secrets-1.1.72.tgz",
-            "integrity": "sha512-rmamFRMZvgijmeQOSNAd+0U1IgnSQrqLa75mnprdHA8fyC1RXpvja9vR29tX9vtzm9U2+OMDyirKfKWFrWh1aw==",
-            "license": "Apache-2.0",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@apify/input_secrets/-/input_secrets-1.2.0.tgz",
+            "integrity": "sha512-h9sycwqruX3Eo7az9C0oZLxxorRuCTwm5etlbuAwrTrL2S1Bh5C4WHLdOy/FlzQ80LxoUJXPVE4csn3uobO6KA==",
             "dependencies": {
-                "@apify/log": "^2.5.18",
-                "@apify/utilities": "^2.15.5",
+                "@apify/log": "^2.5.20",
+                "@apify/utilities": "^2.16.2",
                 "ow": "^0.28.2"
             }
         },
         "node_modules/@apify/log": {
-            "version": "2.5.18",
-            "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.18.tgz",
-            "integrity": "sha512-pCh8GvO+Z6JTP8gQHAv1m1niO7RCubeVwF6e4ZDaeG91AhOFoIXxygLX28TfemLu6fEFmHIZyA06OGHiW4vcbQ==",
-            "license": "Apache-2.0",
+            "version": "2.5.20",
+            "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.20.tgz",
+            "integrity": "sha512-iLdKvzE4jluHtJyb/USjO/ygyT2HcgJvX0EdFZpo8V3q8jwgWmjW/jkfnDUZdecyNo948yqFEwxcxA9upZ4hug==",
             "dependencies": {
-                "@apify/consts": "^2.41.0",
+                "@apify/consts": "^2.43.0",
                 "ansi-colors": "^4.1.1"
             }
         },
@@ -148,13 +145,12 @@
             "license": "Apache-2.0"
         },
         "node_modules/@apify/utilities": {
-            "version": "2.15.5",
-            "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.15.5.tgz",
-            "integrity": "sha512-9jgKiuDYxYjPXXl5vQ5garbsf5hSiqKGTNF3U2iOe3zSnz6FLKIClZiG493sF1yCI08PzAwsYYuKL44lC+Kp6A==",
-            "license": "Apache-2.0",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.16.2.tgz",
+            "integrity": "sha512-CyK+H4Q2w5U06qFd1+1edYg7oA2MnncTRKwbctLawEYcSasEgtX+dUnBVi+IFRCj+ArVUlsR2Fj2Cigfju4ZIQ==",
             "dependencies": {
-                "@apify/consts": "^2.41.0",
-                "@apify/log": "^2.5.18"
+                "@apify/consts": "^2.43.0",
+                "@apify/log": "^2.5.20"
             }
         },
         "node_modules/@asamuzakjp/css-color": {
@@ -20300,7 +20296,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@apify/consts": "^2.23.0",
-                "@apify/input_secrets": "^1.1.40",
+                "@apify/input_secrets": "^1.2.0",
                 "@apify/log": "^2.4.3",
                 "@apify/timeout": "^0.3.0",
                 "@apify/utilities": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "devDependencies": {
         "@apify/consts": "^2.29.0",
         "@apify/eslint-config": "^1.0.0",
-        "@apify/input_secrets": "^1.1.53",
+        "@apify/input_secrets": "^1.2.0",
         "@apify/tsconfig": "^0.1.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@playwright/browser-chromium": "^1.46.0",

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -55,7 +55,7 @@
     },
     "dependencies": {
         "@apify/consts": "^2.23.0",
-        "@apify/input_secrets": "^1.1.40",
+        "@apify/input_secrets": "^1.2.0",
         "@apify/log": "^2.4.3",
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.13.0",


### PR DESCRIPTION
To support decryption of secret object/array - https://github.com/apify/apify-shared-js/pull/515