### PR TITLE
ci: rebase before pushing release/version-docs commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,6 +122,7 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: 'chore(release): set package version to ${{ needs.release_metadata.outputs.version_number }} and update changelog [skip ci]'
+                  pull: '--rebase --autostash'
 
     create_github_release:
         name: Create github release
@@ -176,6 +177,9 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: 'docs: version docs for ${{ needs.update_changelog.outputs.version_number }} [skip ci]'
+                  pull: '--rebase --autostash'
+                  # `actions/checkout` detaches HEAD on SHA refs; EndBug needs a branch to push.
+                  new_branch: ${{ github.event.repository.default_branch }}
 
     publish_to_npm:
         name: Publish to npm


### PR DESCRIPTION
## Summary
- Add `pull: '--rebase --autostash'` to the `EndBug/add-and-commit` step in the `update_changelog` job so the changelog/version commit survives a concurrent ref update on master.
- Same for the `version_docs` job. Also add `new_branch: ${{ github.event.repository.default_branch }}` since that job checks out a SHA (detached HEAD) — EndBug needs a branch name to push to.

## Context
This is the same race that bit `apify/apify-client-js` in [run 25114327598](https://github.com/apify/apify-client-js/actions/runs/25114327598/job/73597522121):

```
remote rejected (cannot lock ref 'refs/heads/master': is at <new> but expected <old>)
```

The bypass logs `remote: Bypassed rule violations for refs/heads/master` — so it's not permissions, it's just non-fast-forward because something landed on master between checkout and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)