### PR TITLE
fix: apiBaseUrl format adding trailing slash

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -204,7 +204,7 @@ export class Configuration extends CoreConfiguration {
         defaultDatasetId: LOCAL_ACTOR_ENV_VARS[ACTOR_ENV_VARS.DEFAULT_DATASET_ID],
         defaultRequestQueueId: LOCAL_ACTOR_ENV_VARS[ACTOR_ENV_VARS.DEFAULT_REQUEST_QUEUE_ID],
         inputKey: 'INPUT',
-        apiBaseUrl: 'https://api.apify.com',
+        apiBaseUrl: 'https://api.apify.com/',
         apiPublicBaseUrl: 'https://api.apify.com',
         proxyStatusUrl: 'http://proxy.apify.com',
         proxyHostname: LOCAL_APIFY_ENV_VARS[APIFY_ENV_VARS.PROXY_HOSTNAME],


### PR DESCRIPTION
Based on discussion on [slack](https://apify.slack.com/archives/C0L33UM7Z/p1783521934919179) ⬇️ 

> According to [docs](https://docs.apify.com/sdk/js/reference/class/Configuration), apiBaseUrl is 'https://api.apify.com/' (no trailing slash) but on the [Notion page](https://app.notion.com/p/apify/Multi-tenant-standby-developer-facing-documentation-38af39950a22806cb407e6f0bb825864) about charging with multi-tenant and [this very professional console.log](https://console.apify.com/actors/TurdicaJfal48CoEU/runs/vLRb6bp9iMIEDadXR#log) say otherwise