### PR TITLE
chore: bump `apify-client` version in `apify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4292,25 +4292,6 @@
             "resolved": "packages/apify",
             "link": true
         },
-        "node_modules/apify-client": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.16.0.tgz",
-            "integrity": "sha512-/9xbz0czQhXBUBZ6rTw4Hae4B2Zlro12511kadVeAUokWqolU0GmekQimkGlvIsi0vaj9NdmsjuPvyujWLDLxg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@apify/consts": "^2.25.0",
-                "@apify/log": "^2.2.6",
-                "@apify/utilities": "^2.18.0",
-                "@crawlee/types": "^3.3.0",
-                "agentkeepalive": "^4.2.1",
-                "async-retry": "^1.3.3",
-                "axios": "^1.6.7",
-                "content-type": "^1.0.5",
-                "ow": "^0.28.2",
-                "tslib": "^2.5.0",
-                "type-fest": "^4.0.0"
-            }
-        },
         "node_modules/aproba": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -19023,7 +19004,7 @@
                 "@crawlee/core": "^3.14.1",
                 "@crawlee/types": "^3.14.1",
                 "@crawlee/utils": "^3.14.1",
-                "apify-client": "^2.12.1",
+                "apify-client": "^2.17.0",
                 "fs-extra": "^11.2.0",
                 "ow": "^0.28.2",
                 "semver": "^7.5.4",
@@ -19032,6 +19013,25 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "packages/apify/node_modules/apify-client": {
+            "version": "2.17.0",
+            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.17.0.tgz",
+            "integrity": "sha512-fxYQD/aV75AFRo49Pzwcjz2V5o23H9LQ38DnFjjDtY6+anEN59sLva8oBRXgrTWCgDnQh6JlG9l0s769/1MiuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@apify/consts": "^2.42.0",
+                "@apify/log": "^2.2.6",
+                "@apify/utilities": "^2.18.0",
+                "@crawlee/types": "^3.3.0",
+                "agentkeepalive": "^4.2.1",
+                "async-retry": "^1.3.3",
+                "axios": "^1.6.7",
+                "content-type": "^1.0.5",
+                "ow": "^0.28.2",
+                "tslib": "^2.5.0",
+                "type-fest": "^4.0.0"
             }
         },
         "packages/scraper-tools": {

--- a/packages/apify/package.json
+++ b/packages/apify/package.json
@@ -62,7 +62,7 @@
         "@crawlee/core": "^3.14.1",
         "@crawlee/types": "^3.14.1",
         "@crawlee/utils": "^3.14.1",
-        "apify-client": "^2.12.1",
+        "apify-client": "^2.17.0",
         "fs-extra": "^11.2.0",
         "ow": "^0.28.2",
         "semver": "^7.5.4",


### PR DESCRIPTION
Makes use of the recent patches to `apify-client` in SDK.