### PR TITLE
feat: export ApifyStorageClient (+ fix v4 e2e storage reads)

### DIFF
--- a/docs/04_upgrading/upgrading_v4.md
+++ b/docs/04_upgrading/upgrading_v4.md
@@ -1,0 +1,122 @@
+---
+id: upgrading-to-v4
+title: Upgrading to v4
+---
+
+This page summarizes the breaking changes between Apify SDK v3 and v4. Apify SDK v4 adopts the redesigned Crawlee v4 interfaces (`Configuration`, `EventManager`, `StorageClient`, `ProxyConfiguration`), so most of the changes here track the corresponding Crawlee v4 changes.
+
+## Node.js 22+
+
+The SDK now requires **Node.js 22 or newer**.
+
+## ESM
+
+The SDK is now published as native ESM (the package is `"type": "module"`) and no longer ships a separate CommonJS build. This does **not** change how you load it: the SDK has no top-level `await`, and the supported Node.js versions can `require()` ESM modules, so both `import` and `require('apify')` keep working.
+
+```ts
+import { Actor } from 'apify';
+// CommonJS projects can still use:
+const { Actor } = require('apify');
+```
+
+## Configuration
+
+The `Configuration` class no longer exposes `.get(key)` / `.set(key, value)`. Configuration values are resolved eagerly at construction time and exposed as plain typed properties.
+
+Before (v3):
+
+```ts
+import { Configuration } from 'apify';
+
+const config = Configuration.getGlobalConfig();
+const token = config.get('token');
+config.set('token', 'new-token');
+```
+
+After (v4):
+
+```ts
+import { Configuration } from 'apify';
+
+// Construct with overrides — Configuration is immutable.
+const config = new Configuration({ token: 'new-token' });
+const token = config.token;
+```
+
+Resolution order (highest to lowest priority): constructor options → environment variables → `crawlee.json` → schema defaults.
+
+Empty-string environment variables are treated as unset (they fall through to the schema default) rather than being coerced to `0` / `''` / `false`. For example, `ACTOR_MAX_TOTAL_CHARGE_USD=""` now resolves to `undefined` instead of `0`.
+
+When a setting is exposed under several environment variables, the Apify-specific ones take precedence over Crawlee's generic one — i.e. `ACTOR_*` / `APIFY_*` are checked before `CRAWLEE_*`. For example, if both `APIFY_HEADLESS` and `CRAWLEE_HEADLESS` are set, `APIFY_HEADLESS` wins.
+
+`new Actor({ configuration })` accepts a pre-built `Configuration`, but it must be the Apify SDK's `Configuration` (imported from `apify`), not a bare Crawlee one — otherwise the `APIFY_*` / `ACTOR_*` environment variables are never resolved, so the SDK now throws if given a non-Apify instance.
+
+## ProxyConfiguration: `newUrl()` / `newProxyInfo()` no longer take `sessionId`
+
+The `sessionId` parameter has been removed from both `ProxyConfiguration.newUrl()` and `ProxyConfiguration.newProxyInfo()`. Each call now returns an independent URL; for Apify Proxy the SDK mints a fresh random session id internally for every URL it hands out, so consecutive calls resolve to different IPs.
+
+Before (v3):
+
+```ts
+const proxyConfiguration = await Actor.createProxyConfiguration({
+    groups: ['RESIDENTIAL'],
+});
+
+// Sticky pairing: same sessionId → same proxy URL → same IP.
+const url1 = await proxyConfiguration.newUrl('mySession');
+const url2 = await proxyConfiguration.newUrl('mySession'); // === url1
+```
+
+After (v4):
+
+```ts
+const proxyConfiguration = await Actor.createProxyConfiguration({
+    groups: ['RESIDENTIAL'],
+});
+
+// Every call returns an independent URL with its own session id.
+const url1 = await proxyConfiguration.newUrl();
+const url2 = await proxyConfiguration.newUrl(); // !== url1
+```
+
+Session continuity (reusing the same IP across multiple requests) is now handled one level up by Crawlee's `SessionPool`: a `Session` stores the proxy URL it was paired with and the crawler reuses that URL for subsequent requests bound to the same session. When using `CheerioCrawler`, `PlaywrightCrawler`, etc. with `useSessionPool: true`, this is automatic — no code changes are required on the consumer side.
+
+`ProxyInfo` no longer carries a `sessionId` field. If you used it for logging or analytics, parse the `session-<id>` segment out of `proxyInfo.username` instead (it is included for Apify Proxy URLs).
+
+The `tieredProxyUrls` and `tieredProxyConfig` options on `ProxyConfigurationOptions` were dropped in Crawlee v4 ([apify/crawlee#3599](https://github.com/apify/crawlee/pull/3599)) and the SDK no longer threads them through. Migrate to named sessions via `SessionPool` if you relied on tiered rotation.
+
+## EventManager
+
+`PlatformEventManager` now extends Crawlee v4's `EventManager` and integrates with the new service locator. Use `Configuration.getGlobalConfig()` (or pass a `Configuration` instance explicitly) when constructing it directly — the constructor no longer accepts a `config` override via the `override` keyword pattern because Crawlee's base class manages the configuration through `serviceLocator` instead of a `config` field.
+
+If you only interact with events through `Actor.on()` / `Actor.off()` / `Actor.events`, no code changes are needed.
+
+## StorageClient
+
+The SDK's storage layer was adapted to the new Crawlee v4 `StorageClient` interface. The Apify platform client is wrapped via the `ApifyStorageClient` adapter — now exported from `apify` — which implements `createDatasetClient`, `createKeyValueStoreClient`, and `createRequestQueueClient`.
+
+`Actor` wires this up for you, so most code needs no changes. But if you previously passed a raw `apify-client` `ApifyClient` straight into a Crawlee storage as its `storageClient` — which worked in v3 — it no longer does: Crawlee v4 calls `createKeyValueStoreClient()` / `createDatasetClient()`, which the raw client doesn't implement. Wrap it in `ApifyStorageClient`:
+
+```ts
+// v3
+import { ApifyClient, KeyValueStore } from 'apify';
+
+const client = new ApifyClient({ token });
+const store = await KeyValueStore.open(storeId, { storageClient: client });
+
+// v4
+import { ApifyClient, ApifyStorageClient, KeyValueStore } from 'apify';
+
+const client = new ApifyClient({ token });
+const store = await KeyValueStore.open(storeId, { storageClient: new ApifyStorageClient(client) });
+```
+
+`KeyValueStore.getPublicUrl()` is now asynchronous (it signs URLs server-side when running on the Apify platform). Update call sites accordingly:
+
+```ts
+// v3
+const url = store.getPublicUrl('myKey');
+
+// v4
+const url = await store.getPublicUrl('myKey');
+```

--- a/src/apify_storage_client.ts
+++ b/src/apify_storage_client.ts
@@ -114,6 +114,18 @@ class PpeAwareDatasetClient<
  * first (when one exists on the platform) and fall back to a name otherwise —
  * otherwise crawlee's `resolveStorageIdentifier` treats every string as a name
  * and the SDK would silently create a new storage named like the passed id.
+ *
+ * `Actor` wires this up automatically; construct it directly only to use Apify
+ * platform storage with crawlee's storage classes outside of `Actor` — e.g. to
+ * read another run's output with an explicit token:
+ *
+ * ```ts
+ * import { ApifyClient, ApifyStorageClient, Dataset } from 'apify';
+ *
+ * const client = new ApifyClient({ token });
+ * const dataset = await Dataset.open(datasetId, { storageClient: new ApifyStorageClient(client) });
+ * const { items } = await dataset.getData();
+ * ```
  */
 export class ApifyStorageClient implements StorageClient {
     constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './actor.js';
+export { ApifyStorageClient } from './apify_storage_client.js';
 export type {
     OpenStorageOptions,
     StorageAlias,

--- a/test/e2e/sdk/actorCharge/test.mjs
+++ b/test/e2e/sdk/actorCharge/test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { ApifyClient, KeyValueStore } from 'apify';
+import { ApifyClient } from 'apify';
 import { sleep } from 'crawlee';
 
 const client = new ApifyClient({
@@ -39,11 +39,8 @@ test('basic functionality', async () => {
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, { foobar: 4 });
 
-    const store = await KeyValueStore.open(run.defaultKeyValueStoreId, {
-        storageClient: client,
-    });
-
-    const chargingDatasetId = await store.getValue('CHARGING_LOG_DATASET_ID');
+    const record = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('CHARGING_LOG_DATASET_ID');
+    const chargingDatasetId = record?.value ?? null;
     assert.equal(chargingDatasetId, null, 'Charging dataset ID must not be present');
 });
 

--- a/test/e2e/sdk/actorCharge/test.mjs
+++ b/test/e2e/sdk/actorCharge/test.mjs
@@ -26,15 +26,26 @@ await actor.update({
     ],
 });
 
-const runActor = async (input, options) => {
+// The platform reconciles `chargedEventCounts` onto the run record asynchronously
+// after the run finishes — and noticeably slower for runs that hit the charge
+// limit — so poll until it reaches the expected value instead of racing a fixed
+// delay (which made this test flaky).
+const runActor = async (input, options, expectedChargedEventCounts) => {
     const { id: runId } = await actor.call(input, options);
     await client.run(runId).waitForFinish();
-    await sleep(6000); // wait for updates to propagate to MongoDB
-    return await client.run(runId).get();
+
+    const expected = JSON.stringify(expectedChargedEventCounts);
+    const deadline = Date.now() + 60_000;
+    let run = await client.run(runId).get();
+    while (JSON.stringify(run.chargedEventCounts ?? {}) !== expected && Date.now() < deadline) {
+        await sleep(2000);
+        run = await client.run(runId).get();
+    }
+    return run;
 };
 
 test('basic functionality', async () => {
-    const run = await runActor({}, { maxTotalChargeUsd: 10 });
+    const run = await runActor({}, { maxTotalChargeUsd: 10 }, { foobar: 4 });
 
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, { foobar: 4 });
@@ -45,7 +56,7 @@ test('basic functionality', async () => {
 });
 
 test('charge limit', async () => {
-    const run = await runActor({}, { maxTotalChargeUsd: 0.2 });
+    const run = await runActor({}, { maxTotalChargeUsd: 0.2 }, { foobar: 3 });
 
     assert.strictEqual(run.status, 'SUCCEEDED');
 
@@ -54,7 +65,7 @@ test('charge limit', async () => {
 });
 
 test('default options start cost-unlimited runs', async () => {
-    const run = await runActor({}, {});
+    const run = await runActor({}, {}, { foobar: 4 });
 
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, { foobar: 4 });

--- a/test/e2e/sdk/actorChargeLocal/src/main.mjs
+++ b/test/e2e/sdk/actorChargeLocal/src/main.mjs
@@ -1,4 +1,4 @@
-import { Actor, ApifyClient, Dataset, log } from 'apify';
+import { Actor, ApifyClient, log } from 'apify';
 
 const client = new ApifyClient({
     token: process.env.APIFY_TOKEN,
@@ -33,7 +33,6 @@ const chargingLogDataset = await actor.openDataset('charging_log');
 const data = await chargingLogDataset.getData();
 
 // Transfer contents of the local charging log dataset into the default dataset on the platform
-const dataset = await Dataset.open(undefined, { storageClient: client });
-await dataset.pushData(data.items);
+await client.dataset(run.defaultDatasetId).pushItems(data.items);
 
 await actor.exit();

--- a/test/e2e/sdk/actorChargeLocal/src/main.mjs
+++ b/test/e2e/sdk/actorChargeLocal/src/main.mjs
@@ -16,7 +16,9 @@ const actor = new Actor({
     useChargingLogDataset: true,
     testPayPerEvent: true,
     isAtHome: false,
-    maxTotalChargeUsd: maxTotalChargeUsd ?? Infinity,
+    // The SDK treats `0`/unset as "no limit" — don't pass `Infinity`, which
+    // isn't a valid config input (zod rejects non-finite numbers).
+    maxTotalChargeUsd: maxTotalChargeUsd ?? 0,
     logLevel: 'DEBUG',
 });
 

--- a/test/e2e/sdk/actorChargeLocal/test.mjs
+++ b/test/e2e/sdk/actorChargeLocal/test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { ApifyClient, Dataset } from 'apify';
+import { ApifyClient } from 'apify';
 import { sleep } from 'crawlee';
 
 const client = new ApifyClient({
@@ -23,15 +23,12 @@ test('basic functionality', async () => {
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, undefined);
 
-    const chargingDataset = await Dataset.open(run.defaultDatasetId, {
-        storageClient: client,
-    });
-    const chargingRecords = await chargingDataset.getData();
+    const chargingRecords = await client.dataset(run.defaultDatasetId).listItems();
 
     assert.strictEqual(
         chargingRecords.count,
         1,
-        `There must be exactly one item in the charging dataset (ID ${chargingDataset.id})`,
+        `There must be exactly one item in the charging dataset (ID ${run.defaultDatasetId})`,
     );
     assert.strictEqual(chargingRecords.items[0].chargedCount, 4);
     assert.strictEqual(chargingRecords.items[0].eventName, 'foobar');
@@ -43,15 +40,12 @@ test('charge limit', async () => {
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, undefined);
 
-    const chargingDataset = await Dataset.open(run.defaultDatasetId, {
-        storageClient: client,
-    });
-    const chargingRecords = await chargingDataset.getData();
+    const chargingRecords = await client.dataset(run.defaultDatasetId).listItems();
 
     assert.strictEqual(
         chargingRecords.count,
         1,
-        `There must be exactly one item in the charging dataset (ID ${chargingDataset.id})`,
+        `There must be exactly one item in the charging dataset (ID ${run.defaultDatasetId})`,
     );
     // The Actor tries to charge 4 events, the limit allows 2, but the SDK intentionally overcharges by 1 so that the Actor doesn't get stuck
     assert.strictEqual(chargingRecords.items[0].chargedCount, 3);

--- a/test/e2e/sdk/actorInput/test.mjs
+++ b/test/e2e/sdk/actorInput/test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { ApifyClient, KeyValueStore } from 'apify';
+import { ApifyClient } from 'apify';
 import { sleep } from 'crawlee';
 
 const client = new ApifyClient({
@@ -22,12 +22,8 @@ test('defaults work', async () => {
 
     assert.strictEqual(run.status, 'SUCCEEDED');
 
-    const store = await KeyValueStore.open(run.defaultKeyValueStoreId, {
-        storageClient: client,
-    });
-
-    const receivedInput = await store.getValue('RECEIVED_INPUT');
-    assert.deepEqual(receivedInput, { foo: 'bar' });
+    const record = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('RECEIVED_INPUT');
+    assert.deepEqual(record?.value, { foo: 'bar' });
 });
 
 test('input is passed through', async () => {
@@ -35,10 +31,6 @@ test('input is passed through', async () => {
 
     assert.strictEqual(run.status, 'SUCCEEDED');
 
-    const store = await KeyValueStore.open(run.defaultKeyValueStoreId, {
-        storageClient: client,
-    });
-
-    const receivedInput = await store.getValue('RECEIVED_INPUT');
-    assert.deepEqual(receivedInput, { foo: 'baz' });
+    const record = await client.keyValueStore(run.defaultKeyValueStoreId).getRecord('RECEIVED_INPUT');
+    assert.deepEqual(record?.value, { foo: 'baz' });
 });

--- a/test/e2e/sdk/actorPushDataSynth/test.mjs
+++ b/test/e2e/sdk/actorPushDataSynth/test.mjs
@@ -36,15 +36,33 @@ await actor.update({
     ],
 });
 
-const runActor = async (input, options) => {
+// The platform reconciles `chargedEventCounts` onto the run record asynchronously
+// after the run finishes, so poll until it reaches the expected value instead of
+// racing a fixed delay (which made this test flaky).
+const runActor = async (input, options, expectedChargedEventCounts) => {
     const { id: runId } = await actor.call(input, options);
     await client.run(runId).waitForFinish();
-    await sleep(9000); // wait for updates to propagate to MongoDB
-    return await client.run(runId).get();
+
+    const expected = JSON.stringify(expectedChargedEventCounts);
+    const deadline = Date.now() + 60_000;
+    let run = await client.run(runId).get();
+    while (JSON.stringify(run.chargedEventCounts ?? {}) !== expected && Date.now() < deadline) {
+        await sleep(2000);
+        run = await client.run(runId).get();
+    }
+    return run;
 };
 
 test('pushData charges both apify-default-dataset-item and custom event', async () => {
-    const run = await runActor({}, { maxTotalChargeUsd: 10 });
+    const run = await runActor(
+        {},
+        { maxTotalChargeUsd: 10 },
+        {
+            'apify-actor-start': 1,
+            'apify-default-dataset-item': 100,
+            result: 100,
+        },
+    );
 
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, {
@@ -60,7 +78,15 @@ test('charge limit applies to combined cost of both events', async () => {
     // Remaining: $0.50
     // Each pushData item costs $0.005 (default) + $0.01 (result) = $0.015
     // Items within budget: floor($0.50 / $0.015) = 33
-    const run = await runActor({}, { maxTotalChargeUsd: 1.5 });
+    const run = await runActor(
+        {},
+        { maxTotalChargeUsd: 1.5 },
+        {
+            'apify-actor-start': 1,
+            'apify-default-dataset-item': 33,
+            result: 33,
+        },
+    );
 
     assert.strictEqual(run.status, 'SUCCEEDED');
     assert.deepEqual(run.chargedEventCounts, {

--- a/test/e2e/sdk/helloWorld/test.mjs
+++ b/test/e2e/sdk/helloWorld/test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import { ApifyClient, Dataset } from 'apify';
+import { ApifyClient } from 'apify';
 
 const client = new ApifyClient({
     token: process.env.APIFY_TOKEN,
@@ -11,8 +11,5 @@ const actor = client.actor(process.argv[2]);
 const run = await actor.call({}, { waitSecs: 15 });
 assert.equal(run.exitCode, 0);
 
-const dataset = await Dataset.open(run.defaultDatasetId, {
-    storageClient: client,
-});
-const data = await dataset.getData();
+const data = await client.dataset(run.defaultDatasetId).listItems();
 assert.deepEqual(data.items, [{ hello: 'world' }]);

--- a/test/e2e/sdk/multiStorage/test.mjs
+++ b/test/e2e/sdk/multiStorage/test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { ApifyClient, Dataset, KeyValueStore } from 'apify';
+import { ApifyClient } from 'apify';
 import { sleep } from 'crawlee';
 
 const client = new ApifyClient({
@@ -23,11 +23,10 @@ test('aliased storages are resolved and written to correctly', async () => {
     assert.strictEqual(run.status, 'SUCCEEDED');
 
     // Read the aliased storage IDs that the actor stored in the default KVS
-    const defaultStore = await KeyValueStore.open(run.defaultKeyValueStoreId, {
-        storageClient: client,
-    });
-
-    const aliasedDatasetId = await defaultStore.getValue('ALIASED_DATASET_ID');
+    const aliasedDatasetIdRecord = await client
+        .keyValueStore(run.defaultKeyValueStoreId)
+        .getRecord('ALIASED_DATASET_ID');
+    const aliasedDatasetId = aliasedDatasetIdRecord?.value ?? null;
 
     assert.ok(aliasedDatasetId, 'Aliased dataset ID must be present');
 
@@ -35,10 +34,7 @@ test('aliased storages are resolved and written to correctly', async () => {
     assert.notEqual(aliasedDatasetId, run.defaultDatasetId, 'Aliased dataset should differ from the default dataset');
 
     // Verify data in the aliased dataset
-    const aliasedDataset = await Dataset.open(aliasedDatasetId, {
-        storageClient: client,
-    });
-    const datasetData = await aliasedDataset.getData();
+    const datasetData = await client.dataset(aliasedDatasetId).listItems();
 
     assert.strictEqual(datasetData.count, 2, 'Aliased dataset should have 2 items');
     assert.strictEqual(datasetData.items[0].url, 'https://example.com');

--- a/test/e2e/sdk/multiStorageLocal/src/lifecycle.mjs
+++ b/test/e2e/sdk/multiStorageLocal/src/lifecycle.mjs
@@ -1,4 +1,4 @@
-import { Actor, ApifyClient, Dataset } from 'apify';
+import { Actor, ApifyClient } from 'apify';
 
 const client = new ApifyClient({
     token: process.env.APIFY_TOKEN,
@@ -34,11 +34,7 @@ const allData = await resultsDatasetAgain.getData();
 
 // Transfer results to the platform's default dataset so the test script can verify
 const run = await client.run(process.env.ACTOR_RUN_ID).get();
-const platformDataset = await Dataset.open(run.defaultDatasetId, {
-    storageClient: client,
-});
-
-await platformDataset.pushData([
+await client.dataset(run.defaultDatasetId).pushItems([
     {
         datasetItemCount: allData.count,
         datasetItems: allData.items,

--- a/test/e2e/sdk/multiStorageLocal/test.mjs
+++ b/test/e2e/sdk/multiStorageLocal/test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { ApifyClient, Dataset } from 'apify';
+import { ApifyClient } from 'apify';
 import { sleep } from 'crawlee';
 
 const client = new ApifyClient({
@@ -26,10 +26,7 @@ test('aliased storages work locally with purge-on-first-open across restarts', a
 
     assert.strictEqual(run.status, 'SUCCEEDED');
 
-    const dataset = await Dataset.open(run.defaultDatasetId, {
-        storageClient: client,
-    });
-    const data = await dataset.getData();
+    const data = await client.dataset(run.defaultDatasetId).listItems();
 
     assert.strictEqual(data.count, 2, 'There must be exactly two summary items (one per lifecycle)');
 

--- a/test/e2e/sdk/publicUrl/src/main.mjs
+++ b/test/e2e/sdk/publicUrl/src/main.mjs
@@ -9,7 +9,7 @@ await Actor.setValue('public-record-key', JSON.stringify(data), {
 });
 
 const defaultKeyValueStore = await Actor.openKeyValueStore();
-const publicUrl = defaultKeyValueStore.getPublicUrl('public-record-key');
+const publicUrl = await defaultKeyValueStore.getPublicUrl('public-record-key');
 
 // Here we store the url itself
 await Actor.setValue('urlToPublicData', publicUrl);


### PR DESCRIPTION
## What

Two related changes around crawlee v4's storage-client interface:

1. **`feat:` export `ApifyStorageClient`** — the adapter from apify-client to crawlee v4's `StorageClient` interface. `Actor` wires it up internally, but it wasn't exported, so external code had no supported way to use Apify platform storage with crawlee's storage classes — e.g. `Dataset.open(id, { storageClient: new ApifyStorageClient(client) })` with an explicit token. Now public, with a usage example in its JSDoc.

2. **`test:` fix the v4 e2e tests** ([`actorCharge › basic functionality`](https://github.com/apify/apify-sdk-js/actions/runs/26893929679/job/79327413293) etc.), which failed with `client.createKeyValueStoreClient is not a function`.

## Why the e2e tests broke

They read/write a run's platform storage via crawlee's `Dataset.open` / `KeyValueStore.open`, passing the raw apify-client as `storageClient`:

```js
const client = new ApifyClient({ token });
await KeyValueStore.open(run.defaultKeyValueStoreId, { storageClient: client });
```

That worked under crawlee v3, but v4's `StorageClient` interface expects `createKeyValueStoreClient()` / `createDatasetClient()`, which the raw apify-client doesn't have.

These scripts are pure **verification** — they just read a run's output (or transfer it) to assert on it; they aren't exercising the SDK's storage path. So they now use the apify-client resource methods directly (the pattern already used in `actorChargeLocal/src/main.mjs`):

- `client.keyValueStore(id).getRecord(key)` instead of `KeyValueStore.open(...).getValue(key)`
- `client.dataset(id).listItems()` instead of `Dataset.open(...).getData()` (same `{ items, count, total }` shape)
- `client.dataset(id).pushItems(items)` instead of `Dataset.open(...).pushData(items)`

## Verification

- `pnpm build`, `pnpm lint`, `pnpm format:check` — clean; unit suite 122 passed / 14 skipped.
- `ApifyStorageClient` export resolves and adapts correctly (`createKeyValueStoreClient` → client with `getRecord`, `createDatasetClient` → client with `listItems`). Full e2e on CI.
