### PR TITLE
docs: Shorten long generated descriptions

### DIFF
--- a/website/versioned_docs/version-2.3/api/Configuration.md
+++ b/website/versioned_docs/version-2.3/api/Configuration.md
@@ -1,6 +1,7 @@
 ---
 id: configuration
 title: Configuration
+description: Configuration is a value object holding the SDK configuration.
 ---
 
 <a name="configuration"></a>
@@ -128,7 +129,7 @@ instance.
 Caching works based on the API URL and token, so calling this method with different options will return multiple instances, one for each variant of
 the options.
 
-**Internal**:  
+**Internal**:
 **Parameters**:
 
 - **`[options]`**: `object`
@@ -153,7 +154,7 @@ instance.
 Caching works based on the `storageDir` option, so calling this method with different `storageDir` will return multiple instances, one for each
 directory.
 
-**Internal**:  
+**Internal**:
 **Parameters**:
 
 - **`[options]`**: `object`
@@ -172,7 +173,7 @@ directory.
 
 Creates an instance of ApifyClient using options as defined in the environment variables or in this `Configuration` instance.
 
-**Internal**:  
+**Internal**:
 **Parameters**:
 
 - **`[options]`**: `object`
@@ -192,7 +193,7 @@ Creates an instance of ApifyClient using options as defined in the environment v
 
 Creates an instance of ApifyStorageLocal using options as defined in the environment variables or in this `Configuration` instance.
 
-**Internal**:  
+**Internal**:
 **Parameters**:
 
 - **`[options]`**: `object`

--- a/website/versioned_docs/version-2.3/api/Dataset.md
+++ b/website/versioned_docs/version-2.3/api/Dataset.md
@@ -1,6 +1,7 @@
 ---
 id: dataset
 title: Dataset
+description: The Dataset class represents a store for structured data where each object stored has the same attributes, such as online store products or real estate offers.
 ---
 
 <a name="dataset"></a>

--- a/website/versioned_docs/version-2.3/api/RequestQueue.md
+++ b/website/versioned_docs/version-2.3/api/RequestQueue.md
@@ -1,6 +1,7 @@
 ---
 id: request-queue
 title: RequestQueue
+description: Represents a queue of URLs to crawl, which is used for deep crawling of websites where you start with several URLs and then recursively follow links to other pages.
 ---
 
 <a name="requestqueue"></a>

--- a/website/versioned_docs/version-2.3/api/log.md
+++ b/website/versioned_docs/version-2.3/api/log.md
@@ -1,6 +1,7 @@
 ---
 id: log
 title: utils.log
+description: The log instance enables level aware logging of messages and we advise to use it instead of `console.log()`.
 ---
 
 <a name="log"></a>

--- a/website/versioned_docs/version-2.3/typedefs/ProxyInfo.md
+++ b/website/versioned_docs/version-2.3/typedefs/ProxyInfo.md
@@ -1,6 +1,7 @@
 ---
 id: proxy-info
 title: ProxyInfo
+description: The main purpose of the ProxyInfo object is to provide information about the current proxy connection used by the crawler for the request.
 ---
 
 <a name="proxyinfo"></a>
@@ -11,10 +12,9 @@ crawlers, you can get this object by calling [`ProxyConfiguration.newProxyInfo`]
 **Example usage:**
 
 ```javascript
-
 const proxyConfiguration = await Apify.createProxyConfiguration({
-  groups: ['GROUP1', 'GROUP2'] // List of Apify Proxy groups
-  countryCode: 'US',
+    groups: ['GROUP1', 'GROUP2'], // List of Apify Proxy groups
+    countryCode: 'US',
 });
 
 // Getting proxyInfo object by calling class method directly
@@ -22,17 +22,16 @@ const proxyInfo = proxyConfiguration.newProxyInfo();
 
 // In crawler
 const crawler = new Apify.CheerioCrawler({
-  // ...
-  proxyConfiguration,
-  handlePageFunction: ({ proxyInfo }) => {
-     // Getting used proxy URL
-      const proxyUrl = proxyInfo.url;
+    // ...
+    proxyConfiguration,
+    handlePageFunction: ({ proxyInfo }) => {
+        // Getting used proxy URL
+        const proxyUrl = proxyInfo.url;
 
-     // Getting ID of used Session
-      const sessionIdentifier = proxyInfo.sessionId;
-  }
-})
-
+        // Getting ID of used Session
+        const sessionIdentifier = proxyInfo.sessionId;
+    },
+});
 ```
 
 ## Properties


### PR DESCRIPTION
Part of apify/apify-docs#1783

As some descriptions contains code and are multiline (even 20 or more lines), I've used description prop for affected files.