### PR TITLE
chore(ci): modernize Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
-    "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
-    "pinVersions": false,
+    "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
+    "rangeStrategy": "replace",
     "separateMajorMinor": false,
     "dependencyDashboard": false,
     "semanticCommits": "enabled",


### PR DESCRIPTION
Modernizes the Renovate config to the current schema. Renovate v36+ renamed several options, and `renovate-config-validator --strict` reported that the config needs migration. Applies exactly the migrations the validator prescribes:

- `config:base` → `config:recommended`
- `pinVersions: false` → `rangeStrategy: "replace"`

No behavior change: after the change the config validates cleanly (`Config validated successfully`), whereas before it emitted `Config migration necessary`.
