### PR TITLE
docs: add status message section to Actor lifecycle page

### DIFF
--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -13,6 +13,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 import MainSource from '!!raw-loader!./apify_platform_main.ts';
 import InitExitSource from '!!raw-loader!./apify_platform_init_exit.ts';
+import StatusMessageSource from '!!raw-loader!./code/status_message.ts';
 
 [Apify](https://apify.com) is a platform built to serve large-scale and high-performance web scraping
 and automation needs. It provides easy access to compute instances (_Actors_),
@@ -197,6 +198,18 @@ When the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> is stored on the 
 - [Key-value stores API reference](https://apify.com/docs/api/v2#/reference/key-value-stores)
 - [Datasets API reference](https://docs.apify.com/api/v2#/reference/datasets)
 - [Request queues API reference](https://docs.apify.com/api/v2#/reference/request-queues)
+
+## Status messages
+
+Status messages are human-readable messages that provide information about an Actor's progress. Unlike logs, status messages are visible at a glance in the Apify Console on the Actor run details page, making them useful for monitoring long-running Actors without digging through logs.
+
+Use [`Actor.setStatusMessage()`](https://sdk.apify.com/api/apify/class/Actor#setStatusMessage) to update the status message at meaningful milestones during your Actor's execution. Avoid updating it on every single item — focus on key transitions like starting a new phase, reaching a progress milestone, or completing the run.
+
+<CodeBlock language="js">{StatusMessageSource}</CodeBlock>
+
+The SDK only sends an API request when the status message actually changes, so you don't need to worry about duplicate updates.
+
+When your Actor finishes, you can mark the final status message as **terminal** using the `isStatusMessageTerminal` option. A terminal status message persists after the run completes, so users can see the final result at a glance.
 
 ## Environment variables
 

--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -201,7 +201,7 @@ When the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> is stored on the 
 
 ## Status messages
 
-[Status messages](/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console (separate from logs). Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results".
+[Status messages](https://docs.apify.com//platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console (separate from logs). Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results".
 
 Update the status only when the user's understanding of progress changes - avoid frequent updates for every processed item. Detailed information should go to logs or storages (Dataset, Key-value store) instead.
 

--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -201,15 +201,15 @@ When the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> is stored on the 
 
 ## Status messages
 
-Status messages are human-readable messages that provide information about an Actor's progress. Unlike logs, status messages are visible at a glance in the Apify Console on the Actor run details page, making them useful for monitoring long-running Actors without digging through logs.
+[Status messages](/platform/actors/development/programming-interface/status-messages) are lightweight, human-readable progress indicators displayed with the Actor run in the Apify Console (separate from logs). Use them to communicate high-level phases or milestones, such as "Fetching list", "Processed 120/500 pages", or "Uploading results".
 
-Use [`Actor.setStatusMessage()`](https://sdk.apify.com/api/apify/class/Actor#setStatusMessage) to update the status message at meaningful milestones during your Actor's execution. Avoid updating it on every single item — focus on key transitions like starting a new phase, reaching a progress milestone, or completing the run.
+Update the status only when the user's understanding of progress changes - avoid frequent updates for every processed item. Detailed information should go to logs or storages (Dataset, Key-value store) instead.
+
+Use <ApiLink to="class/Actor#setStatusMessage">`Actor.setStatusMessage()`</ApiLink> to set the message:
 
 <CodeBlock language="js">{StatusMessageSource}</CodeBlock>
 
-The SDK only sends an API request when the status message actually changes, so you don't need to worry about duplicate updates.
-
-When your Actor finishes, you can mark the final status message as **terminal** using the `isStatusMessageTerminal` option. A terminal status message persists after the run completes, so users can see the final result at a glance.
+The SDK only sends an API request when the message text changes, so repeating the same message incurs no additional cost.
 
 ## Environment variables
 

--- a/docs/02_concepts/code/status_message.ts
+++ b/docs/02_concepts/code/status_message.ts
@@ -1,0 +1,30 @@
+import { Actor } from 'apify';
+
+await Actor.init();
+
+// highlight-start
+await Actor.setStatusMessage('Fetching the list of URLs...');
+// highlight-end
+
+// Simulate some work
+const urls = [
+    'https://example.com/1',
+    'https://example.com/2',
+    'https://example.com/3',
+];
+
+for (let i = 0; i < urls.length; i++) {
+    // Process each URL...
+    // highlight-start
+    await Actor.setStatusMessage(`Processing ${i + 1} of ${urls.length} URLs`);
+    // highlight-end
+}
+
+// highlight-start
+// Mark the final status message as terminal
+await Actor.setStatusMessage('All URLs processed successfully!', {
+    isStatusMessageTerminal: true,
+});
+// highlight-end
+
+await Actor.exit();


### PR DESCRIPTION
I was going through apify-docs issues and noticed https://github.com/apify/apify-docs/issues/400.

This PR adds similar section as is already in Python docs & creates a new codeblock demonstrating the functionality.