### PR TITLE
chore: fix PPE charge limit e2e test

### DIFF
--- a/test/e2e/sdk/actorCharge/test.mjs
+++ b/test/e2e/sdk/actorCharge/test.mjs
@@ -58,9 +58,9 @@ test('charge limit', async () => {
     assert.deepEqual(run.chargedEventCounts, { foobar: 2 });
 });
 
-test('default charge limit 0', async () => {
+test('default options start cost-unlimited runs', async () => {
     const run = await runActor({}, {});
 
     assert.strictEqual(run.status, 'SUCCEEDED');
-    assert.deepEqual(run.chargedEventCounts, { foobar: 0 });
+    assert.deepEqual(run.chargedEventCounts, { foobar: 4 });
 });


### PR DESCRIPTION
Originally, this test assumes that _passing no limit === spending no money_. Ever since I fixed the test last week, it's been failing, because apparently on Platform _passing no limit === unlimited spending_.

cc @novotnyj @stetizu1 could you help to shine some light on this? Is the current behavior correct? Has this changed semi-recently? Or was the original test plainly wrong?

Closes #458 