### PR TITLE
chore(build): clean tsconfig.build.tsbuildinfo so re-builds emit

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ],
     "scripts": {
         "prepare": "husky",
-        "clean": "rimraf ./dist",
+        "clean": "rimraf ./dist ./tsconfig.build.tsbuildinfo",
         "compile": "tsc -p tsconfig.build.json && gen-esm-wrapper ./dist/index.js ./dist/index.mjs",
         "fixApifyExport": "node ./scripts/temp_fix_apify_exports.mjs",
         "build": "pnpm clean && pnpm compile && pnpm fixApifyExport",


### PR DESCRIPTION
## Summary

Fixes the failed beta publish in https://github.com/apify/apify-sdk-js/actions/runs/25323929668/job/74239692757.

### Root cause

The publish workflow runs \`pnpm build\` twice:
1. Explicit \`Build module\` step (\`pnpm build\`)
2. \`pnpm publish\` re-runs it via \`prepublishOnly: pnpm build\`

The second run does \`pnpm clean\` (\`rimraf ./dist\`) and then \`tsc\`, but the leftover \`tsconfig.build.tsbuildinfo\` from the first run convinces TypeScript that everything is already emitted, so \`dist/\` stays empty and \`gen-esm-wrapper ./dist/index.js\` fails with \`MODULE_NOT_FOUND\`.

This was masked before #599 because \`tsconfig.build.json\` didn't have an explicit \`rootDir\`. Adding \`rootDir: "./src"\` in #599 made the incremental cache believable enough to short-circuit emit on the second pass, breaking the beta publish.

### Fix

Have \`clean\` also \`rimraf ./tsconfig.build.tsbuildinfo\`. Tested locally — two consecutive \`pnpm build\` runs both emit \`dist/index.js\`.

## Test plan

- [x] \`rm -rf dist tsconfig.build.tsbuildinfo && pnpm build && pnpm build\` — both runs emit \`dist/index.js\` cleanly