### PR TITLE
fix: set `runScripts` to `false` by default for JSDOM Scraper

### DIFF
--- a/packages/actor-scraper/jsdom-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/jsdom-scraper/INPUT_SCHEMA.json
@@ -68,8 +68,9 @@
         "runScripts": {
             "title": "Run scripts",
             "type": "boolean",
-            "default": true,
-            "description": "Whether to execute JavaScript in the downloaded page. If enabled, the JSDOM engine will process the JavaScript in the page as if it was loaded in a browser. This is useful for pages that use JavaScript to render the content, but it can also cause secuirty issues."
+            "default": false,
+            "prefill": false,
+            "description": "Whether to execute JavaScript in the downloaded page. If enabled, the JSDOM engine will process the JavaScript in the page as if it was loaded in a browser. This is useful for pages that use JavaScript to render the content.\n\n⚠️ Warning ⚠️\n\nThis option allows potentially malicious scripts to be executed in the context of the Actor. Only enable this option if you trust the target website."
         },
         "showInternalConsole": {
             "title": "Show internal console logs",

--- a/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/jsdom-scraper/src/internals/crawler_setup.ts
@@ -222,7 +222,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             proxyConfiguration: this.proxyConfiguration,
             requestHandler: this._requestHandler.bind(this),
             preNavigationHooks: [],
-            runScripts: this.input.runScripts ?? true,
+            runScripts: this.input.runScripts ?? false,
             hideInternalConsole: !(this.input.showInternalConsole ?? false),
             postNavigationHooks: [],
             requestQueue: this.requestQueue,


### PR DESCRIPTION
Sets `runScripts` input option of JSDOM Scraper to `false` by default. Adds a vulnerability warning to the tooltip of the option.