### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,21 +40,11 @@ jobs:
                   SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_DOCS_PROJECT_KEY }}
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
-            - name: Stage the updated package.json and lockfile
-              id: stage
-              run: |
-                  git add website/package.json pnpm-lock.yaml
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit the updated package.json and lockfile
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore: Automatic theme updating workflow [skip ci]'
+                  message: 'chore: Automatic theme updating workflow [skip ci]'
+                  add: 'website/package.json pnpm-lock.yaml'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Set up GitHub Pages

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,14 +40,22 @@ jobs:
                   SMARTLOOK_PROJECT_KEY: ${{ secrets.SMARTLOOK_DOCS_PROJECT_KEY }}
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
+            - name: Stage the updated package.json and lockfile
+              id: stage
+              run: |
+                  git add website/package.json pnpm-lock.yaml
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit the updated package.json and lockfile
-              uses: stefanzweifel/git-auto-commit-action@v7
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  commit_message: 'chore: Automatic theme updating workflow [skip ci]'
-                  file_pattern: 'website/package.json pnpm-lock.yaml'
-                  commit_user_name: Apify Bot
-                  commit_user_email: my-github-actions-bot@example.org
-                  commit_author: Apify Bot <apify@apify.com>
+                  commit-message: 'chore: Automatic theme updating workflow [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Set up GitHub Pages
               uses: actions/configure-pages@v6

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,7 +41,7 @@ jobs:
                   SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
             - name: Commit the updated package.json and lockfile
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: 'chore: Automatic theme updating workflow [skip ci]'
                   add: 'website/package.json pnpm-lock.yaml'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
         needs: [release_metadata, build_and_test]
         runs-on: ubuntu-22.04
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha }}
             version_number: ${{ needs.release_metadata.outputs.version_number }}
             tag_name: ${{ needs.release_metadata.outputs.tag_name }}
             release_notes: ${{ needs.release_metadata.outputs.release_notes }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
         needs: [release_metadata, build_and_test]
         runs-on: ubuntu-22.04
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
             version_number: ${{ needs.release_metadata.outputs.version_number }}
             tag_name: ${{ needs.release_metadata.outputs.tag_name }}
             release_notes: ${{ needs.release_metadata.outputs.release_notes }}
@@ -112,23 +112,12 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
-            - name: Stage release changes
-              id: stage
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Add changes to the release commit and push
               id: commit
-              if: steps.stage.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'chore(release): set package version to ${{ needs.release_metadata.outputs.version_number }} and update changelog [skip ci]'
+                  message: 'chore(release): set package version to ${{ needs.release_metadata.outputs.version_number }} and update changelog [skip ci]'
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     create_github_release:
@@ -175,22 +164,11 @@ jobs:
                   pnpm exec docusaurus docs:version "$MAJOR_MINOR"
                   pnpm exec docusaurus api:version "$MAJOR_MINOR"
 
-            - name: Stage versioned docs
-              id: stage-version-docs
-              run: |
-                  git pull --rebase --autostash
-                  git add -A
-                  if git diff --cached --quiet; then
-                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
-                  fi
-
             - name: Commit versioned docs
-              if: steps.stage-version-docs.outputs.has-changes == 'true'
-              uses: apify/workflows/commit@v0.44.0
+              uses: apify/actions/signed-commit@v1.0.0
               with:
-                  commit-message: 'docs: version docs for ${{ needs.update_changelog.outputs.version_number }} [skip ci]'
+                  message: 'docs: version docs for ${{ needs.update_changelog.outputs.version_number }} [skip ci]'
+                  pull: '--rebase --autostash'
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     publish_to_npm:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
         needs: [release_metadata, build_and_test]
         runs-on: ubuntu-22.04
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit_sha }}
             version_number: ${{ needs.release_metadata.outputs.version_number }}
             tag_name: ${{ needs.release_metadata.outputs.tag_name }}
             release_notes: ${{ needs.release_metadata.outputs.release_notes }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,7 @@ jobs:
 
             - name: Add changes to the release commit and push
               id: commit
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: 'chore(release): set package version to ${{ needs.release_metadata.outputs.version_number }} and update changelog [skip ci]'
                   pull: '--rebase --autostash'
@@ -165,7 +165,7 @@ jobs:
                   pnpm exec docusaurus api:version "$MAJOR_MINOR"
 
             - name: Commit versioned docs
-              uses: apify/actions/signed-commit@v1.0.0
+              uses: apify/actions/signed-commit@v1.1.2
               with:
                   message: 'docs: version docs for ${{ needs.update_changelog.outputs.version_number }} [skip ci]'
                   pull: '--rebase --autostash'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
         needs: [release_metadata, build_and_test]
         runs-on: ubuntu-22.04
         outputs:
-            changelog_commitish: ${{ steps.commit.outputs.commit_long_sha || github.sha }}
+            changelog_commitish: ${{ steps.commit.outputs.commit-sha || github.sha }}
             version_number: ${{ needs.release_metadata.outputs.version_number }}
             tag_name: ${{ needs.release_metadata.outputs.tag_name }}
             release_notes: ${{ needs.release_metadata.outputs.release_notes }}
@@ -112,14 +112,24 @@ jobs:
                   write-mode: overwrite
                   contents: ${{ needs.release_metadata.outputs.changelog }}
 
+            - name: Stage release changes
+              id: stage
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Add changes to the release commit and push
               id: commit
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'chore(release): set package version to ${{ needs.release_metadata.outputs.version_number }} and update changelog [skip ci]'
-                  pull: '--rebase --autostash'
+                  commit-message: 'chore(release): set package version to ${{ needs.release_metadata.outputs.version_number }} and update changelog [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     create_github_release:
         name: Create github release
@@ -145,7 +155,9 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
-                  ref: ${{ needs.update_changelog.outputs.changelog_commitish }}
+                  # Always check out the default branch (not the SHA) so the commit
+                  # action can push to a branch ref.
+                  ref: ${{ github.event.repository.default_branch }}
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Use Node.js 24
@@ -163,15 +175,23 @@ jobs:
                   pnpm exec docusaurus docs:version "$MAJOR_MINOR"
                   pnpm exec docusaurus api:version "$MAJOR_MINOR"
 
+            - name: Stage versioned docs
+              id: stage-version-docs
+              run: |
+                  git pull --rebase --autostash
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "has-changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has-changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Commit versioned docs
-              uses: EndBug/add-and-commit@v10
+              if: steps.stage-version-docs.outputs.has-changes == 'true'
+              uses: apify/workflows/commit@v0.44.0
               with:
-                  author_name: Apify Release Bot
-                  author_email: noreply@apify.com
-                  message: 'docs: version docs for ${{ needs.update_changelog.outputs.version_number }} [skip ci]'
-                  pull: '--rebase --autostash'
-                  # `actions/checkout` detaches HEAD on SHA refs; EndBug needs a branch to push.
-                  new_branch: ${{ github.event.repository.default_branch }}
+                  commit-message: 'docs: version docs for ${{ needs.update_changelog.outputs.version_number }} [skip ci]'
+                  github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
     publish_to_npm:
         name: Publish to npm


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.