### PR TITLE
docs: replace legacy `sdk.apify.com` links with `docs.apify.com/sdk/js`

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -61,7 +61,7 @@ npm install apify playwright
 
 If you want to make use of Playwright on the Apify Platform, you need to use a Docker image
 that supports Playwright. We've created them for you, so head over to the new
-[Docker image guide](https://sdk.apify.com/docs/guides/docker-images) and pick the one
+[Docker image guide](https://docs.apify.com/sdk/js/docs/concepts/docker-images) and pick the one
 that best suits your needs.
 
 Note that your `package.json` **MUST** include `puppeteer` and/or `playwright` as dependencies.

--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -65,7 +65,7 @@ variable to your API token.
 
 ### Log in with Configuration
 
-Another option is to use the [`Configuration`](https://sdk.apify.com/api/apify/class/Configuration) instance and set your api token there.
+Another option is to use the <ApiLink to="apify/class/Configuration">`Configuration`</ApiLink> instance and set your api token there.
 
 ```javascript
 import { Actor } from 'apify';
@@ -111,13 +111,13 @@ apify run
 
 For running Crawlee code as an actor on [Apify platform](https://apify.com/actors) you should either:
 
-- use a combination of [`Actor.init()`](https://sdk.apify.com/api/apify/class/Actor#init) and [`Actor.exit()`](https://sdk.apify.com/api/apify/class/Actor#exit) functions;
-- or wrap it into [`Actor.main()`](https://sdk.apify.com/api/apify/class/Actor#main) function.
+- use a combination of <ApiLink to="apify/class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="apify/class/Actor#exit">`Actor.exit()`</ApiLink> functions;
+- or wrap it into <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function.
 
 :::info NOTE
 
-- Adding [`Actor.init()`](https://sdk.apify.com/api/apify/class/Actor#init) and [`Actor.exit()`](https://sdk.apify.com/api/apify/class/Actor#exit) to your code are the only two important things needed to run it on Apify platform as an actor. `Actor.init()` is needed to initialize your actor (e.g. to set the correct storage implementation), while without `Actor.exit()` the process will simply never stop.
-- [`Actor.main()`](https://sdk.apify.com/api/apify/class/Actor#main) is an alternative to `Actor.init()` and `Actor.exit()` as it calls both behind the scenes.
+- Adding <ApiLink to="apify/class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="apify/class/Actor#exit">`Actor.exit()`</ApiLink> to your code are the only two important things needed to run it on Apify platform as an actor. `Actor.init()` is needed to initialize your actor (e.g. to set the correct storage implementation), while without `Actor.exit()` the process will simply never stop.
+- <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> is an alternative to `Actor.init()` and `Actor.exit()` as it calls both behind the scenes.
   :::
 
 Let's look at the `CheerioCrawler` example from the <CrawleeLink to="docs/quick-start">Quick Start</CrawleeLink> guide:
@@ -204,22 +204,22 @@ There are several things worth mentioning here.
 
 To simplify access to the _default_ storages, instead of using the helper functions of respective storage classes, you could use:
 
-- [`Actor.setValue()`](https://sdk.apify.com/api/apify/class/Actor#setValue), [`Actor.getValue()`](https://sdk.apify.com/api/apify/class/Actor#getValue), [`Actor.getInput()`](https://sdk.apify.com/api/apify/class/Actor#getInput) for `Key-Value Store`
-- [`Actor.pushData()`](https://sdk.apify.com/api/apify/class/Actor#pushData) for `Dataset`
+- <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink>, <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink>, <ApiLink to="apify/class/Actor#getInput">`Actor.getInput()`</ApiLink> for `Key-Value Store`
+- <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> for `Dataset`
 
 ### Using platform storage in a local actor
 
-When you plan to use the platform storage while developing and running your actor locally, you should use [`Actor.openKeyValueStore()`](https://sdk.apify.com/api/apify/class/Actor#openKeyValueStore), [`Actor.openDataset()`](https://sdk.apify.com/api/apify/class/Actor#openDataset) and [`Actor.openRequestQueue()`](https://sdk.apify.com/api/apify/class/Actor#openRequestQueue) to open the respective storage.
+When you plan to use the platform storage while developing and running your actor locally, you should use <ApiLink to="apify/class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="apify/class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="apify/class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> to open the respective storage.
 
-Using each of these methods allows to pass the [`OpenStorageOptions`](https://sdk.apify.com/api/apify/interface/OpenStorageOptions) as a second argument, which has only one optional property: [`forceCloud`](https://sdk.apify.com/api/apify/interface/OpenStorageOptions#forceCloud). If set to `true` - cloud storage will be used instead of the folder on the local disk.
+Using each of these methods allows to pass the <ApiLink to="apify/interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="apify/interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
 
 :::note
-If you don't plan to force usage of the platform storages when running the actor locally, there is no need to use the [`Actor`](https://sdk.apify.com/api/apify/class/Actor) class for it. The Crawlee variants <ApiLink to="apify/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="apify/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="apify/class/RequestQueue#open">`RequestQueue.open()`</ApiLink> will work the same.
+If you don't plan to force usage of the platform storages when running the actor locally, there is no need to use the <ApiLink to="apify/class/Actor">`Actor`</ApiLink> class for it. The Crawlee variants <ApiLink to="apify/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="apify/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="apify/class/RequestQueue#open">`RequestQueue.open()`</ApiLink> will work the same.
 :::
 
 ### Getting public url of an item in the platform storage
 
-If you need to share a link to some file stored in a Key-Value Store on Apify Platform, you can use [`getPublicUrl()`](https://sdk.apify.com/api/apify/class/KeyValueStore#getPublicUrl) method. It accepts only one parameter: `key` - the key of the item you want to share.
+If you need to share a link to some file stored in a Key-Value Store on Apify Platform, you can use <ApiLink to="apify/class/KeyValueStore#getPublicUrl">`getPublicUrl()`</ApiLink> method. It accepts only one parameter: `key` - the key of the item you want to share.
 
 ```js
 import { KeyValueStore } from 'apify';
@@ -312,7 +312,7 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
-Note that unlike using your own proxies in Crawlee, you shouldn't use the constructor to create <ApiLink to="apify/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy you should create an instance using the [`Actor.createProxyConfiguration()`](https://sdk.apify.com/api/apify/class/Actor#createProxyConfiguration) function instead.
+Note that unlike using your own proxies in Crawlee, you shouldn't use the constructor to create <ApiLink to="apify/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
 
 ### Apify Proxy Configuration
 
@@ -345,7 +345,7 @@ essentially has two modes: Apify Proxy or Own (third party) proxy.
 The difference is easy to remember.
 
 - If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="apify/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="apify/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
-- If you are planning to use Apify Proxy - you should create an instance using the [`Actor.createProxyConfiguration()`](https://sdk.apify.com/api/apify/class/Actor#createProxyConfiguration) function. <ApiLink to="apify/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="apify/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
+- If you are planning to use Apify Proxy - you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. <ApiLink to="apify/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="apify/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
 
 **Related links**
 

--- a/docs/02_concepts/01_actor_lifecycle.mdx
+++ b/docs/02_concepts/01_actor_lifecycle.mdx
@@ -65,7 +65,7 @@ variable to your API token.
 
 ### Log in with Configuration
 
-Another option is to use the <ApiLink to="apify/class/Configuration">`Configuration`</ApiLink> instance and set your api token there.
+Another option is to use the <ApiLink to="class/Configuration">`Configuration`</ApiLink> instance and set your api token there.
 
 ```javascript
 import { Actor } from 'apify';
@@ -111,13 +111,13 @@ apify run
 
 For running Crawlee code as an actor on [Apify platform](https://apify.com/actors) you should either:
 
-- use a combination of <ApiLink to="apify/class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="apify/class/Actor#exit">`Actor.exit()`</ApiLink> functions;
-- or wrap it into <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> function.
+- use a combination of <ApiLink to="class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="class/Actor#exit">`Actor.exit()`</ApiLink> functions;
+- or wrap it into <ApiLink to="class/Actor#main">`Actor.main()`</ApiLink> function.
 
 :::info NOTE
 
-- Adding <ApiLink to="apify/class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="apify/class/Actor#exit">`Actor.exit()`</ApiLink> to your code are the only two important things needed to run it on Apify platform as an actor. `Actor.init()` is needed to initialize your actor (e.g. to set the correct storage implementation), while without `Actor.exit()` the process will simply never stop.
-- <ApiLink to="apify/class/Actor#main">`Actor.main()`</ApiLink> is an alternative to `Actor.init()` and `Actor.exit()` as it calls both behind the scenes.
+- Adding <ApiLink to="class/Actor#init">`Actor.init()`</ApiLink> and <ApiLink to="class/Actor#exit">`Actor.exit()`</ApiLink> to your code are the only two important things needed to run it on Apify platform as an actor. `Actor.init()` is needed to initialize your actor (e.g. to set the correct storage implementation), while without `Actor.exit()` the process will simply never stop.
+- <ApiLink to="class/Actor#main">`Actor.main()`</ApiLink> is an alternative to `Actor.init()` and `Actor.exit()` as it calls both behind the scenes.
   :::
 
 Let's look at the `CheerioCrawler` example from the <CrawleeLink to="docs/quick-start">Quick Start</CrawleeLink> guide:
@@ -204,22 +204,22 @@ There are several things worth mentioning here.
 
 To simplify access to the _default_ storages, instead of using the helper functions of respective storage classes, you could use:
 
-- <ApiLink to="apify/class/Actor#setValue">`Actor.setValue()`</ApiLink>, <ApiLink to="apify/class/Actor#getValue">`Actor.getValue()`</ApiLink>, <ApiLink to="apify/class/Actor#getInput">`Actor.getInput()`</ApiLink> for `Key-Value Store`
-- <ApiLink to="apify/class/Actor#pushData">`Actor.pushData()`</ApiLink> for `Dataset`
+- <ApiLink to="class/Actor#setValue">`Actor.setValue()`</ApiLink>, <ApiLink to="class/Actor#getValue">`Actor.getValue()`</ApiLink>, <ApiLink to="class/Actor#getInput">`Actor.getInput()`</ApiLink> for `Key-Value Store`
+- <ApiLink to="class/Actor#pushData">`Actor.pushData()`</ApiLink> for `Dataset`
 
 ### Using platform storage in a local actor
 
-When you plan to use the platform storage while developing and running your actor locally, you should use <ApiLink to="apify/class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="apify/class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="apify/class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> to open the respective storage.
+When you plan to use the platform storage while developing and running your actor locally, you should use <ApiLink to="class/Actor#openKeyValueStore">`Actor.openKeyValueStore()`</ApiLink>, <ApiLink to="class/Actor#openDataset">`Actor.openDataset()`</ApiLink> and <ApiLink to="class/Actor#openRequestQueue">`Actor.openRequestQueue()`</ApiLink> to open the respective storage.
 
-Using each of these methods allows to pass the <ApiLink to="apify/interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="apify/interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
+Using each of these methods allows to pass the <ApiLink to="interface/OpenStorageOptions">`OpenStorageOptions`</ApiLink> as a second argument, which has only one optional property: <ApiLink to="interface/OpenStorageOptions#forceCloud">`forceCloud`</ApiLink>. If set to `true` - cloud storage will be used instead of the folder on the local disk.
 
 :::note
-If you don't plan to force usage of the platform storages when running the actor locally, there is no need to use the <ApiLink to="apify/class/Actor">`Actor`</ApiLink> class for it. The Crawlee variants <ApiLink to="apify/class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="apify/class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="apify/class/RequestQueue#open">`RequestQueue.open()`</ApiLink> will work the same.
+If you don't plan to force usage of the platform storages when running the actor locally, there is no need to use the <ApiLink to="class/Actor">`Actor`</ApiLink> class for it. The Crawlee variants <ApiLink to="class/KeyValueStore#open">`KeyValueStore.open()`</ApiLink>, <ApiLink to="class/Dataset#open">`Dataset.open()`</ApiLink> and <ApiLink to="class/RequestQueue#open">`RequestQueue.open()`</ApiLink> will work the same.
 :::
 
 ### Getting public url of an item in the platform storage
 
-If you need to share a link to some file stored in a Key-Value Store on Apify Platform, you can use <ApiLink to="apify/class/KeyValueStore#getPublicUrl">`getPublicUrl()`</ApiLink> method. It accepts only one parameter: `key` - the key of the item you want to share.
+If you need to share a link to some file stored in a Key-Value Store on Apify Platform, you can use <ApiLink to="class/KeyValueStore#getPublicUrl">`getPublicUrl()`</ApiLink> method. It accepts only one parameter: `key` - the key of the item you want to share.
 
 ```js
 import { KeyValueStore } from 'apify';
@@ -232,7 +232,7 @@ const url = store.getPublicUrl('your-file');
 
 ### Exporting dataset data
 
-When the <ApiLink to="apify/class/Dataset">`Dataset`</ApiLink> is stored on the [Apify platform](https://apify.com/actors), you can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
+When the <ApiLink to="class/Dataset">`Dataset`</ApiLink> is stored on the [Apify platform](https://apify.com/actors), you can export its data to the following formats: HTML, JSON, CSV, Excel, XML and RSS. The datasets are displayed on the actor run details page and in the [Storage](https://console.apify.com/storage) section in the Apify Console. The actual data is exported using the [Get dataset items](https://apify.com/docs/api/v2#/reference/datasets/item-collection/get-items) Apify API endpoint. This way you can easily share the crawling results.
 
 **Related links**
 
@@ -312,7 +312,7 @@ const proxyConfiguration = await Actor.createProxyConfiguration();
 const proxyUrl = await proxyConfiguration.newUrl();
 ```
 
-Note that unlike using your own proxies in Crawlee, you shouldn't use the constructor to create <ApiLink to="apify/class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
+Note that unlike using your own proxies in Crawlee, you shouldn't use the constructor to create <ApiLink to="class/ProxyConfiguration">`ProxyConfiguration`</ApiLink> instance. For using Apify Proxy you should create an instance using the <ApiLink to="class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function instead.
 
 ### Apify Proxy Configuration
 
@@ -344,8 +344,8 @@ essentially has two modes: Apify Proxy or Own (third party) proxy.
 
 The difference is easy to remember.
 
-- If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="apify/class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="apify/interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
-- If you are planning to use Apify Proxy - you should create an instance using the <ApiLink to="apify/class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. <ApiLink to="apify/interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="apify/interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
+- If you're using your own proxies - you should create an instance with the ProxyConfiguration <ApiLink to="class/ProxyConfiguration#constructor">`constructor`</ApiLink> function based on the provided <ApiLink to="interface/ProxyConfigurationOptions">`ProxyConfigurationOptions`</ApiLink>.
+- If you are planning to use Apify Proxy - you should create an instance using the <ApiLink to="class/Actor#createProxyConfiguration">`Actor.createProxyConfiguration()`</ApiLink> function. <ApiLink to="interface/ProxyConfigurationOptions#proxyUrls">`ProxyConfigurationOptions.proxyUrls`</ApiLink> and <ApiLink to="interface/ProxyConfigurationOptions#newUrlFunction">`ProxyConfigurationOptions.newUrlFunction`</ApiLink> enable use of your custom proxy URLs, whereas all the other options are there to configure Apify Proxy.
 
 **Related links**
 

--- a/docs/03_guides/cheerio_crawler.ts
+++ b/docs/03_guides/cheerio_crawler.ts
@@ -25,7 +25,7 @@ const crawler = new CheerioCrawler({
 
     // This function will be called for each URL to crawl.
     // It accepts a single parameter, which is an object with options as:
-    // https://sdk.apify.com/docs/typedefs/cheerio-crawler-options#handlepagefunction
+    // https://crawlee.dev/js/api/cheerio-crawler/interface/CheerioCrawlerOptions#requestHandler
     // We use for demonstration only 2 of them:
     // - request: an instance of the Request class with information such as URL and HTTP method
     // - $: the cheerio object containing parsed HTML

--- a/docs/04_upgrading/upgrading_v1.md
+++ b/docs/04_upgrading/upgrading_v1.md
@@ -74,7 +74,7 @@ npm install apify playwright
 
 If you want to make use of Playwright on the Apify Platform, you need to use a Docker image
 that supports Playwright. We've created them for you, so head over to the new
-[Docker image guide](https://sdk.apify.com/docs/guides/docker-images) and pick the one
+[Docker image guide](https://docs.apify.com/sdk/js/docs/concepts/docker-images) and pick the one
 that best suits your needs.
 
 Note that your `package.json` **MUST** include `puppeteer` and/or `playwright` as dependencies.

--- a/src/proxy_configuration.ts
+++ b/src/proxy_configuration.ts
@@ -264,7 +264,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
         if (proxyUrls && proxyUrls.some((url) => url?.includes('apify.com'))) {
             this.log.warning(
                 'Some Apify proxy features may work incorrectly. Please consider setting up Apify properties instead of `proxyUrls`.\n' +
-                    'See https://sdk.apify.com/docs/guides/proxy-management#apify-proxy-configuration',
+                    'See https://docs.apify.com/sdk/js/docs/concepts/proxy-management#apify-proxy-configuration',
             );
         }
     }

--- a/website/tools/utils/externalLink.js
+++ b/website/tools/utils/externalLink.js
@@ -2,7 +2,7 @@ const { parse } = require('url');
 
 const visit = import('unist-util-visit').then((m) => m.visit);
 
-const internalUrls = ['sdk.apify.com'];
+const internalUrls = ['docs.apify.com'];
 
 /**
  * @param {import('url').UrlWithStringQuery} href


### PR DESCRIPTION
## Summary

- Replaces references to the legacy `sdk.apify.com` domain with the current `docs.apify.com/sdk/js` URLs.
- Prefers the `ApiLink` component (introduced in #610) for API references in MDX docs so they stay tied to the current version.
- Updates the `externalLink` rehype plugin's internal-host allowlist to `docs.apify.com`.

Touched files:
- `MIGRATIONS.md`, `docs/04_upgrading/upgrading_v1.md` — Docker image guide link.
- `docs/02_concepts/01_actor_lifecycle.mdx` — switched all `sdk.apify.com/api/apify/...` links to `<ApiLink>`.
- `docs/03_guides/cheerio_crawler.ts` — updated stale comment URL (CheerioCrawler now lives in Crawlee).
- `src/proxy_configuration.ts` — warning message URL.
- `website/tools/utils/externalLink.js` — internal-host list now matches `docs.apify.com`.

Versioned docs under `website/versioned_docs/` were intentionally left untouched (they are frozen snapshots of past releases).

Closes #612

## Test plan

- [ ] `npm run build` (website) renders without broken-link errors
- [ ] Spot-check that `<ApiLink>` references in `docs/02_concepts/01_actor_lifecycle.mdx` resolve to the correct API pages
- [ ] Confirm the proxy warning message renders cleanly when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)