### PR TITLE
chore(ci): update jsdom-scraper build tag and version

### DIFF
--- a/.github/workflows/release-generic-actors.yaml
+++ b/.github/workflows/release-generic-actors.yaml
@@ -84,8 +84,8 @@ jobs:
                       development-build-tag: development
                       should-build: ${{ github.event.inputs.puppeteer-scraper }}
                     - actor: jsdom-scraper
-                      stable-version: '0.1'
-                      stable-build-tag: latest
+                      stable-version: '0.2'
+                      stable-build-tag: version-0
                       development-version: '0.0'
                       development-build-tag: development
                       should-build: ${{ github.event.inputs.jsdom-scraper }}


### PR DESCRIPTION
Bumps the "stable" JSDOM Scraper version to `version-0` to reflect the recent breaking change (#505 ) and align the tag naming with the other generic scrapers.