### PR TITLE
feat: bump `apify-client` minimal version to `2.17.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "@types/semver": "^7.5.8",
                 "@types/tough-cookie": "^4.0.5",
                 "@types/ws": "^8.5.12",
+                "apify-client": "^2.17.0",
                 "commitlint": "^19.3.0",
                 "crawlee": "^3.13.5",
                 "eslint": "^9.23.0",
@@ -4291,6 +4292,25 @@
         "node_modules/apify": {
             "resolved": "packages/apify",
             "link": true
+        },
+        "node_modules/apify-client": {
+            "version": "2.17.0",
+            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.17.0.tgz",
+            "integrity": "sha512-fxYQD/aV75AFRo49Pzwcjz2V5o23H9LQ38DnFjjDtY6+anEN59sLva8oBRXgrTWCgDnQh6JlG9l0s769/1MiuQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@apify/consts": "^2.42.0",
+                "@apify/log": "^2.2.6",
+                "@apify/utilities": "^2.18.0",
+                "@crawlee/types": "^3.3.0",
+                "agentkeepalive": "^4.2.1",
+                "async-retry": "^1.3.3",
+                "axios": "^1.6.7",
+                "content-type": "^1.0.5",
+                "ow": "^0.28.2",
+                "tslib": "^2.5.0",
+                "type-fest": "^4.0.0"
+            }
         },
         "node_modules/aproba": {
             "version": "2.0.0",
@@ -19013,25 +19033,6 @@
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "packages/apify/node_modules/apify-client": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.17.0.tgz",
-            "integrity": "sha512-fxYQD/aV75AFRo49Pzwcjz2V5o23H9LQ38DnFjjDtY6+anEN59sLva8oBRXgrTWCgDnQh6JlG9l0s769/1MiuQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@apify/consts": "^2.42.0",
-                "@apify/log": "^2.2.6",
-                "@apify/utilities": "^2.18.0",
-                "@crawlee/types": "^3.3.0",
-                "agentkeepalive": "^4.2.1",
-                "async-retry": "^1.3.3",
-                "axios": "^1.6.7",
-                "content-type": "^1.0.5",
-                "ow": "^0.28.2",
-                "tslib": "^2.5.0",
-                "type-fest": "^4.0.0"
             }
         },
         "packages/scraper-tools": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "@types/semver": "^7.5.8",
         "@types/tough-cookie": "^4.0.5",
         "@types/ws": "^8.5.12",
+        "apify-client": "^2.17.0",
         "commitlint": "^19.3.0",
         "crawlee": "^3.13.5",
         "eslint": "^9.23.0",


### PR DESCRIPTION
Fixes failing CI tests by adding the recent `apify-client` patch to the root `package.json` too.