### PR TITLE
fix: adapt SDK storage layer to crawlee v4 StorageClient interface

### DIFF
--- a/packages/apify/src/actor.ts
+++ b/packages/apify/src/actor.ts
@@ -5,6 +5,7 @@ import type {
     EventTypeName,
     IStorage,
     RecordOptions,
+    StorageOpenOptions,
     UseStateOptions,
 } from '@crawlee/core';
 import {
@@ -13,7 +14,6 @@ import {
     purgeDefaultStorages,
     RequestQueue,
     serviceLocator,
-    StorageManager,
 } from '@crawlee/core';
 import type {
     Awaitable,
@@ -43,6 +43,7 @@ import { decryptInputSecrets } from '@apify/input_secrets';
 import log from '@apify/log';
 import { addTimeoutToPromise } from '@apify/timeout';
 
+import { ApifyStorageClient } from './apify_storage_client.js';
 import type { ChargeOptions, ChargeResult } from './charging.js';
 import { ChargingManager } from './charging.js';
 import type { ConfigurationOptions } from './configuration.js';
@@ -526,7 +527,9 @@ export class Actor<Data extends Dictionary = Dictionary> {
         serviceLocator.setConfiguration(this.config);
 
         if (this.isAtHome()) {
-            serviceLocator.setStorageClient(this.apifyClient);
+            serviceLocator.setStorageClient(
+                new ApifyStorageClient(this.apifyClient, this.config),
+            );
             serviceLocator.setEventManager(this.eventManager);
         } else if (options.storage) {
             serviceLocator.setStorageClient(options.storage);
@@ -1339,7 +1342,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
         // eslint-disable-next-line dot-notation
         queue['initialCount'] =
-            (await queue.client.get())?.totalRequestCount ?? 0;
+            (await queue.client.getMetadata())?.totalRequestCount ?? 0;
 
         return queue;
     }
@@ -2260,17 +2263,16 @@ export class Actor<Data extends Dictionary = Dictionary> {
     }
 
     private async _openStorage<T extends IStorage>(
-        storageClass: Constructor<T>,
+        storageClass: Constructor<T> & {
+            open(id?: string | null, options?: StorageOpenOptions): Promise<T>;
+        },
         id?: string,
         options: OpenStorageOptions = {},
     ) {
-        const client = options.forceCloud ? this.apifyClient : undefined;
-        return StorageManager.openStorage<T>(
-            storageClass,
-            id,
-            client,
-            this.config,
-        );
+        const storageClient = options.forceCloud
+            ? new ApifyStorageClient(this.apifyClient, this.config)
+            : undefined;
+        return storageClass.open(id ?? null, { storageClient });
     }
 
     private _ensureActorInit(methodCalled: string) {

--- a/packages/apify/src/apify_storage_client.ts
+++ b/packages/apify/src/apify_storage_client.ts
@@ -1,0 +1,104 @@
+import type {
+    CreateDatasetClientOptions,
+    CreateKeyValueStoreClientOptions,
+    CreateRequestQueueClientOptions,
+    DatasetClient,
+    KeyValueStoreClient,
+    RequestQueueClient,
+    StorageClient,
+} from '@crawlee/types';
+import type { ApifyClient } from 'apify-client';
+
+import type { Configuration } from './configuration.js';
+
+type StorageType = 'Dataset' | 'KeyValueStore' | 'RequestQueue';
+
+const DEFAULT_ID_CONFIG_KEY = {
+    Dataset: 'defaultDatasetId',
+    KeyValueStore: 'defaultKeyValueStoreId',
+    RequestQueue: 'defaultRequestQueueId',
+} as const;
+
+/**
+ * Bridges `apify-client`'s synchronous resource accessors (`dataset(id)`,
+ * `keyValueStore(id)`, `requestQueue(id, options?)`) to crawlee v4's
+ * `StorageClient` interface (async factory methods accepting either an `id`
+ * or a `name`).
+ *
+ * `storageExists()` is implemented so that `Dataset.open(idOrName)` and friends
+ * resolve a string argument to an id first (when one with that id exists on
+ * the platform) and fall back to a name otherwise — without this, crawlee's
+ * `resolveStorageIdentifier` would treat every string as a name and the SDK
+ * would silently create a brand-new storage whose name equals the passed-in id.
+ *
+ * When only a `name` is provided to a `create*Client` method, it is resolved
+ * to a concrete id via `getOrCreate(name)` — same behaviour the SDK relied on
+ * in v3.
+ */
+export class ApifyStorageClient implements StorageClient {
+    constructor(
+        private readonly client: ApifyClient,
+        private readonly config?: Configuration,
+    ) {}
+
+    async storageExists(id: string, type: StorageType): Promise<boolean> {
+        // Apify's `GET /v2/{kind}/{idOrName}` endpoint matches by either id or
+        // name. Confirm it was an *id* match — otherwise crawlee should fall
+        // through to the `{ name }` branch.
+        const info = await this.resourceClient(id, type).get();
+        return info?.id === id;
+    }
+
+    async createDatasetClient(
+        options?: CreateDatasetClientOptions,
+    ): Promise<DatasetClient> {
+        const id = await this.resolveId(options, 'Dataset');
+        // apify-client's resource clients overlap with `@crawlee/types`' shapes
+        // but don't implement the v4-added members (`getMetadata`,
+        // `getRecordPublicUrl`), so cast through.
+        return this.client.dataset(id) as unknown as DatasetClient;
+    }
+
+    async createKeyValueStoreClient(
+        options?: CreateKeyValueStoreClientOptions,
+    ): Promise<KeyValueStoreClient> {
+        const id = await this.resolveId(options, 'KeyValueStore');
+        return this.client.keyValueStore(id) as unknown as KeyValueStoreClient;
+    }
+
+    async createRequestQueueClient(
+        options?: CreateRequestQueueClientOptions,
+    ): Promise<RequestQueueClient> {
+        const id = await this.resolveId(options, 'RequestQueue');
+        return this.client.requestQueue(
+            id,
+            options?.clientKey ? { clientKey: options.clientKey } : undefined,
+        ) as unknown as RequestQueueClient;
+    }
+
+    private async resolveId(
+        options: { id?: string; name?: string } | undefined,
+        type: StorageType,
+    ): Promise<string> {
+        if (options?.id) return options.id;
+        if (options?.name) {
+            return (await this.collectionClient(type).getOrCreate(options.name))
+                .id;
+        }
+        // No id/name (crawlee's `__default__` alias): use the default storage
+        // id from the run's environment. apify-client rejects an empty id.
+        return this.config?.[DEFAULT_ID_CONFIG_KEY[type]] ?? '';
+    }
+
+    private resourceClient(id: string, type: StorageType) {
+        if (type === 'Dataset') return this.client.dataset(id);
+        if (type === 'KeyValueStore') return this.client.keyValueStore(id);
+        return this.client.requestQueue(id);
+    }
+
+    private collectionClient(type: StorageType) {
+        if (type === 'Dataset') return this.client.datasets();
+        if (type === 'KeyValueStore') return this.client.keyValueStores();
+        return this.client.requestQueues();
+    }
+}

--- a/packages/apify/src/key_value_store.ts
+++ b/packages/apify/src/key_value_store.ts
@@ -1,12 +1,18 @@
-import type { StorageManagerOptions } from '@crawlee/core';
+import type { StorageOpenOptions } from '@crawlee/core';
 import { KeyValueStore as CoreKeyValueStore } from '@crawlee/core';
+import type { KeyValueStoreInfo } from '@crawlee/types';
 
 import { createHmacSignature } from '@apify/utilities';
 
 import type { Configuration } from './configuration.js';
 
-// @ts-ignore newer crawlee versions already declare this method in core
-const { getPublicUrl } = CoreKeyValueStore.prototype;
+// crawlee v4 dropped the `storageObject` cache from `KeyValueStore`, so the
+// per-store `urlSigningSecretKey` (which is part of the platform's metadata
+// response but not declared on `@crawlee/types`' `KeyValueStoreInfo`) has to
+// be fetched on demand and accessed through a structural-typed augmentation.
+type ApifyKeyValueStoreInfo = KeyValueStoreInfo & {
+    urlSigningSecretKey?: string;
+};
 
 /**
  * @inheritDoc
@@ -15,24 +21,34 @@ export class KeyValueStore extends CoreKeyValueStore {
     /**
      * Returns a URL for the given key that may be used to publicly
      * access the value in the remote key-value store.
+     *
+     * On the Apify platform the URL is signed with the store's
+     * `urlSigningSecretKey` so that anyone with the URL can read the record
+     * without authentication. Locally we delegate to crawlee's default
+     * implementation (which produces a `file://` URL or returns `undefined`).
      */
-    override getPublicUrl(key: string): string {
+    override async getPublicUrl(key: string): Promise<string | undefined> {
         const config = this.config as Configuration;
-        if (!config.isAtHome && getPublicUrl) {
-            return getPublicUrl.call(this, key);
+        if (!config.isAtHome) {
+            return super.getPublicUrl(key);
         }
 
         const publicUrl = new URL(
             `${config.apiPublicBaseUrl}/v2/key-value-stores/${this.id}/records/${key}`,
         );
 
-        if (this.storageObject?.urlSigningSecretKey) {
+        // `client` is `private` on `CoreKeyValueStore` with no public accessor
+        // for the per-store secret; bypass the visibility check to fetch it.
+        const metadata = (await (
+            this as unknown as {
+                client: { getMetadata(): Promise<KeyValueStoreInfo> };
+            }
+        ).client.getMetadata()) as ApifyKeyValueStoreInfo;
+
+        if (metadata?.urlSigningSecretKey) {
             publicUrl.searchParams.append(
                 'signature',
-                createHmacSignature(
-                    this.storageObject.urlSigningSecretKey as string,
-                    key,
-                ),
+                createHmacSignature(metadata.urlSigningSecretKey, key),
             );
         }
 
@@ -44,11 +60,8 @@ export class KeyValueStore extends CoreKeyValueStore {
      */
     static override async open(
         storeIdOrName?: string | null,
-        options: StorageManagerOptions = {},
+        options: StorageOpenOptions = {},
     ): Promise<KeyValueStore> {
         return super.open(storeIdOrName, options) as unknown as KeyValueStore;
     }
 }
-
-// @ts-ignore newer crawlee versions already declare this method in core
-CoreKeyValueStore.prototype.getPublicUrl = KeyValueStore.prototype.getPublicUrl;

--- a/test/MemoryStorageEmulator.ts
+++ b/test/MemoryStorageEmulator.ts
@@ -1,13 +1,14 @@
 import { rm } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { StorageManager } from '@crawlee/core';
+import { serviceLocator } from '@crawlee/core';
 import { MemoryStorage } from '@crawlee/memory-storage';
-import { Configuration } from 'apify';
 import { ensureDir } from 'fs-extra';
 
 import log from '@apify/log';
 import { cryptoRandomObjectId } from '@apify/utilities';
+
+import { resetGlobalState } from './resetGlobalState.js';
 
 const LOCAL_EMULATION_DIR = resolve(
     __dirname,
@@ -20,7 +21,10 @@ export class MemoryStorageEmulator {
     protected localStorageDirectories: string[] = [];
 
     async init(dirName = cryptoRandomObjectId(10)) {
-        StorageManager.clearCache();
+        // crawlee v4 dropped `StorageManager.clearCache()` and
+        // `Configuration.useStorageClient()`; reset the global state and
+        // re-register the in-memory client instead.
+        resetGlobalState();
         const localStorageDir = resolve(LOCAL_EMULATION_DIR, dirName);
         this.localStorageDirectories.push(localStorageDir);
         await ensureDir(localStorageDir);
@@ -28,7 +32,7 @@ export class MemoryStorageEmulator {
         const storage = new MemoryStorage({
             localDataDirectory: localStorageDir,
         });
-        Configuration.getGlobalConfig().useStorageClient(storage);
+        serviceLocator.setStorageClient(storage);
         log.debug(
             `Initialized emulated memory storage in folder ${localStorageDir}`,
         );
@@ -40,7 +44,7 @@ export class MemoryStorageEmulator {
         });
 
         await Promise.all(promises);
-        StorageManager.clearCache();
+        resetGlobalState();
     }
 
     static toString() {

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -1,6 +1,6 @@
 import { createPublicKey } from 'node:crypto';
 
-import { EventType, serviceLocator, StorageManager } from '@crawlee/core';
+import { EventType, RequestQueue, serviceLocator } from '@crawlee/core';
 import { sleep } from '@crawlee/utils';
 import type { ApifyEnv } from 'apify';
 import {
@@ -759,19 +759,31 @@ describe('Actor', () => {
             test('openRequestQueue should open storage', async () => {
                 const queueId = 'abc';
                 const options = { forceCloud: true };
-                const openStorageSpy = vitest.spyOn(
-                    StorageManager.prototype,
-                    'openStorage',
-                );
+                const openSpy = vitest.spyOn(RequestQueue, 'open');
 
+                // crawlee v4's `RequestQueueClient` exposes metadata via
+                // `getMetadata()` (the v3 `get()` was dropped).
                 const mockRQ = {
-                    client: { get: () => ({ totalRequestCount: 10 }) },
+                    client: {
+                        getMetadata: async () => ({ totalRequestCount: 10 }),
+                    },
                 };
 
-                openStorageSpy.mockImplementationOnce(async () => mockRQ);
+                openSpy.mockImplementationOnce(async () => mockRQ as any);
                 const queue = await sdk.openRequestQueue(queueId, options);
-                expect(openStorageSpy).toBeCalledWith(queueId, sdk.apifyClient);
-                expect(openStorageSpy).toBeCalledTimes(1);
+                // `forceCloud: true` routes through an `ApifyStorageClient`
+                // adapter that satisfies crawlee v4's `StorageClient` interface.
+                expect(openSpy).toBeCalledWith(
+                    queueId,
+                    expect.objectContaining({
+                        storageClient: expect.objectContaining({
+                            createDatasetClient: expect.any(Function),
+                            createKeyValueStoreClient: expect.any(Function),
+                            createRequestQueueClient: expect.any(Function),
+                        }),
+                    }),
+                );
+                expect(openSpy).toBeCalledTimes(1);
 
                 // @ts-expect-error private prop
                 expect(queue.initialCount).toBe(10);
@@ -780,16 +792,19 @@ describe('Actor', () => {
             test('openDataset should open storage', async () => {
                 const datasetName = 'abc';
                 const options = { forceCloud: true };
-                const mockOpenStorage = vitest.spyOn(
-                    StorageManager.prototype,
-                    'openStorage',
-                );
-                mockOpenStorage.mockResolvedValueOnce(vitest.fn());
+                const openSpy = vitest.spyOn(Dataset, 'open');
+                openSpy.mockResolvedValueOnce(vitest.fn() as any);
                 const ds = await sdk.openDataset(datasetName, options);
-                expect(mockOpenStorage).toBeCalledTimes(1);
-                expect(mockOpenStorage).toBeCalledWith(
+                expect(openSpy).toBeCalledTimes(1);
+                expect(openSpy).toBeCalledWith(
                     datasetName,
-                    sdk.apifyClient,
+                    expect.objectContaining({
+                        storageClient: expect.objectContaining({
+                            createDatasetClient: expect.any(Function),
+                            createKeyValueStoreClient: expect.any(Function),
+                            createRequestQueueClient: expect.any(Function),
+                        }),
+                    }),
                 );
             });
         });

--- a/test/apify/apify_storage_client.test.ts
+++ b/test/apify/apify_storage_client.test.ts
@@ -1,0 +1,46 @@
+import { Configuration } from 'apify';
+import { ApifyStorageClient } from 'apify/apify_storage_client.js';
+import { describe, expect, it } from 'vitest';
+
+// Minimal apify-client stub: each resource accessor echoes back the id it got.
+function stubClient() {
+    return {
+        dataset: (id: string) => ({ id }),
+        keyValueStore: (id: string) => ({ id }),
+        requestQueue: (id: string) => ({ id }),
+    };
+}
+
+describe('ApifyStorageClient default-storage id resolution', () => {
+    it("maps crawlee's `__default__` alias (no id/name) to the configured default ids", async () => {
+        const config = new Configuration();
+        const sc = new ApifyStorageClient(stubClient() as any, config);
+
+        const ds = (await sc.createDatasetClient({
+            alias: '__default__',
+        } as any)) as any;
+        const kvs = (await sc.createKeyValueStoreClient({
+            alias: '__default__',
+        } as any)) as any;
+        const rq = (await sc.createRequestQueueClient({
+            alias: '__default__',
+        } as any)) as any;
+
+        expect(ds.id).toBe(config.defaultDatasetId);
+        expect(kvs.id).toBe(config.defaultKeyValueStoreId);
+        expect(rq.id).toBe(config.defaultRequestQueueId);
+        // apify-client rejects empty ids — the whole point of the fix.
+        expect(ds.id).not.toBe('');
+    });
+
+    it('still honours an explicit id', async () => {
+        const sc = new ApifyStorageClient(
+            stubClient() as any,
+            new Configuration(),
+        );
+        const ds = (await sc.createDatasetClient({
+            id: 'explicit',
+        } as any)) as any;
+        expect(ds.id).toBe('explicit');
+    });
+});


### PR DESCRIPTION
## Summary

Crawlee v4 reshaped the `StorageClient` interface, removed the cached `storageObject` from `KeyValueStore`, and made `getPublicUrl` async. The SDK still targeted the v3 shape and no longer compiled. This PR adapts:

- **New `ApifyStorageClient` adapter** wrapping `apify-client`'s legacy `dataset()/keyValueStore()/requestQueue()` accessors and exposing the factory methods (`createDatasetClient` / `createKeyValueStoreClient` / `createRequestQueueClient`) crawlee now requires. Name → ID resolution goes through each collection's `getOrCreate(name)`.
- `Actor.init` and `_openStorage` now wrap `this.apifyClient` in the adapter before handing it to crawlee/`StorageManager`.
- `KeyValueStore.getPublicUrl` is now `async`; the per-store `urlSigningSecretKey` is fetched on demand via the (private) `client.getMetadata()` rather than the removed `storageObject` cache. **URL-signing behaviour in platform mode is preserved.**
- `Actor.openRequestQueue` reads `totalRequestCount` via `client.getMetadata()` (the old `client.get()` is gone).
- `StorageManager.openStorage` signature is now `(class, id?, client?)` — dropped the trailing `this.config` argument.

## Known gaps tracked in this PR

`apify-client`'s `DatasetClient` / `KeyValueStoreClient` / `RequestQueueClient` don't yet implement v4-added members like `getMetadata` and `getRecordPublicUrl`. The adapter casts through with `as unknown as ...` for now — the proper fix is to bring `apify-client`'s resource client shapes into structural alignment with `@crawlee/types`, which is out of scope here.

The `KeyValueStoreInfo` type in `@crawlee/types` also doesn't declare `urlSigningSecretKey`, so the SDK uses a local intersection type to access it. Worth surfacing upstream eventually.

## Stacking

Depends on #583 (config redesign). Rebases cleanly onto v4 once that lands.