### PR TITLE
docs: Improve Docker image versioning guidance

### DIFF
--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -107,7 +107,9 @@ FROM apify/actor-node-playwright-chrome:24-1.52.0
 ```
 
 :::warning Version matching is important
+
 The version in `package.json` **must match** the version in the Docker image tag. If they don't match, npm will attempt to install a different version, which can cause compatibility issues with the pre-installed browser binaries.
+
 :::
 
 ### Alternative approach (using `*`)


### PR DESCRIPTION
See: https://apify.slack.com/archives/CQ96RHG2U/p1768757339018769

- Update best practices to recommend pinning both Node.js and automation library versions in Dockerfile tags and matching them in package.json for reproducible builds
- Add "Finding available tags" section with direct Docker Hub links for all images and a curl command to query tags programmatically
- Document the `*` approach as an alternative rather than the primary recommendation
- Add warning about version matching importance between Dockerfile and package.json