### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Update docs theme
               run: pnpm --filter apify-sdk-website update @apify/docs-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Update docs theme
               run: pnpm --filter apify-sdk-website update @apify/docs-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update docs theme
               run: pnpm --filter apify-sdk-website update @apify/docs-theme

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Update docs theme
               run: pnpm --filter apify-sdk-website update @apify/docs-theme

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -39,7 +39,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Build module
               run: pnpm build

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -39,7 +39,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Build module
               run: pnpm build

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -39,7 +39,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Build module
               run: pnpm build

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -39,7 +39,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build module
               run: pnpm build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -67,7 +67,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/workflows/git-cliff-release@main
+            - uses: apify/actions/git-cliff-release@v1.0.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -100,7 +100,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -154,7 +154,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Run docusaurus versioning
               run: |
@@ -179,7 +179,7 @@ jobs:
         needs: [update_changelog]
         steps:
             - name: Publish to npm
-              uses: apify/workflows/execute-workflow@main
+              uses: apify/actions/execute-workflow@v1.0.0
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -67,7 +67,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.1.0
+            - uses: apify/actions/git-cliff-release@v1.1.1
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -100,7 +100,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -154,7 +154,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Run docusaurus versioning
               run: |
@@ -179,7 +179,7 @@ jobs:
         needs: [update_changelog]
         steps:
             - name: Publish to npm
-              uses: apify/actions/execute-workflow@v1.1.0
+              uses: apify/actions/execute-workflow@v1.1.1
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -67,7 +67,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.0.0
+            - uses: apify/actions/git-cliff-release@v1.1.0
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -100,7 +100,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -154,7 +154,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Run docusaurus versioning
               run: |
@@ -179,7 +179,7 @@ jobs:
         needs: [update_changelog]
         steps:
             - name: Publish to npm
-              uses: apify/actions/execute-workflow@v1.0.0
+              uses: apify/actions/execute-workflow@v1.1.0
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -67,7 +67,7 @@ jobs:
             changelog: ${{ steps.release_metadata.outputs.changelog }}
             release_notes: ${{ steps.release_metadata.outputs.release_notes }}
         steps:
-            - uses: apify/actions/git-cliff-release@v1.1.1
+            - uses: apify/actions/git-cliff-release@v1.1.2
               name: Prepare release metadata
               id: release_metadata
               with:
@@ -100,7 +100,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Update package version in package.json
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
@@ -154,7 +154,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Run docusaurus versioning
               run: |
@@ -179,7 +179,7 @@ jobs:
         needs: [update_changelog]
         steps:
             - name: Publish to npm
-              uses: apify/actions/execute-workflow@v1.1.1
+              uses: apify/actions/execute-workflow@v1.1.2
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -39,7 +39,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -64,7 +64,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build docs
               if: github.ref != 'refs/heads/master'
@@ -84,7 +84,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Lint
               run: pnpm lint
@@ -110,10 +110,10 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Publish beta to npm
-              uses: apify/workflows/execute-workflow@main
+              uses: apify/actions/execute-workflow@v1.0.0
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -39,7 +39,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -64,7 +64,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Build docs
               if: github.ref != 'refs/heads/master'
@@ -84,7 +84,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Lint
               run: pnpm lint
@@ -110,10 +110,10 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Publish beta to npm
-              uses: apify/actions/execute-workflow@v1.1.0
+              uses: apify/actions/execute-workflow@v1.1.1
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -39,7 +39,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -64,7 +64,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Build docs
               if: github.ref != 'refs/heads/master'
@@ -84,7 +84,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Lint
               run: pnpm lint
@@ -110,10 +110,10 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Publish beta to npm
-              uses: apify/actions/execute-workflow@v1.1.1
+              uses: apify/actions/execute-workflow@v1.1.2
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -39,7 +39,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps
@@ -64,7 +64,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Build docs
               if: github.ref != 'refs/heads/master'
@@ -84,7 +84,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Lint
               run: pnpm lint
@@ -110,10 +110,10 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Publish beta to npm
-              uses: apify/actions/execute-workflow@v1.0.0
+              uses: apify/actions/execute-workflow@v1.1.0
               with:
                   workflow: publish-to-npm.yaml
                   inputs: >

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.0
+              uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Build
               run: pnpm ci:build

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.0.0
+              uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Build
               run: pnpm ci:build

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/actions/pnpm-install@v1.1.1
+              uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Build
               run: pnpm ci:build

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
 
             - name: Install pnpm and dependencies
-              uses: apify/workflows/pnpm-install@main
+              uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Build
               run: pnpm ci:build


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.