### PR TITLE
refactor: use native node:http for the proxy status check (drop undici)

### DIFF
--- a/docs/04_upgrading/upgrading_v4.md
+++ b/docs/04_upgrading/upgrading_v4.md
@@ -5,9 +5,9 @@ title: Upgrading to v4
 
 This page summarizes the breaking changes between Apify SDK v3 and v4. Apify SDK v4 adopts the redesigned Crawlee v4 interfaces (`Configuration`, `EventManager`, `StorageClient`, `ProxyConfiguration`), so most of the changes here track the corresponding Crawlee v4 changes.
 
-## Node.js 22.19+
+## Node.js 22+
 
-The SDK now requires **Node.js 22.19 or newer**.
+The SDK now requires **Node.js 22 or newer**.
 
 ## ESM
 
@@ -152,6 +152,6 @@ The original `ZodError` is also kept on `error.cause`.
 
 The SDK dropped several runtime dependencies in favor of native Node.js APIs and packages it already pulls in:
 
-- **`got-scraping`** — the internal Apify Proxy status check now uses the native `fetch` (via `undici`'s `ProxyAgent`). If your Actor imported `got-scraping` transitively through `apify`, add it to your own `dependencies`.
+- **`got-scraping`** — the internal Apify Proxy status check now uses a native `node:http` request. If your Actor imported `got-scraping` transitively through `apify`, add it to your own `dependencies`.
 - **`fs-extra`** — replaced with `node:fs`.
 - **`ow`** — replaced with `zod` (see above).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "3.7.2",
     "description": "The scalable web crawling and scraping library for JavaScript/Node.js. Enables development of data extraction and web automation jobs (not only) with headless Chrome and Puppeteer.",
     "engines": {
-        "node": ">=22.19.0"
+        "node": ">=22.0.0"
     },
     "type": "module",
     "main": "./dist/index.js",
@@ -83,7 +83,6 @@
         "apify-client": "^2.23.4",
         "semver": "^7.5.4",
         "tslib": "^2.6.2",
-        "undici": "^8.0.0",
         "ws": "^8.18.0",
         "zod": "^4.0.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,6 @@ importers:
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
-      undici:
-        specifier: ^8.0.0
-        version: 8.3.0
       ws:
         specifier: ^8.18.0
         version: 8.21.0
@@ -8506,10 +8503,6 @@ packages:
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
-
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
-    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -19169,8 +19162,6 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@7.24.8: {}
-
-  undici@8.3.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/src/proxy_configuration.ts
+++ b/src/proxy_configuration.ts
@@ -1,7 +1,10 @@
+import { once } from 'node:events';
+import { request as httpRequest, type IncomingMessage } from 'node:http';
+import { json } from 'node:stream/consumers';
+
 import type { ProxyConfigurationOptions as CoreProxyConfigurationOptions } from '@crawlee/core';
 import { ProxyConfiguration as CoreProxyConfiguration } from '@crawlee/core';
 import type { ProxyInfo as CoreProxyInfo } from '@crawlee/types';
-import { fetch, ProxyAgent } from 'undici';
 import { z } from 'zod';
 
 import { APIFY_ENV_VARS, APIFY_PROXY_VALUE_REGEX } from '@apify/consts';
@@ -21,6 +24,13 @@ const SUBDIVISION_CODE_REGEX = /^[A-Z0-9]{1,3}$/;
 // users; a fresh one is minted for every URL the SDK hands out so that the
 // returned proxy URLs are independent.
 const SESSION_ID_LENGTH = 12;
+
+/** Response of the Apify Proxy status endpoint (`proxy.apify.com/?format=json`). */
+interface ProxyStatus {
+    connected: boolean;
+    connectionError: string;
+    isManInTheMiddle: boolean;
+}
 
 type NewUrlOptions = Parameters<CoreProxyConfiguration['newProxyInfo']>[0];
 
@@ -423,49 +433,64 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
     /**
      * Apify Proxy can be down for a second or a minute, but this should not crash processes.
      */
-    protected async _fetchStatus(): Promise<
-        | {
-              connected: boolean;
-              connectionError: string;
-              isManInTheMiddle: boolean;
-          }
-        | undefined
-    > {
+    protected async _fetchStatus(): Promise<ProxyStatus | undefined> {
         const { proxyStatusUrl } = this.config;
-        const url = `${proxyStatusUrl}/?format=json`;
+        const statusUrl = `${proxyStatusUrl}/?format=json`;
 
-        // The status endpoint (`proxy.apify.com`) is requested *through* the proxy
-        // so it can report on this exact connection (auth + man-in-the-middle).
-        // `undici`'s `fetch` + `ProxyAgent` come from the same package, so the
-        // dispatcher is recognized (Node's global `fetch` uses a separate internal
-        // copy of undici that would reject this dispatcher instance).
         const proxyUrl = await this.newUrl();
         // Without a proxy URL we can't perform the (proxied) status check.
         if (!proxyUrl) return undefined;
-        const dispatcher = new ProxyAgent(proxyUrl);
 
-        try {
-            for (let attempt = 1; attempt <= CHECK_ACCESS_MAX_ATTEMPTS; attempt++) {
-                try {
-                    const response = await fetch(url, {
-                        dispatcher,
-                        signal: AbortSignal.timeout(CHECK_ACCESS_REQUEST_TIMEOUT_MILLIS),
-                    });
-                    if (!response.ok) continue;
-                    return (await response.json()) as {
-                        connected: boolean;
-                        connectionError: string;
-                        isManInTheMiddle: boolean;
-                    };
-                } catch {
-                    // retry connection errors
-                }
+        for (let attempt = 1; attempt <= CHECK_ACCESS_MAX_ATTEMPTS; attempt++) {
+            try {
+                return await this._requestStatus(statusUrl, proxyUrl);
+            } catch {
+                // retry connection errors
             }
-
-            return undefined;
-        } finally {
-            await dispatcher.close();
         }
+
+        return undefined;
+    }
+
+    /**
+     * Fetches the Apify Proxy status endpoint once, *through* the proxy, so the
+     * response reports on this exact connection (auth + man-in-the-middle).
+     *
+     * Uses a native `node:http` forward-proxy request — an absolute request URL
+     * plus a `Proxy-Authorization` header — so no proxy-agent dependency is
+     * needed. The status endpoint (`http://proxy.apify.com`) is plain HTTP.
+     */
+    protected async _requestStatus(statusUrl: string, proxyUrl: string): Promise<ProxyStatus> {
+        const target = new URL(statusUrl);
+        const proxy = new URL(proxyUrl);
+
+        const headers: Record<string, string> = { host: target.host };
+        if (proxy.username) {
+            const credentials = `${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`;
+            headers['proxy-authorization'] = `Basic ${Buffer.from(credentials).toString('base64')}`;
+        }
+
+        const request = httpRequest({
+            host: proxy.hostname,
+            port: proxy.port,
+            // Absolute-form request URI tells the proxy to forward the request.
+            path: target.href,
+            headers,
+            signal: AbortSignal.timeout(CHECK_ACCESS_REQUEST_TIMEOUT_MILLIS),
+        });
+        request.end();
+
+        // `once` rejects if the request emits `error` first (connection refused,
+        // timeout/abort), so failures propagate to the retry loop in `_fetchStatus`.
+        const [response] = (await once(request, 'response')) as [IncomingMessage];
+
+        const statusCode = response.statusCode ?? 0;
+        if (statusCode < 200 || statusCode >= 300) {
+            response.resume(); // drain so the socket can be freed
+            throw new Error(`Apify Proxy status check responded with status code ${statusCode}.`);
+        }
+
+        return (await json(response)) as ProxyStatus;
     }
 
     /**

--- a/test/apify/proxy_configuration.test.ts
+++ b/test/apify/proxy_configuration.test.ts
@@ -1,7 +1,7 @@
 import { Actor, ArgumentValidationError, ProxyConfiguration } from 'apify';
 import { UserClient } from 'apify-client';
 import { type Dictionary, sleep } from 'crawlee';
-import { fetch, ProxyAgent } from 'undici';
+import type { MockInstance } from 'vitest';
 
 import { APIFY_ENV_VARS, LOCAL_APIFY_ENV_VARS } from '@apify/consts';
 
@@ -22,30 +22,20 @@ const basicOpts = {
 const apifyProxyUrlPattern =
     /^http:\/\/groups-GROUP1\+GROUP2,session-[A-Za-z0-9]+,country-CZ:test12345@proxy\.apify\.com:8000$/;
 
-// The proxy status check uses undici's `fetch` (routed through a `ProxyAgent`)
-// instead of a heavy HTTP client. Mock both: `fetchSpy` stubs the status
-// response, `proxyAgentSpy` lets us assert the proxy URL the request is sent
-// through.
-// `ProxyAgent` is instantiated with `new`, so the mock must be a regular
-// (constructable) function, not an arrow.
-vitest.mock('undici', () => {
-    return {
-        fetch: vitest.fn(),
-        ProxyAgent: vitest.fn(function () {
-            return { close: vitest.fn() };
-        }),
-    };
-});
-
-const fetchSpy = vitest.mocked(fetch);
-const proxyAgentSpy = vitest.mocked(ProxyAgent);
-
-/** Builds a fake undici `Response` whose `json()` resolves to `body`. */
-const statusResponse = (body: unknown, ok = true) => ({ ok, json: async () => body }) as any;
+// The proxy status check is a `node:http` request through the proxy, encapsulated
+// in `_requestStatus(statusUrl, proxyUrl)`. Spy on it to stub the status response
+// and to assert the (session/groups/country) proxy URL the request is routed
+// through — without touching the network.
+//
+// The spy is (re)created in `beforeEach` because the vitest config has
+// `restoreMocks: true`, which un-spies module-level spies between tests. It
+// defaults to "unavailable" so tests that don't set a status never hit the real
+// network; tests opt in via `requestStatusSpy.mockResolvedValueOnce(...)`.
+let requestStatusSpy: MockInstance;
 
 beforeEach(() => {
-    fetchSpy.mockReset();
-    proxyAgentSpy.mockClear();
+    requestStatusSpy = vitest.spyOn(ProxyConfiguration.prototype as never, '_requestStatus');
+    requestStatusSpy.mockRejectedValue(new Error('Proxy status unavailable in tests'));
 });
 
 afterEach(() => {
@@ -426,7 +416,7 @@ describe('Actor.createProxyConfiguration()', () => {
     test('should work with all options', async () => {
         const status = { connected: true };
         const url = 'http://proxy.apify.com/?format=json';
-        fetchSpy.mockResolvedValueOnce(statusResponse(status));
+        requestStatusSpy.mockResolvedValueOnce(status);
 
         const proxyConfiguration = await Actor.createProxyConfiguration(basicOpts);
 
@@ -444,11 +434,7 @@ describe('Actor.createProxyConfiguration()', () => {
 
         // The status endpoint is fetched through a proxy whose URL carries the
         // groups/country/session built from the options.
-        expect(proxyAgentSpy).toBeCalledWith(expect.stringMatching(apifyProxyUrlPattern));
-        expect(fetchSpy).toBeCalledWith(url, {
-            dispatcher: expect.anything(),
-            signal: expect.any(AbortSignal),
-        });
+        expect(requestStatusSpy).toBeCalledWith(url, expect.stringMatching(apifyProxyUrlPattern));
     });
 
     test('disabling `checkAccess` skips the proxy status check', async () => {
@@ -459,7 +445,7 @@ describe('Actor.createProxyConfiguration()', () => {
 
         expect(proxyConfiguration).toBeInstanceOf(ProxyConfiguration);
         // The status endpoint must not be hit when access checking is disabled.
-        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(requestStatusSpy).not.toHaveBeenCalled();
     });
 
     test('should work without password (with token)', async () => {
@@ -470,7 +456,7 @@ describe('Actor.createProxyConfiguration()', () => {
         const getUserSpy = vitest.spyOn(UserClient.prototype, 'get');
         const status = { connected: true };
 
-        fetchSpy.mockResolvedValueOnce(statusResponse(status));
+        requestStatusSpy.mockResolvedValueOnce(status);
         getUserSpy.mockResolvedValueOnce(userData as any);
 
         const proxyConfiguration = await Actor.createProxyConfiguration(opts);
@@ -508,7 +494,7 @@ describe('Actor.createProxyConfiguration()', () => {
 
         const status = { connected: true };
 
-        fetchSpy.mockResolvedValueOnce(statusResponse(status));
+        requestStatusSpy.mockResolvedValueOnce(status);
 
         await expect(Actor.createProxyConfiguration()).rejects.toThrow('Apify Proxy password must be provided');
 
@@ -524,7 +510,7 @@ describe('Actor.createProxyConfiguration()', () => {
         const status = { connected: false, connectionError };
         const getUserSpy = vitest.spyOn(UserClient.prototype, 'get');
         getUserSpy.mockResolvedValue(userData as any);
-        fetchSpy.mockResolvedValueOnce(statusResponse(status));
+        requestStatusSpy.mockResolvedValueOnce(status);
 
         await expect(Actor.createProxyConfiguration({ groups })).rejects.toThrow(connectionError);
 
@@ -536,8 +522,7 @@ describe('Actor.createProxyConfiguration()', () => {
 
     test('should not throw when access check is unresponsive', async () => {
         process.env.APIFY_PROXY_PASSWORD = '123456789';
-        fetchSpy.mockRejectedValueOnce(new Error('some error'));
-        fetchSpy.mockRejectedValueOnce(new Error('some error'));
+        requestStatusSpy.mockRejectedValue(new Error('some error'));
 
         const proxyConfiguration = new ProxyConfiguration();
         // @ts-expect-error private property
@@ -554,17 +539,14 @@ describe('Actor.createProxyConfiguration()', () => {
         process.env.APIFY_PROXY_HOSTNAME = 'proxy-domain.apify.com';
         process.env.APIFY_PROXY_PASSWORD = password;
 
-        fetchSpy.mockResolvedValueOnce(statusResponse({ connected: true }));
+        requestStatusSpy.mockResolvedValueOnce({ connected: true });
 
         await Actor.createProxyConfiguration();
-        expect(proxyAgentSpy).toBeCalledWith(
+        expect(requestStatusSpy).toBeCalledWith(
+            `${process.env.APIFY_PROXY_STATUS_URL}/?format=json`,
             expect.stringMatching(
                 new RegExp(`^http://session-[A-Za-z0-9]+:${password}@${process.env.APIFY_PROXY_HOSTNAME}:8000$`),
             ),
         );
-        expect(fetchSpy).toBeCalledWith(`${process.env.APIFY_PROXY_STATUS_URL}/?format=json`, {
-            dispatcher: expect.anything(),
-            signal: expect.any(AbortSignal),
-        });
     });
 });


### PR DESCRIPTION
Follow-up to #636. That PR replaced `got-scraping` with `undici`'s `ProxyAgent` for the Apify Proxy status check — but undici isn't actually needed.

The status endpoint (`http://proxy.apify.com/?format=json`) is plain HTTP fetched **through** an HTTP proxy, which native `node:http` handles directly: an absolute-form request URL plus a `Proxy-Authorization` header. No proxy-agent dependency.

It's written with modern primitives — no callback soup:

```ts
const request = httpRequest({ host: proxy.hostname, port: proxy.port, path: target.href, headers, signal: AbortSignal.timeout(...) });
request.end();
const [response] = await once(request, 'response'); // rejects on error/abort
// ...status-code check...
return await json(response); // node:stream/consumers
```

- `AbortSignal.timeout` for the timeout, `events.once()` for the response (rejects on connection error/abort → caught by the existing retry loop), `node:stream/consumers` `json()` to parse.
- All available on **Node 22.0**, so this reverts the `engines.node` bump back to `>=22.0.0` and **removes `undici`** — net result: dropping `got-scraping` cost us *zero* new dependencies.

The status request is encapsulated in `_requestStatus(statusUrl, proxyUrl)`; tests spy on that seam (and assert the proxy URL it's routed through), so no real network calls.

Caveat: this cleanly covers the default HTTP status URL. If someone overrides `APIFY_PROXY_STATUS_URL` to an `https://` URL (non-default, unusual), the forward-proxy GET won't tunnel it and the check falls back to its existing non-fatal "access check timed out" warning. Happy to add CONNECT tunneling if we think that's worth supporting.

Compile, lint, build, and 123 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)