### PR TITLE
ci: use pnpm for docs versioning step in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,21 +152,16 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: 24
-                  cache: 'npm'
-                  cache-dependency-path: 'package-lock.json'
 
-            - name: Install Dependencies
-              run: |
-                  npm ci
-                  cd website
-                  npm ci
+            - name: Install pnpm and dependencies
+              uses: apify/workflows/pnpm-install@main
 
             - name: Run docusaurus versioning
               run: |
                   MAJOR_MINOR=$(echo "${{ needs.update_changelog.outputs.version_number }}" | cut -d. -f1,2)
                   cd website
-                  npx docusaurus docs:version "$MAJOR_MINOR"
-                  npx docusaurus api:version "$MAJOR_MINOR"
+                  pnpm exec docusaurus docs:version "$MAJOR_MINOR"
+                  pnpm exec docusaurus api:version "$MAJOR_MINOR"
 
             - name: Commit versioned docs
               uses: EndBug/add-and-commit@v10


### PR DESCRIPTION
## Summary

The `version_docs` job in `.github/workflows/release.yaml` still used npm (`npm ci` and `npx`) and referenced a non-existent `package-lock.json`, while the rest of the workflow and the repo as a whole are on pnpm (`packageManager: pnpm@10.24.0`, `pnpm-lock.yaml`, and a root `preinstall: npx only-allow pnpm` guard).

This means a minor/major release would fail at the docs versioning step — `npm ci` would be blocked by `only-allow pnpm` and there's no `package-lock.json` to consume anyway.

## Changes

- Replace the `Install Dependencies` step (`npm ci` in root and in `website/`) with the same `apify/workflows/pnpm-install@main` action used elsewhere in this workflow (e.g. `build_and_test`, `update_changelog`) and in `docs.yaml`.
- Drop the now-irrelevant `cache: 'npm'` / `cache-dependency-path: 'package-lock.json'` config from `setup-node`.
- Run docusaurus via `pnpm exec` instead of `npx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)