### PR TITLE
ci: cache Playwright browsers and add install timeout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,16 @@ jobs:
             - name: Install pnpm and dependencies
               uses: apify/actions/pnpm-install@v1.1.2
 
+            - name: Cache Playwright browsers
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      playwright-${{ runner.os }}-
+
             - name: Install Playwright browsers
+              timeout-minutes: 10
               run: pnpm exec playwright install --with-deps
 
             - name: Build

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -41,7 +41,16 @@ jobs:
             - name: Install pnpm and dependencies
               uses: apify/actions/pnpm-install@v1.1.2
 
+            - name: Cache Playwright browsers
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      playwright-${{ runner.os }}-
+
             - name: Install Playwright browsers
+              timeout-minutes: 10
               run: pnpm exec playwright install --with-deps
 
             - name: Build


### PR DESCRIPTION
`playwright install --with-deps` re-downloaded all browsers from `cdn.playwright.dev` on every CI run, with no browser cache and no timeout. When the CDN stalls, the step hangs until the job limit instead of failing fast — which is why many PRs get stuck on `Install Playwright browsers` at once (CDN-driven, not PR-specific).

Caches `~/.cache/ms-playwright` keyed by the lockfile so warm runs skip the download, and caps the install step at `timeout-minutes: 10` so a stalled download fails fast and can be retried. Applied to `test-and-release.yaml` and `release.yaml`. Mirrors apify/crawlee#3691.