### PR TITLE
fix: setting `maxPagesPerCrawl` to 0 sets no limit

### DIFF
--- a/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/camoufox-scraper/src/internals/crawler_setup.ts
@@ -241,7 +241,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             respectRobotsTxtFile: this.input.respectRobotsTxtFile,
             maxConcurrency: this.input.maxConcurrency,
             maxRequestRetries: this.input.maxRequestRetries,
-            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            maxRequestsPerCrawl:
+                this.input.maxPagesPerCrawl === 0
+                    ? undefined
+                    : this.input.maxPagesPerCrawl,
             proxyConfiguration: (await Actor.createProxyConfiguration(
                 this.input.proxyConfiguration,
             )) as any as ProxyConfiguration,

--- a/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
@@ -231,7 +231,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             failedRequestHandler: this._failedRequestHandler.bind(this),
             respectRobotsTxtFile: this.input.respectRobotsTxtFile,
             maxRequestRetries: this.input.maxRequestRetries,
-            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            maxRequestsPerCrawl:
+                this.input.maxPagesPerCrawl === 0
+                    ? undefined
+                    : this.input.maxPagesPerCrawl,
             additionalMimeTypes: this.input.additionalMimeTypes,
             autoscaledPoolOptions: {
                 maxConcurrency: this.input.maxConcurrency,

--- a/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
@@ -232,7 +232,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             failedRequestHandler: this._failedRequestHandler.bind(this),
             respectRobotsTxtFile: this.input.respectRobotsTxtFile,
             maxRequestRetries: this.input.maxRequestRetries,
-            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            maxRequestsPerCrawl:
+                this.input.maxPagesPerCrawl === 0
+                    ? undefined
+                    : this.input.maxPagesPerCrawl,
             additionalMimeTypes: this.input.additionalMimeTypes,
             autoscaledPoolOptions: {
                 maxConcurrency: this.input.maxConcurrency,

--- a/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
@@ -275,7 +275,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             respectRobotsTxtFile: this.input.respectRobotsTxtFile,
             maxConcurrency: this.input.maxConcurrency,
             maxRequestRetries: this.input.maxRequestRetries,
-            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            maxRequestsPerCrawl:
+                this.input.maxPagesPerCrawl === 0
+                    ? undefined
+                    : this.input.maxPagesPerCrawl,
             proxyConfiguration: (await Actor.createProxyConfiguration(
                 this.input.proxyConfiguration,
             )) as any as ProxyConfiguration,

--- a/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
@@ -272,7 +272,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             respectRobotsTxtFile: this.input.respectRobotsTxtFile,
             maxConcurrency: this.input.maxConcurrency,
             maxRequestRetries: this.input.maxRequestRetries,
-            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            maxRequestsPerCrawl:
+                this.input.maxPagesPerCrawl === 0
+                    ? undefined
+                    : this.input.maxPagesPerCrawl,
             proxyConfiguration: (await Actor.createProxyConfiguration(
                 this.input.proxyConfiguration,
             )) as any as ProxyConfiguration,

--- a/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
@@ -301,7 +301,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 ? MAX_CONCURRENCY_IN_DEVELOPMENT
                 : this.input.maxConcurrency,
             maxRequestRetries: this.input.maxRequestRetries,
-            maxRequestsPerCrawl: this.input.maxPagesPerCrawl,
+            maxRequestsPerCrawl:
+                this.input.maxPagesPerCrawl === 0
+                    ? undefined
+                    : this.input.maxPagesPerCrawl,
             proxyConfiguration: (await Actor.createProxyConfiguration(
                 this.input.proxyConfiguration,
             )) as any as ProxyConfiguration,


### PR DESCRIPTION
Due to optimizations in Crawlee (regarding the [RQ not enqueuing over user-set limits](https://github.com/apify/crawlee/blob/dc39cc223a90d0c97c60c5a715bdf524cc32bbac/packages/basic-crawler/src/internals/basic-crawler.ts#L1144-L1147)), using 0 as the "no limit" value for `maxRequestsPerCrawl` stopped working in the generic Actors. This PR handles this logic directly in the Actor, so we don't rely on undefined behaviour from Crawlee.

Closes #453 