### PR TITLE
fix: add trailing slash to default `apiBaseUrl`

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -94,7 +94,7 @@ export interface ConfigurationOptions extends CoreConfigurationOptions {
  * `actorPermissionLevel` | `ACTOR_PERMISSION_LEVEL` | -
  * `actorRunId` | `ACTOR_RUN_ID` | -
  * `actorTaskId` | `ACTOR_TASK_ID` | -
- * `apiBaseUrl` | `APIFY_API_BASE_URL` | `'https://api.apify.com'`
+ * `apiBaseUrl` | `APIFY_API_BASE_URL` | `'https://api.apify.com/'`
  * `containerPort` | `ACTOR_WEB_SERVER_PORT` | `4321`
  * `containerUrl` | `ACTOR_WEB_SERVER_URL` | `'http://localhost:4321'`
  * `inputKey` | `ACTOR_INPUT_KEY` | `'INPUT'`
@@ -204,7 +204,7 @@ export class Configuration extends CoreConfiguration {
         defaultDatasetId: LOCAL_ACTOR_ENV_VARS[ACTOR_ENV_VARS.DEFAULT_DATASET_ID],
         defaultRequestQueueId: LOCAL_ACTOR_ENV_VARS[ACTOR_ENV_VARS.DEFAULT_REQUEST_QUEUE_ID],
         inputKey: 'INPUT',
-        apiBaseUrl: 'https://api.apify.com',
+        apiBaseUrl: 'https://api.apify.com/',
         apiPublicBaseUrl: 'https://api.apify.com',
         proxyStatusUrl: 'http://proxy.apify.com',
         proxyHostname: LOCAL_APIFY_ENV_VARS[APIFY_ENV_VARS.PROXY_HOSTNAME],


### PR DESCRIPTION
This is a PR in response to a discussion that emerged  on [Slack](https://apify.slack.com/archives/C0L33UM7Z/p1783521934919179). 

`APIFY_API_BASE_URL` is overridden by some value at runtime. This value is created with a trailing slash which is not showed in the default value.