### PR TITLE
fix: force quit stuck `Actor.exit()` calls

### DIFF
--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -329,7 +329,7 @@ export const EXIT_CODES = {
  */
 export class Actor<Data extends Dictionary = Dictionary> {
     /** @internal */
-     
+    // eslint-disable-next-line no-use-before-define -- self-reference
     static _instance: Actor;
 
     /**

--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -329,7 +329,7 @@ export const EXIT_CODES = {
  */
 export class Actor<Data extends Dictionary = Dictionary> {
     /** @internal */
-    // eslint-disable-next-line no-use-before-define -- self-reference
+     
     static _instance: Actor;
 
     /**
@@ -553,6 +553,15 @@ export class Actor<Data extends Dictionary = Dictionary> {
         log.debug(
             `Waiting for all event listeners to complete their execution (with ${options.timeoutSecs} seconds timeout)`,
         );
+
+        if (options.exit) {
+            // `addTimeoutToPromise` is a cooperative timeout. This ensures that the process exits
+            // after the timeout, even if the event listeners are still running.
+            setTimeout(() => {
+                process.exit(options.exitCode!);
+            }, options.timeoutSecs * 1000);
+        }
+
         await addTimeoutToPromise(
             async () => {
                 await events.waitForAllListenersToComplete();


### PR DESCRIPTION
Encountered in https://console.apify.com/view/runs/ZlPUJOjFTsIHzH8dP

<img width="1581" height="481" alt="image" src="https://github.com/user-attachments/assets/38b03740-94c5-480c-b396-b7c93567a2d0" />

`WARN  Main crawler finished successfully, exiting the run...` is the last log line before the `Actor.exit()` call. The internals of the call seem to be blocking execution for ~1 hour, before the Platform migrates.

These changes place the `process.exit()` call into the event loop before any potentially time-consuming operations.