### PR TITLE
chore: stop publishing broken declaration and source maps

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,10 @@
         "outDir": "./dist",
         "rootDir": "./src",
         "module": "Node16",
-        "moduleResolution": "Node16"
+        "moduleResolution": "Node16",
+
+        "declarationMap": false,
+        "sourceMap": false
     },
     "include": ["./src/**/*"],
     "exclude": ["**/node_modules", "**/dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.build.json",
     "compilerOptions": {
+        "sourceMap": true,
         "paths": {
             "apify": ["./src"]
         }


### PR DESCRIPTION
The published tarball excludes `src` but ships `.d.ts.map`/`.js.map` that reference `../src/*.ts`, so the maps never resolve — editors fall back to the compiled `.d.ts`/`.js` instead of the original source. Disabling `declarationMap`/`sourceMap` in the build config stops emitting these dead maps and shrinks the tarball; `sourceMap` stays on in the dev `tsconfig.json` for local debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)