### PR TITLE
perf: don't await final status message

### DIFF
--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -583,10 +583,15 @@ export class Actor<Data extends Dictionary = Dictionary> {
                 }
 
                 if (options.statusMessage != null) {
-                    await this.setStatusMessage(options.statusMessage, {
-                        isStatusMessageTerminal: true,
-                        level: options.exitCode! > 0 ? 'ERROR' : 'INFO',
-                    });
+                    const statusMessagePromise = this.setStatusMessage(
+                        options.statusMessage,
+                        {
+                            isStatusMessageTerminal: true,
+                            level: options.exitCode! > 0 ? 'ERROR' : 'INFO',
+                        },
+                    );
+                    // Waiting 1ms is enough for the network request to be sent. We don't need to wait for the response.
+                    await Promise.race([statusMessagePromise, sleep(1)]);
                 }
             },
             options.timeoutSecs * 1000,


### PR DESCRIPTION
This saves about 25ms at the end of each run.

Related to discussion - https://github.com/apify/crawlee/pull/3207#issuecomment-3435494322

I did about 700 runs and it worked in each. Without any sleep it didn't print it on platform. The actual delay is about 2-3ms, which is probably the networking code executing. 