### PR TITLE
chore: require zod v4 (drop v3 support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "semver": "^7.5.4",
         "tslib": "^2.6.2",
         "ws": "^8.18.0",
-        "zod": "^3.24.0 || ^4.0.0"
+        "zod": "^4.0.0"
     },
     "devDependencies": {
         "@apify/oxlint-config": "^0.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: ^8.18.0
         version: 8.21.0
       zod:
-        specifier: ^3.24.0 || ^4.0.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@apify/oxlint-config':
         specifier: ^0.2.5
@@ -8974,6 +8974,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -10366,7 +10369,7 @@ snapshots:
       tough-cookie: 6.0.1
       tslib: 2.8.1
       type-fest: 4.41.0
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19659,6 +19662,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -78,7 +78,7 @@ export const apifyConfigFields = {
     disableBrowserSandbox: withApifyEnv(
         crawleeConfigFields.disableBrowserSandbox,
         'APIFY_DISABLE_BROWSER_SANDBOX',
-        coerceBoolean.optional().default(() => (isAtHome() ? true : undefined)),
+        coerceBoolean.default(() => isAtHome()),
     ),
     persistStateIntervalMillis: withApifyEnv(crawleeConfigFields.persistStateIntervalMillis, [
         APIFY_ENV_VARS.PERSIST_STATE_INTERVAL_MILLIS,


### PR DESCRIPTION
## What

Require **zod v4** (`zod: "^4.0.0"`), dropping v3 from the supported range.

## Why

The SDK declared `zod: "^3.24.0 || ^4.0.0"`, but its lockfile/tests resolved **v3**, while fresh installs and the Apify platform resolve **v4**. So v4-only behavior shipped untested — and bit us: zod v4 is stricter (it rejects non-finite numbers like `Infinity`, and tightened `.default()` typings), which surfaced as a production `ZodError` in an e2e actor. Pinning to `^4` means the SDK is built and tested against the version it actually runs on.

Verified `@crawlee/core` resolves the **same** zod 4 instance, so there's no zod-3-vs-4 schema-interop mismatch between the SDK and crawlee.

## The one code change

`disableBrowserSandbox` used `coerceBoolean.optional().default(() => isAtHome() ? true : undefined)`. zod v4's `.default()` no longer accepts a callback that can return `undefined` (it was always a type-lie — the field is typed `boolean`). Replaced with `coerceBoolean.default(() => isAtHome())`:

- on the platform → `true` (unchanged — containers run as root, where Chrome can't sandbox),
- locally → now an explicit `false` (sandbox kept) instead of `undefined` (behaviorally identical for browser launch, and matches crawlee's `boolean` type).

## Verification

- `pnpm build` (tsc under zod 4) — clean
- `pnpm test` — 122 passed / 14 skipped
- `pnpm lint`, `pnpm format:check` — clean
