### PR TITLE
docs: link external symbols from the docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -138,6 +138,46 @@ module.exports = {
                 })),
                 typedocOptions: {
                     excludeExternals: false,
+                    externalSymbolLinkMappings: {
+                        '@crawlee/core': {
+                            Configuration:
+                                'https://crawlee.dev/js/api/core/class/Configuration',
+                            Dataset:
+                                'https://crawlee.dev/js/api/core/class/Dataset',
+                            DatasetExportOptions:
+                                'https://crawlee.dev/js/api/core/interface/DatasetExportOptions',
+                            DatasetExportToOptions:
+                                'https://crawlee.dev/js/api/core/interface/DatasetExportToOptions',
+                            EventManager:
+                                'https://crawlee.dev/js/api/core/class/EventManager',
+                            KeyValueStore:
+                                'https://crawlee.dev/js/api/core/class/KeyValueStore',
+                            StorageManagerOptions:
+                                'https://crawlee.dev/js/api/core/interface/StorageManagerOptions',
+                            ConfigurationOptions:
+                                'https://crawlee.dev/js/api/core/interface/ConfigurationOptions',
+                            EventManager:
+                                'https://crawlee.dev/js/api/core/interface/EventManager',
+                            RecordOptions:
+                                'https://crawlee.dev/js/api/core/interface/RecordOptions',
+                            UseStateOptions:
+                                'https://crawlee.dev/js/api/core/interface/UseStateOptions',
+                        },
+                        'apify-client': {
+                            ActorCallOptions:
+                                'https://docs.apify.com/api/client/js/reference/interface/ActorCallOptions',
+                            ActorStartOptions:
+                                'https://docs.apify.com/api/client/js/reference/interface/ActorStartOptions',
+                            ApifyClientOptions:
+                                'https://docs.apify.com/api/client/js/reference/interface/ApifyClientOptions',
+                            RunAbortOptions:
+                                'https://docs.apify.com/api/client/js/reference/interface/RunAbortOptions',
+                            TaskCallOptions:
+                                'https://docs.apify.com/api/client/js/reference/interface/TaskCallOptions',
+                            Webhook:
+                                'https://docs.apify.com/api/client/js/reference/interface/Webhook',
+                        },
+                    },
                 },
                 routeBasePath: 'reference',
             },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@apify/docs-theme": "^1.0.181",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.4.8",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.4.12",
                 "@apify/eslint-config": "^1.0.0",
                 "@docusaurus/core": "^3.8.1",
                 "@docusaurus/faster": "^3.8.1",
@@ -332,7 +332,6 @@
             "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.43.0.tgz",
             "integrity": "sha512-wKy6x6fKcnB1CsfeNNdGp4dzLzz04k8II3JLt6Sp81F8s57Ks3/K9qsysmL9SJa8P486s719bBttVLE8JJYurQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@algolia/client-common": "5.43.0",
                 "@algolia/requester-browser-xhr": "5.43.0",
@@ -2837,9 +2836,9 @@
             }
         },
         "node_modules/@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.4.8",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.4.8.tgz",
-            "integrity": "sha512-iAGPaFKXz5SBzhf+611bk41b2sBRXPPINQOegxd0tOXwGOopnkKfr0LAvJp1Hd1jZFrVJhjyDsVZ6HM7Wwh9zg==",
+            "version": "4.4.12",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.4.12.tgz",
+            "integrity": "sha512-xtjNeKJc9Crnz0RSwc9q1xikfjKHzjrdSnV8EGefxEsEhVyNDC1SfPzQGrkm8+AMSOZoskHTF7DOv3JNC52buw==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/codicons": "^0.0.35",
@@ -2932,7 +2931,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -4668,7 +4666,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -4691,7 +4688,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4801,7 +4797,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -5223,7 +5218,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -5990,7 +5984,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
             "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/babel": "3.9.2",
                 "@docusaurus/bundler": "3.9.2",
@@ -6079,7 +6072,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.2.tgz",
             "integrity": "sha512-DEVIwhbrZZ4ir31X+qQNEQqDWkgCJUV6kiPPAd2MGTY8n5/n0c4B8qA5k1ipF2izwH00JEf0h6Daaut71zzkyw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/types": "3.9.2",
                 "@rspack/core": "^1.5.0",
@@ -6116,7 +6108,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
             "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/logger": "3.9.2",
                 "@docusaurus/utils": "3.9.2",
@@ -6233,7 +6224,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
             "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/logger": "3.9.2",
@@ -6432,7 +6422,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
             "integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/plugin-content-blog": "3.9.2",
@@ -6575,7 +6564,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
             "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@mdx-js/mdx": "^3.0.0",
                 "@types/history": "^4.7.11",
@@ -6612,7 +6600,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
             "integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@docusaurus/logger": "3.9.2",
                 "@docusaurus/types": "3.9.2",
@@ -7328,7 +7315,6 @@
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
             "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0"
             },
@@ -8041,7 +8027,6 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -8146,7 +8131,6 @@
             "integrity": "sha512-8SnJV+JV0rYbfSiEiUvYOmf62E7QwsEG+aZueqSlKoxFt0pw333+bgZSQXGUV6etXU88nxur0afVMaINujBMSw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.25"
@@ -8845,7 +8829,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
             "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -9018,7 +9001,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
             "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.3",
                 "@typescript-eslint/types": "8.46.3",
@@ -9439,7 +9421,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -9525,7 +9506,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -9590,7 +9570,6 @@
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.43.0.tgz",
             "integrity": "sha512-hbkK41JsuGYhk+atBDxlcKxskjDCh3OOEDpdKZPtw+3zucBqhlojRG5e5KtCmByGyYvwZswVeaSWglgLn2fibg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@algolia/abtesting": "1.9.0",
                 "@algolia/client-abtesting": "5.43.0",
@@ -10265,7 +10244,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.19",
                 "caniuse-lite": "^1.0.30001751",
@@ -10713,7 +10691,6 @@
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
             "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -11250,7 +11227,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -12451,7 +12427,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
             "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -12591,7 +12566,6 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -16386,7 +16360,6 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
             "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -19903,7 +19876,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -20819,7 +20791,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -21709,7 +21680,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -21719,7 +21689,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -21777,7 +21746,8 @@
             "version": "19.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
             "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-json-view-lite": {
             "version": "2.5.0",
@@ -21797,7 +21767,6 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
             "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             },
@@ -22513,7 +22482,6 @@
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
             "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
@@ -23549,7 +23517,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -24589,7 +24556,6 @@
             "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
             "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/traverse": "^7.4.5",
@@ -25019,8 +24985,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -25207,7 +25172,6 @@
             "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.3.tgz",
             "integrity": "sha512-bAfgMavTuGo+8n6/QQDVQz4tZ4f7Soqg53RbrlZQEoAltYop/XR4RAts/I0BrO3TTClTSTFJ0wYbla+P8cEWJA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "8.46.3",
                 "@typescript-eslint/parser": "8.46.3",
@@ -25801,7 +25765,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
             "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -26542,7 +26505,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
             "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.181",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.4.8",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.4.12",
         "@apify/eslint-config": "^1.0.0",
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",


### PR DESCRIPTION
Links several interfaces / classes from Crawlee and `apify-client` in the API reference. Recent updates to `@apify/docusaurus-typedoc-api-plugin` allow rendering those as links in the built HTML.

The enumeration is not exhaustive, it's very possible I missed some interfaces / types.

Closes #283 