### PR TITLE
fix: respect `forceCloud` in `KeyValueStore.getPublicUrl()` calls

### DIFF
--- a/packages/apify/src/key_value_store.ts
+++ b/packages/apify/src/key_value_store.ts
@@ -1,5 +1,6 @@
 import type { StorageManagerOptions } from '@crawlee/core';
 import { KeyValueStore as CoreKeyValueStore } from '@crawlee/core';
+import { KeyValueStoreClient as RemoteKeyValueStoreClient } from 'apify-client';
 
 import { createHmacSignature } from '@apify/utilities';
 
@@ -18,7 +19,13 @@ export class KeyValueStore extends CoreKeyValueStore {
      */
     override getPublicUrl(key: string): string {
         const config = this.config as Configuration;
-        if (!config.get('isAtHome') && getPublicUrl) {
+
+        const isLocalStore = !(
+            // eslint-disable-next-line dot-notation
+            this['client'] instanceof RemoteKeyValueStoreClient
+        );
+
+        if (isLocalStore && getPublicUrl) {
             return getPublicUrl.call(this, key);
         }
 


### PR DESCRIPTION
The original check from #302 was not sufficient. When the user passes `forceCloud: true` to `KVS.open()`, the SDK instance points to a platform-backed KVS, even if the script is run locally.

This PR proposes checking the runtime type of `KeyValueStore.client`. If this is a client instance from `apify-client`, we're communicating with the platform, regardless of the place of execution (Platform / locally).

Closes #459 