### PR TITLE
ci: auto-bump patch version for beta releases

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -24,14 +24,15 @@ function addBetaSuffixToVersion(version) {
     const versions = JSON.parse(versionString);
 
     if (versions.some((v) => v === version)) {
-        console.error(
-            `before-deploy: A release with version ${version} already exists. Please increment version accordingly.`,
+        const [major, minor, patch] = version.split('.').map(Number);
+        version = `${major}.${minor}.${patch + 1}`;
+        console.log(
+            `before-deploy: Version ${pkgJson.version} already exists on npm, bumping to ${version}`,
         );
-        process.exit(1);
     }
 
     const prereleaseNumbers = versions
-        .filter((v) => v.startsWith(version) && v.includes('-'))
+        .filter((v) => v.startsWith(`${version}-`) && v.includes('-'))
         .map((v) => Number(v.match(/\.(\d+)$/)[1]));
     const lastPrereleaseNumber = Math.max(-1, ...prereleaseNumbers);
     return `${version}-beta.${lastPrereleaseNumber + 1}`;


### PR DESCRIPTION
When the stable version already exists on npm, increment the patch version instead of failing. Also fix startsWith filter to prevent false prefix matches.

Fixes failing `beta` builds in CI ([example](https://github.com/apify/apify-sdk-js/actions/runs/21672902239/job/62485169092))

<img width="1457" height="899" alt="image" src="https://github.com/user-attachments/assets/88ec062d-8eeb-44fe-a1e9-e4705138ed69" />
<img width="870" height="205" alt="image" src="https://github.com/user-attachments/assets/d5134ef5-5611-40e4-b0a3-4ad5fae16541" />

Closes #550 