### PR TITLE
chore(ci): fix failing e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@apify/consts": "^2.29.0",
                 "@apify/eslint-config": "^1.0.0",
                 "@apify/input_secrets": "^1.2.0",
+                "@apify/log": "^2.5.22",
                 "@apify/tsconfig": "^0.1.0",
                 "@commitlint/config-conventional": "^19.2.2",
                 "@playwright/browser-chromium": "^1.46.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "@apify/consts": "^2.29.0",
         "@apify/eslint-config": "^1.0.0",
         "@apify/input_secrets": "^1.2.0",
+        "@apify/log": "^2.5.22",
         "@apify/tsconfig": "^0.1.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@playwright/browser-chromium": "^1.46.0",

--- a/test/e2e/runScraperTests.mjs
+++ b/test/e2e/runScraperTests.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isMainThread, Worker, workerData } from 'node:worker_threads';
 
-import { log } from '@apify/log';
+import { default as log } from '@apify/log';
 
 import { clearStorage, colors, SKIPPED_TEST_CLOSE_CODE } from './tools.mjs';
 

--- a/test/e2e/scrapers/cheerio-default/test.mjs
+++ b/test/e2e/scrapers/cheerio-default/test.mjs
@@ -13,9 +13,9 @@ const { exit } = process;
 process.exit = () => {};
 
 await run(testDir, 'cheerio-scraper', {
-    startUrls: [{ url: 'https://crawlee.dev' }],
+    startUrls: [{ url: 'https://crawlee.dev/js/docs/guides/request-storage' }],
     keepUrlFragments: false,
-    globs: ['https://crawlee.dev/*/*'],
+    globs: ['https://crawlee.dev/js/docs/guides/**'],
     linkSelector: 'a',
     pageFunction: async function pageFunction(context) {
         const { $, request, log } = context;

--- a/test/e2e/scrapers/jsdom-default/test.mjs
+++ b/test/e2e/scrapers/jsdom-default/test.mjs
@@ -13,9 +13,9 @@ const { exit } = process;
 process.exit = () => {};
 
 await run(testDir, 'jsdom-scraper', {
-    startUrls: [{ url: 'https://crawlee.dev' }],
+    startUrls: [{ url: 'https://crawlee.dev/js/docs/guides/request-storage' }],
     keepUrlFragments: false,
-    globs: ['https://crawlee.dev/*/*'],
+    globs: ['https://crawlee.dev/js/docs/guides/**'],
     linkSelector: 'a',
     pageFunction: async function pageFunction(context) {
         const { window, request, log } = context;

--- a/test/e2e/scrapers/playwright-default/test.mjs
+++ b/test/e2e/scrapers/playwright-default/test.mjs
@@ -13,10 +13,10 @@ const { exit } = process;
 process.exit = () => {};
 
 await run(testDir, 'playwright-scraper', {
-    startUrls: [{ url: 'https://crawlee.dev' }],
-    globs: ['https://crawlee.dev/*/*'],
-    linkSelector: 'a',
+    startUrls: [{ url: 'https://crawlee.dev/js/docs/guides/request-storage' }],
     keepUrlFragments: false,
+    globs: ['https://crawlee.dev/js/docs/guides/**'],
+    linkSelector: 'a',
     pageFunction: async function pageFunction(context) {
         const { page, request, log } = context;
         const { url } = request;

--- a/test/e2e/scrapers/puppeteer-default/test.mjs
+++ b/test/e2e/scrapers/puppeteer-default/test.mjs
@@ -13,10 +13,10 @@ const { exit } = process;
 process.exit = () => {};
 
 await run(testDir, 'puppeteer-scraper', {
-    startUrls: [{ url: 'https://crawlee.dev' }],
-    pseudoUrls: [{ purl: 'https://crawlee.dev[(/[\\w-]+){2}]' }],
-    linkSelector: 'a',
+    startUrls: [{ url: 'https://crawlee.dev/js/docs/guides/request-storage' }],
     keepUrlFragments: false,
+    globs: ['https://crawlee.dev/js/docs/guides/**'],
+    linkSelector: 'a',
     pageFunction: async function pageFunction(context) {
         const { page, request, log } = context;
         const { url } = request;

--- a/test/e2e/scrapers/web-default/test.mjs
+++ b/test/e2e/scrapers/web-default/test.mjs
@@ -14,10 +14,10 @@ process.exit = () => {};
 
 await run(testDir, 'web-scraper', {
     runMode: 'PRODUCTION',
-    startUrls: [{ url: 'https://crawlee.dev' }],
-    pseudoUrls: [{ purl: 'https://crawlee.dev[(/[\\w-]+){2}]' }],
-    linkSelector: 'a[href]',
+    startUrls: [{ url: 'https://crawlee.dev/js/docs/guides/request-storage' }],
     keepUrlFragments: false,
+    globs: ['https://crawlee.dev/js/docs/guides/**'],
+    linkSelector: 'a[href]',
     pageFunction: async function pageFunction(context) {
         const $ = context.jQuery;
 

--- a/test/e2e/tools.mjs
+++ b/test/e2e/tools.mjs
@@ -166,7 +166,7 @@ export async function expect(bool, message) {
  * @param {string} reason
  */
 export async function skipTest(reason) {
-    log.warn(`[test skipped] ${reason}`);
+    log.warning(`[test skipped] ${reason}`);
     process.exit(SKIPPED_TEST_CLOSE_CODE);
 }
 


### PR DESCRIPTION
Fixes failing E2E tests (updates dependencies and edits the test assertions based on the current contents of `crawlee.dev`).

Closes #363 