### PR TITLE
fix: allow Actor.newClient().dataset() without Actor.init()

### DIFF
--- a/src/actor.ts
+++ b/src/actor.ts
@@ -1497,7 +1497,12 @@ export class Actor<Data extends Dictionary = Dictionary> {
                 ...storageClientOptions,
                 ...options, // allow overriding the instance configuration
             },
-            this,
+            {
+                config: this.config,
+                // Hand over the raw manager rather than the public getChargingManager(), which
+                // warns about a missing init() — a standalone client is a supported use case.
+                getChargingManager: () => this.chargingManager,
+            },
         );
     }
 

--- a/src/charging.ts
+++ b/src/charging.ts
@@ -236,6 +236,14 @@ export class ChargingManager {
     }
 
     /**
+     * Whether {@link ChargingManager.init} has run. All charging operations (including
+     * {@link ChargingManager.getPricingInfo}) require an initialized manager.
+     */
+    get isInitialized(): boolean {
+        return this.chargingState !== undefined;
+    }
+
+    /**
      * Get information about the pricing for this Actor.
      */
     getPricingInfo(): ActorPricingInfo {

--- a/src/patched_apify_client.ts
+++ b/src/patched_apify_client.ts
@@ -96,8 +96,13 @@ export function createPatchedApifyClient(
                 httpClient: this.httpClient,
             };
 
+            // Charging is only configured for an initialized Actor (a platform run). A
+            // standalone client from `Actor.newClient()` without `Actor.init()` has no
+            // charging state, so skip interception rather than letting getPricingInfo() throw.
+            const chargingManager = actor.getChargingManager();
             const hasDefaultDatasetItemEvent =
-                DEFAULT_DATASET_ITEM_EVENT in actor.getChargingManager().getPricingInfo().perEventPrices;
+                chargingManager.isInitialized &&
+                DEFAULT_DATASET_ITEM_EVENT in chargingManager.getPricingInfo().perEventPrices;
 
             if (!isDefaultDataset || !hasDefaultDatasetItemEvent) {
                 return new DatasetClient(datasetOptions);

--- a/test/apify/charging.test.ts
+++ b/test/apify/charging.test.ts
@@ -788,3 +788,24 @@ describe('ChargingManager', () => {
         });
     });
 });
+
+describe('Actor.newClient()', () => {
+    afterEach(() => {
+        // @ts-expect-error reset the singleton between tests
+        Actor._instance = undefined; // eslint-disable-line no-underscore-dangle
+    });
+
+    test('dataset() works without calling Actor.init()', () => {
+        // `Actor.newClient()` is documented as usable standalone (init() is only required on
+        // the platform). The charging-aware dataset() getter must not require an initialized
+        // ChargingManager, otherwise it throws "ChargingManager is not initialized".
+        const warningSpy = vitest.spyOn(log, 'warning');
+        const client = Actor.newClient({ token: 'test-token' });
+
+        expect(() => client.dataset('some-dataset-id')).not.toThrow();
+        // ...and it must not nag about a missing init() on this supported path.
+        expect(warningSpy).not.toHaveBeenCalledWith(expect.stringContaining('Actor.init()'));
+
+        warningSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## What & why

The charging-aware client returned by `Actor.newClient()` throws `Error: ChargingManager is not initialized` from its `dataset()` getter when `Actor.init()` hasn't been called:

```js
const client = Actor.newClient({ token });
client.dataset(someId); // 💥 ChargingManager is not initialized
```

`PatchedApifyClient.dataset()` always evaluated `actor.getChargingManager().getPricingInfo()`, and `getPricingInfo()` throws when the manager isn't initialized. But the [docs](https://docs.apify.com/sdk/js/reference/class/Actor#init) state `Actor.init()` is only required on the platform, so a standalone client should work. This regressed standalone usage (it surfaced in Crawlee's e2e harness, which reads dataset results via `Actor.newClient()` without `init()`).

## Fix

Mirror the guard the SDK already applies in the `pushData` charging path (`Actor.pushData()` works without `init()` — charging just isn't configured): only apply charging interception when the `ChargingManager` is initialized; otherwise return a plain `DatasetClient`.

- Add `ChargingManager.isInitialized` (mirrors the existing `chargingState === undefined` guards) and gate the interception on it.
- Hand the patched client the raw manager instead of the public `getChargingManager()`. The public getter also logs a misleading *"did you forget Actor.init()?"* warning on this supported path **and** latches `warnedAboutMissingInitCall`, which would make a subsequent `Actor.init()` throw.

When initialized (platform run, PPE pricing, default dataset) behavior is unchanged — the existing charging suite passes.

## Test

Added a regression test (`dataset()` works without calling `Actor.init()`) that asserts no throw and no spurious init warning.