### PR TITLE
docs: use the common `ApiLink` implementation

### DIFF
--- a/website/src/components/ApiLink.jsx
+++ b/website/src/components/ApiLink.jsx
@@ -1,30 +1,12 @@
 import React from 'react';
-import Link from '@docusaurus/Link';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { useDocsVersion } from '@docusaurus/plugin-content-docs/client';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import ThemeApiLink from '@apify/docs-theme/src/theme/ApiLink';
 
 const ApiLink = ({ to, children }) => {
-    const { version, isLast } = useDocsVersion();
-    const { siteConfig } = useDocusaurusContext();
-
     if (to.toString().startsWith('apify/')) {
         to = to.toString().substring('apify/'.length);
     }
 
-    if (siteConfig.presets[0][1].docs.disableVersioning) {
-        return <Link to={`/reference/${to}`}>{children}</Link>;
-    }
-
-    let versionSlug = `${version}/`;
-
-    if (version === 'current') {
-        versionSlug = 'next/';
-    } else if (isLast) {
-        versionSlug = '';
-    }
-
-    return <Link to={`/reference/${versionSlug}${to}`}>{children}</Link>;
+    return <ThemeApiLink to={to}>{children}</ThemeApiLink>;
 };
 
 export default ApiLink;

--- a/website/src/components/ApiLink.jsx
+++ b/website/src/components/ApiLink.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ThemeApiLink from '@apify/docs-theme/src/theme/ApiLink';
+import ThemeApiLink from '@theme/ApiLink';
 
 const ApiLink = ({ to, children }) => {
     if (to.toString().startsWith('apify/')) {


### PR DESCRIPTION
Uses the common `ApiLink` implementation from `@apify/docs-theme`.
