### PR TITLE
chore: render `CHANGELOG.md` file in the docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,6 +40,7 @@ module.exports = {
         [
             '@apify/docs-theme',
             {
+                changelogFromRoot: true,
                 subNavbar: {
                     title: 'SDK for JavaScript',
                     items: [


### PR DESCRIPTION
Uses the `git-cliff`-generated CHANGELOG.md file from the root of the repository to render the changelog in the docs. This unifies all the changelogs and simplifies the docs rendering process.

Closes #417 