### PR TITLE
fix: Fix `inherit` timeout units and no-timeout-left case

### DIFF
--- a/src/actor.ts
+++ b/src/actor.ts
@@ -252,6 +252,8 @@ export interface Timeout {
      *
      * Using `inherit` will set timeout of the newly started Actor run to the time
      * remaining until this Actor run times out so that the new run does not outlive this one.
+     * If there is no time remaining (this run is already past its own timeout), the new run
+     * is not started at all — the method only logs a warning and returns `undefined`.
      */
     timeout?: number | 'inherit';
 }
@@ -748,8 +750,16 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
-    async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun> {
+    async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun | undefined> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
+
+        if (options.timeout === 'inherit' && timeout === 0) {
+            log.warning(
+                "Actor.call() was skipped: `timeout: 'inherit'` was used, but the current run has no time remaining before its own timeout.",
+            );
+            return undefined;
+        }
+
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
         return client.actor(actorId).call(input, { ...rest, timeout });
@@ -779,8 +789,16 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
-    async start(actorId: string, input?: unknown, options: StartOptions = {}): Promise<ClientActorRun> {
+    async start(actorId: string, input?: unknown, options: StartOptions = {}): Promise<ClientActorRun | undefined> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
+
+        if (options.timeout === 'inherit' && timeout === 0) {
+            log.warning(
+                "Actor.start() was skipped: `timeout: 'inherit'` was used, but the current run has no time remaining before its own timeout.",
+            );
+            return undefined;
+        }
+
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
 
@@ -841,8 +859,20 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
-    async callTask(taskId: string, input?: Dictionary, options: CallTaskOptions = {}): Promise<ClientActorRun> {
+    async callTask(
+        taskId: string,
+        input?: Dictionary,
+        options: CallTaskOptions = {},
+    ): Promise<ClientActorRun | undefined> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
+
+        if (options.timeout === 'inherit' && timeout === 0) {
+            log.warning(
+                "Actor.callTask() was skipped: `timeout: 'inherit'` was used, but the current run has no time remaining before its own timeout.",
+            );
+            return undefined;
+        }
+
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
 
@@ -1698,8 +1728,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Otherwise the `options.contentType` parameter must be provided.
      * @param [options]
+     * @returns The Actor run object, or `undefined` when the `timeout: 'inherit'` option is used
+     *  but the current run has no time remaining before its own timeout — the run is then not started at all.
      */
-    static async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun> {
+    static async call(
+        actorId: string,
+        input?: unknown,
+        options: CallOptions = {},
+    ): Promise<ClientActorRun | undefined> {
         return Actor.getDefaultInstance().call(actorId, input, options);
     }
 
@@ -1727,8 +1763,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Provided input will be merged with Actor task input.
      * @param [options]
+     * @returns The Actor run object, or `undefined` when the `timeout: 'inherit'` option is used
+     *  but the current run has no time remaining before its own timeout — the run is then not started at all.
      */
-    static async callTask(taskId: string, input?: Dictionary, options: CallTaskOptions = {}): Promise<ClientActorRun> {
+    static async callTask(
+        taskId: string,
+        input?: Dictionary,
+        options: CallTaskOptions = {},
+    ): Promise<ClientActorRun | undefined> {
         return Actor.getDefaultInstance().callTask(taskId, input, options);
     }
 
@@ -1754,8 +1796,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Otherwise the `options.contentType` parameter must be provided.
      * @param [options]
+     * @returns The Actor run object, or `undefined` when the `timeout: 'inherit'` option is used
+     *  but the current run has no time remaining before its own timeout — the run is then not started at all.
      */
-    static async start(actorId: string, input?: Dictionary, options: StartOptions = {}): Promise<ClientActorRun> {
+    static async start(
+        actorId: string,
+        input?: Dictionary,
+        options: StartOptions = {},
+    ): Promise<ClientActorRun | undefined> {
         return Actor.getDefaultInstance().start(actorId, input, options);
     }
 
@@ -2305,7 +2353,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
     private getRemainingTime(): number | undefined {
         const env = this.getEnv();
         if (this.isAtHome() && env.timeoutAt !== null) {
-            // Rounding up so that a sub-second remainder does not become 0, which the API treats as "no timeout".
+            // Rounded up so that a positive remainder is never truncated to 0 — callers treat 0 (only possible
+            // when this run is already past its own timeout) as "no time remaining" and skip starting the run.
             return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), 0);
         }
         log.warning(

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -252,8 +252,6 @@ export interface Timeout {
      *
      * Using `inherit` will set timeout of the newly started Actor run to the time
      * remaining until this Actor run times out so that the new run does not outlive this one.
-     * If there is no time remaining (this run is already past its own timeout), the new run
-     * is not started at all — the method only logs a warning and returns `undefined`.
      */
     timeout?: number | 'inherit';
 }
@@ -750,25 +748,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
-    async call(actorId: string, input?: unknown, options?: CallOptions & { timeout?: number }): Promise<ClientActorRun>;
-    /** @ignore */
-    async call(
-        actorId: string,
-        input: unknown,
-        options: CallOptions & { timeout: 'inherit' },
-    ): Promise<ClientActorRun | undefined>;
-    /** @ignore */
-    async call(actorId: string, input?: unknown, options?: CallOptions): Promise<ClientActorRun | undefined>;
-    async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun | undefined> {
+    async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
-
-        if (options.timeout === 'inherit' && timeout === 0) {
-            log.warning(
-                "Actor.call() was skipped: `timeout: 'inherit'` was used, but the current run has no time remaining before its own timeout.",
-            );
-            return undefined;
-        }
-
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
         return client.actor(actorId).call(input, { ...rest, timeout });
@@ -798,29 +779,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
-    async start(
-        actorId: string,
-        input?: unknown,
-        options?: StartOptions & { timeout?: number },
-    ): Promise<ClientActorRun>;
-    /** @ignore */
-    async start(
-        actorId: string,
-        input: unknown,
-        options: StartOptions & { timeout: 'inherit' },
-    ): Promise<ClientActorRun | undefined>;
-    /** @ignore */
-    async start(actorId: string, input?: unknown, options?: StartOptions): Promise<ClientActorRun | undefined>;
-    async start(actorId: string, input?: unknown, options: StartOptions = {}): Promise<ClientActorRun | undefined> {
+    async start(actorId: string, input?: unknown, options: StartOptions = {}): Promise<ClientActorRun> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
-
-        if (options.timeout === 'inherit' && timeout === 0) {
-            log.warning(
-                "Actor.start() was skipped: `timeout: 'inherit'` was used, but the current run has no time remaining before its own timeout.",
-            );
-            return undefined;
-        }
-
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
 
@@ -881,33 +841,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
-    async callTask(
-        taskId: string,
-        input?: Dictionary,
-        options?: CallTaskOptions & { timeout?: number },
-    ): Promise<ClientActorRun>;
-    /** @ignore */
-    async callTask(
-        taskId: string,
-        input: Dictionary | undefined,
-        options: CallTaskOptions & { timeout: 'inherit' },
-    ): Promise<ClientActorRun | undefined>;
-    /** @ignore */
-    async callTask(taskId: string, input?: Dictionary, options?: CallTaskOptions): Promise<ClientActorRun | undefined>;
-    async callTask(
-        taskId: string,
-        input?: Dictionary,
-        options: CallTaskOptions = {},
-    ): Promise<ClientActorRun | undefined> {
+    async callTask(taskId: string, input?: Dictionary, options: CallTaskOptions = {}): Promise<ClientActorRun> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
-
-        if (options.timeout === 'inherit' && timeout === 0) {
-            log.warning(
-                "Actor.callTask() was skipped: `timeout: 'inherit'` was used, but the current run has no time remaining before its own timeout.",
-            );
-            return undefined;
-        }
-
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
 
@@ -1763,37 +1698,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Otherwise the `options.contentType` parameter must be provided.
      * @param [options]
-     * @returns The Actor run object.
      */
-    static async call(
-        actorId: string,
-        input?: unknown,
-        options?: CallOptions & { timeout?: number },
-    ): Promise<ClientActorRun>;
-    /**
-     * Runs an Actor on the Apify platform with the timeout inherited from the current run, so that
-     * the new run does not outlive this one.
-     *
-     * @returns The Actor run object, or `undefined` when the current run has no time remaining before
-     *  its own timeout — the run is then not started at all and only a warning is logged.
-     */
-    static async call(
-        actorId: string,
-        input: unknown,
-        options: CallOptions & { timeout: 'inherit' },
-    ): Promise<ClientActorRun | undefined>;
-    /**
-     * Runs an Actor on the Apify platform using the current user account (determined by the `APIFY_TOKEN` environment variable).
-     *
-     * @returns The Actor run object. It is `undefined` only when `options.timeout` resolves to `'inherit'`
-     *  and the current run has no time remaining before its own timeout.
-     */
-    static async call(actorId: string, input?: unknown, options?: CallOptions): Promise<ClientActorRun | undefined>;
-    static async call(
-        actorId: string,
-        input?: unknown,
-        options: CallOptions = {},
-    ): Promise<ClientActorRun | undefined> {
+    static async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun> {
         return Actor.getDefaultInstance().call(actorId, input, options);
     }
 
@@ -1821,41 +1727,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Provided input will be merged with Actor task input.
      * @param [options]
-     * @returns The Actor run object.
      */
-    static async callTask(
-        taskId: string,
-        input?: Dictionary,
-        options?: CallTaskOptions & { timeout?: number },
-    ): Promise<ClientActorRun>;
-    /**
-     * Runs an Actor task on the Apify platform with the timeout inherited from the current run, so that
-     * the new run does not outlive this one.
-     *
-     * @returns The Actor run object, or `undefined` when the current run has no time remaining before
-     *  its own timeout — the run is then not started at all and only a warning is logged.
-     */
-    static async callTask(
-        taskId: string,
-        input: Dictionary | undefined,
-        options: CallTaskOptions & { timeout: 'inherit' },
-    ): Promise<ClientActorRun | undefined>;
-    /**
-     * Runs an Actor task on the Apify platform using the current user account (determined by the `APIFY_TOKEN` environment variable).
-     *
-     * @returns The Actor run object. It is `undefined` only when `options.timeout` resolves to `'inherit'`
-     *  and the current run has no time remaining before its own timeout.
-     */
-    static async callTask(
-        taskId: string,
-        input?: Dictionary,
-        options?: CallTaskOptions,
-    ): Promise<ClientActorRun | undefined>;
-    static async callTask(
-        taskId: string,
-        input?: Dictionary,
-        options: CallTaskOptions = {},
-    ): Promise<ClientActorRun | undefined> {
+    static async callTask(taskId: string, input?: Dictionary, options: CallTaskOptions = {}): Promise<ClientActorRun> {
         return Actor.getDefaultInstance().callTask(taskId, input, options);
     }
 
@@ -1881,42 +1754,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Otherwise the `options.contentType` parameter must be provided.
      * @param [options]
-     * @returns The Actor run object.
      */
-    static async start(
-        actorId: string,
-        input?: Dictionary,
-        options?: StartOptions & { timeout?: number },
-    ): Promise<ClientActorRun>;
-    /**
-     * Starts an Actor run on the Apify platform with the timeout inherited from the current run, so that
-     * the new run does not outlive this one.
-     *
-     * @returns The Actor run object, or `undefined` when the current run has no time remaining before
-     *  its own timeout — the run is then not started at all and only a warning is logged.
-     */
-    static async start(
-        actorId: string,
-        input: Dictionary | undefined,
-        options: StartOptions & { timeout: 'inherit' },
-    ): Promise<ClientActorRun | undefined>;
-    /**
-     * Runs an Actor on the Apify platform using the current user account (determined by the `APIFY_TOKEN` environment variable),
-     * unlike `Actor.call`, this method just starts the run without waiting for finish.
-     *
-     * @returns The Actor run object. It is `undefined` only when `options.timeout` resolves to `'inherit'`
-     *  and the current run has no time remaining before its own timeout.
-     */
-    static async start(
-        actorId: string,
-        input?: Dictionary,
-        options?: StartOptions,
-    ): Promise<ClientActorRun | undefined>;
-    static async start(
-        actorId: string,
-        input?: Dictionary,
-        options: StartOptions = {},
-    ): Promise<ClientActorRun | undefined> {
+    static async start(actorId: string, input?: Dictionary, options: StartOptions = {}): Promise<ClientActorRun> {
         return Actor.getDefaultInstance().start(actorId, input, options);
     }
 
@@ -2460,15 +2299,17 @@ export class Actor<Data extends Dictionary = Dictionary> {
     }
 
     /**
-     * Get time remaining from the Actor run timeout, in seconds. Returns `undefined` if not on an Apify platform
-     * or the current run was started without a timeout.
+     * Get time remaining from the Actor run timeout, rounded up to whole seconds with minimum value of 1 second.
+     *
+     * The API treats a 0 second timeout as no timeout, the minimum acceptable timeout is 1 second.
+     *
+     * Returns `undefined` if not on an Apify platform or the current run was started without a timeout.
      */
     private getRemainingTime(): number | undefined {
         const env = this.getEnv();
+        const smallestPossibleApiTimeout = 1;
         if (this.isAtHome() && env.timeoutAt !== null) {
-            // Rounded up so that a positive remainder is never truncated to 0 — callers treat 0 (only possible
-            // when this run is already past its own timeout) as "no time remaining" and skip starting the run.
-            return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), 0);
+            return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), smallestPossibleApiTimeout);
         }
         log.warning(
             'Using `inherit` argument is only possible when the Actor is running on the Apify platform and when the ' +

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -749,7 +749,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun> {
-        const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
+        const timeout = options.timeout === 'inherit' ? this.getRemainingTimeSecs() : options.timeout;
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
         return client.actor(actorId).call(input, { ...rest, timeout });
@@ -780,7 +780,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async start(actorId: string, input?: unknown, options: StartOptions = {}): Promise<ClientActorRun> {
-        const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
+        const timeout = options.timeout === 'inherit' ? this.getRemainingTimeSecs() : options.timeout;
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
 
@@ -842,7 +842,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async callTask(taskId: string, input?: Dictionary, options: CallTaskOptions = {}): Promise<ClientActorRun> {
-        const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
+        const timeout = options.timeout === 'inherit' ? this.getRemainingTimeSecs() : options.timeout;
         const { token, ...rest } = options;
         const client = token ? this.newClient({ token }) : this.apifyClient;
 
@@ -2309,7 +2309,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         const env = this.getEnv();
         const MINIMUM_API_TIMEOUT_SECS = 1;
         if (this.isAtHome() && env.timeoutAt !== null) {
-            return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), smallestPossibleApiTimeout);
+            return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), MINIMUM_API_TIMEOUT_SECS);
         }
         log.warning(
             'Using `inherit` argument is only possible when the Actor is running on the Apify platform and when the ' +

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -2299,15 +2299,15 @@ export class Actor<Data extends Dictionary = Dictionary> {
     }
 
     /**
-     * Get time remaining from the Actor run timeout, rounded up to whole seconds with minimum value of 1 second.
+     * Get time remaining from the Actor run timeout in seconds, rounded up to whole seconds with minimum value of 1 second.
      *
      * The API treats a 0 second timeout as no timeout, the minimum acceptable timeout is 1 second.
      *
-     * Returns `undefined` if not on an Apify platform or the current run was started without a timeout.
+     * Returns `undefined` if not on the Apify platform or the current run was started without a timeout.
      */
-    private getRemainingTime(): number | undefined {
+    private getRemainingTimeSecs(): number | undefined {
         const env = this.getEnv();
-        const smallestPossibleApiTimeout = 1;
+        const MINIMUM_API_TIMEOUT_SECS = 1;
         if (this.isAtHome() && env.timeoutAt !== null) {
             return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), smallestPossibleApiTimeout);
         }

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -750,6 +750,15 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
+    async call(actorId: string, input?: unknown, options?: CallOptions & { timeout?: number }): Promise<ClientActorRun>;
+    /** @ignore */
+    async call(
+        actorId: string,
+        input: unknown,
+        options: CallOptions & { timeout: 'inherit' },
+    ): Promise<ClientActorRun | undefined>;
+    /** @ignore */
+    async call(actorId: string, input?: unknown, options?: CallOptions): Promise<ClientActorRun | undefined>;
     async call(actorId: string, input?: unknown, options: CallOptions = {}): Promise<ClientActorRun | undefined> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
 
@@ -789,6 +798,19 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
+    async start(
+        actorId: string,
+        input?: unknown,
+        options?: StartOptions & { timeout?: number },
+    ): Promise<ClientActorRun>;
+    /** @ignore */
+    async start(
+        actorId: string,
+        input: unknown,
+        options: StartOptions & { timeout: 'inherit' },
+    ): Promise<ClientActorRun | undefined>;
+    /** @ignore */
+    async start(actorId: string, input?: unknown, options?: StartOptions): Promise<ClientActorRun | undefined>;
     async start(actorId: string, input?: unknown, options: StartOptions = {}): Promise<ClientActorRun | undefined> {
         const timeout = options.timeout === 'inherit' ? this.getRemainingTime() : options.timeout;
 
@@ -859,6 +881,19 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @param [options]
      * @ignore
      */
+    async callTask(
+        taskId: string,
+        input?: Dictionary,
+        options?: CallTaskOptions & { timeout?: number },
+    ): Promise<ClientActorRun>;
+    /** @ignore */
+    async callTask(
+        taskId: string,
+        input: Dictionary | undefined,
+        options: CallTaskOptions & { timeout: 'inherit' },
+    ): Promise<ClientActorRun | undefined>;
+    /** @ignore */
+    async callTask(taskId: string, input?: Dictionary, options?: CallTaskOptions): Promise<ClientActorRun | undefined>;
     async callTask(
         taskId: string,
         input?: Dictionary,
@@ -1728,9 +1763,32 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Otherwise the `options.contentType` parameter must be provided.
      * @param [options]
-     * @returns The Actor run object, or `undefined` when the `timeout: 'inherit'` option is used
-     *  but the current run has no time remaining before its own timeout — the run is then not started at all.
+     * @returns The Actor run object.
      */
+    static async call(
+        actorId: string,
+        input?: unknown,
+        options?: CallOptions & { timeout?: number },
+    ): Promise<ClientActorRun>;
+    /**
+     * Runs an Actor on the Apify platform with the timeout inherited from the current run, so that
+     * the new run does not outlive this one.
+     *
+     * @returns The Actor run object, or `undefined` when the current run has no time remaining before
+     *  its own timeout — the run is then not started at all and only a warning is logged.
+     */
+    static async call(
+        actorId: string,
+        input: unknown,
+        options: CallOptions & { timeout: 'inherit' },
+    ): Promise<ClientActorRun | undefined>;
+    /**
+     * Runs an Actor on the Apify platform using the current user account (determined by the `APIFY_TOKEN` environment variable).
+     *
+     * @returns The Actor run object. It is `undefined` only when `options.timeout` resolves to `'inherit'`
+     *  and the current run has no time remaining before its own timeout.
+     */
+    static async call(actorId: string, input?: unknown, options?: CallOptions): Promise<ClientActorRun | undefined>;
     static async call(
         actorId: string,
         input?: unknown,
@@ -1763,9 +1821,36 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Provided input will be merged with Actor task input.
      * @param [options]
-     * @returns The Actor run object, or `undefined` when the `timeout: 'inherit'` option is used
-     *  but the current run has no time remaining before its own timeout — the run is then not started at all.
+     * @returns The Actor run object.
      */
+    static async callTask(
+        taskId: string,
+        input?: Dictionary,
+        options?: CallTaskOptions & { timeout?: number },
+    ): Promise<ClientActorRun>;
+    /**
+     * Runs an Actor task on the Apify platform with the timeout inherited from the current run, so that
+     * the new run does not outlive this one.
+     *
+     * @returns The Actor run object, or `undefined` when the current run has no time remaining before
+     *  its own timeout — the run is then not started at all and only a warning is logged.
+     */
+    static async callTask(
+        taskId: string,
+        input: Dictionary | undefined,
+        options: CallTaskOptions & { timeout: 'inherit' },
+    ): Promise<ClientActorRun | undefined>;
+    /**
+     * Runs an Actor task on the Apify platform using the current user account (determined by the `APIFY_TOKEN` environment variable).
+     *
+     * @returns The Actor run object. It is `undefined` only when `options.timeout` resolves to `'inherit'`
+     *  and the current run has no time remaining before its own timeout.
+     */
+    static async callTask(
+        taskId: string,
+        input?: Dictionary,
+        options?: CallTaskOptions,
+    ): Promise<ClientActorRun | undefined>;
     static async callTask(
         taskId: string,
         input?: Dictionary,
@@ -1796,9 +1881,37 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *  JSON and its content type set to `application/json; charset=utf-8`.
      *  Otherwise the `options.contentType` parameter must be provided.
      * @param [options]
-     * @returns The Actor run object, or `undefined` when the `timeout: 'inherit'` option is used
-     *  but the current run has no time remaining before its own timeout — the run is then not started at all.
+     * @returns The Actor run object.
      */
+    static async start(
+        actorId: string,
+        input?: Dictionary,
+        options?: StartOptions & { timeout?: number },
+    ): Promise<ClientActorRun>;
+    /**
+     * Starts an Actor run on the Apify platform with the timeout inherited from the current run, so that
+     * the new run does not outlive this one.
+     *
+     * @returns The Actor run object, or `undefined` when the current run has no time remaining before
+     *  its own timeout — the run is then not started at all and only a warning is logged.
+     */
+    static async start(
+        actorId: string,
+        input: Dictionary | undefined,
+        options: StartOptions & { timeout: 'inherit' },
+    ): Promise<ClientActorRun | undefined>;
+    /**
+     * Runs an Actor on the Apify platform using the current user account (determined by the `APIFY_TOKEN` environment variable),
+     * unlike `Actor.call`, this method just starts the run without waiting for finish.
+     *
+     * @returns The Actor run object. It is `undefined` only when `options.timeout` resolves to `'inherit'`
+     *  and the current run has no time remaining before its own timeout.
+     */
+    static async start(
+        actorId: string,
+        input?: Dictionary,
+        options?: StartOptions,
+    ): Promise<ClientActorRun | undefined>;
     static async start(
         actorId: string,
         input?: Dictionary,

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -2299,13 +2299,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
     }
 
     /**
-     * Get time remaining from the Actor run timeout. Returns `undefined` if not on an Apify platform or the current
-     * run was started without a timeout.
+     * Get time remaining from the Actor run timeout, in seconds. Returns `undefined` if not on an Apify platform
+     * or the current run was started without a timeout.
      */
     private getRemainingTime(): number | undefined {
         const env = this.getEnv();
         if (this.isAtHome() && env.timeoutAt !== null) {
-            return env.timeoutAt.getTime() - Date.now();
+            // Rounding up so that a sub-second remainder does not become 0, which the API treats as "no timeout".
+            return Math.max(Math.ceil((env.timeoutAt.getTime() - Date.now()) / 1000), 0);
         }
         log.warning(
             'Using `inherit` argument is only possible when the Actor is running on the Apify platform and when the ' +

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -961,22 +961,20 @@ describe('Actor', () => {
             async ({ methodName }) => {
                 vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
 
-                const warningSpy = vitest.spyOn(log, 'warning').mockImplementation(() => {});
+                vitest.spyOn(log, 'warning').mockImplementation(() => {});
                 const callSpy = vitest.spyOn(ActorClient.prototype, methodName).mockReturnValue();
                 await expect(Actor[methodName](actId, input, { timeout: 'inherit' })).resolves.toBeUndefined();
                 expect(callSpy).not.toBeCalled();
-                expect(warningSpy).toBeCalledWith(expect.stringContaining('skipped'));
             },
         );
 
         test(`Actor.callTask({timeout: 'inherit'}) is skipped when the run is already past its timeout`, async () => {
             vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
 
-            const warningSpy = vitest.spyOn(log, 'warning').mockImplementation(() => {});
+            vitest.spyOn(log, 'warning').mockImplementation(() => {});
             const callSpy = vitest.spyOn(TaskClient.prototype, 'call').mockReturnValue();
             await expect(Actor.callTask(actId, input, { timeout: 'inherit' })).resolves.toBeUndefined();
             expect(callSpy).not.toBeCalled();
-            expect(warningSpy).toBeCalledWith(expect.stringContaining('skipped'));
         });
     });
 

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -956,14 +956,27 @@ describe('Actor', () => {
             });
         });
 
-        test(`inherited timeout is clamped to zero when the run is already past its timeout`, async () => {
+        test.each([{ methodName: 'call' }, { methodName: 'start' }])(
+            `Actor.$methodName({timeout: 'inherit'}) is skipped when the run is already past its timeout`,
+            async ({ methodName }) => {
+                vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
+
+                const warningSpy = vitest.spyOn(log, 'warning').mockImplementation(() => {});
+                const callSpy = vitest.spyOn(ActorClient.prototype, methodName).mockReturnValue();
+                await expect(Actor[methodName](actId, input, { timeout: 'inherit' })).resolves.toBeUndefined();
+                expect(callSpy).not.toBeCalled();
+                expect(warningSpy).toBeCalledWith(expect.stringContaining('skipped'));
+            },
+        );
+
+        test(`Actor.callTask({timeout: 'inherit'}) is skipped when the run is already past its timeout`, async () => {
             vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
 
-            const callSpy = vitest.spyOn(ActorClient.prototype, 'call').mockReturnValue();
-            await Actor.call(actId, input, { timeout: 'inherit' });
-            expect(callSpy).toBeCalledWith(input, {
-                timeout: 0,
-            });
+            const warningSpy = vitest.spyOn(log, 'warning').mockImplementation(() => {});
+            const callSpy = vitest.spyOn(TaskClient.prototype, 'call').mockReturnValue();
+            await expect(Actor.callTask(actId, input, { timeout: 'inherit' })).resolves.toBeUndefined();
+            expect(callSpy).not.toBeCalled();
+            expect(warningSpy).toBeCalledWith(expect.stringContaining('skipped'));
         });
     });
 

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -930,7 +930,8 @@ describe('Actor', () => {
                 const callSpy = vitest.spyOn(ActorClient.prototype, methodName).mockReturnValue();
                 await Actor[methodName](actId, input, options);
                 expect(callSpy).toBeCalledWith(input, {
-                    timeout: actorTimeout - usedTime,
+                    // The client expects the timeout in seconds, while the remaining time is computed in milliseconds.
+                    timeout: (actorTimeout - usedTime) / 1000,
                 });
             },
         );
@@ -941,7 +942,27 @@ describe('Actor', () => {
             const callSpy = vitest.spyOn(TaskClient.prototype, 'call').mockReturnValue();
             await Actor.callTask(actId, input, options);
             expect(callSpy).toBeCalledWith(input, {
-                timeout: actorTimeout - usedTime,
+                timeout: (actorTimeout - usedTime) / 1000,
+            });
+        });
+
+        test(`inherited timeout is rounded up to a whole second`, async () => {
+            vi.setSystemTime(new Date(testStartTime.getTime() + usedTime + 500));
+
+            const callSpy = vitest.spyOn(ActorClient.prototype, 'call').mockReturnValue();
+            await Actor.call(actId, input, { timeout: 'inherit' });
+            expect(callSpy).toBeCalledWith(input, {
+                timeout: (actorTimeout - usedTime) / 1000,
+            });
+        });
+
+        test(`inherited timeout is clamped to zero when the run is already past its timeout`, async () => {
+            vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
+
+            const callSpy = vitest.spyOn(ActorClient.prototype, 'call').mockReturnValue();
+            await Actor.call(actId, input, { timeout: 'inherit' });
+            expect(callSpy).toBeCalledWith(input, {
+                timeout: 0,
             });
         });
     });

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -957,24 +957,26 @@ describe('Actor', () => {
         });
 
         test.each([{ methodName: 'call' }, { methodName: 'start' }])(
-            `Actor.$methodName({timeout: 'inherit'}) is skipped when the run is already past its timeout`,
+            `Actor.$methodName({timeout: 'inherit'}) is clamped to 1 second when the run is already past its timeout`,
             async ({ methodName }) => {
                 vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
 
-                vitest.spyOn(log, 'warning').mockImplementation(() => {});
                 const callSpy = vitest.spyOn(ActorClient.prototype, methodName).mockReturnValue();
-                await expect(Actor[methodName](actId, input, { timeout: 'inherit' })).resolves.toBeUndefined();
-                expect(callSpy).not.toBeCalled();
+                await Actor[methodName](actId, input, { timeout: 'inherit' });
+                expect(callSpy).toBeCalledWith(input, {
+                    timeout: 1,
+                });
             },
         );
 
-        test(`Actor.callTask({timeout: 'inherit'}) is skipped when the run is already past its timeout`, async () => {
+        test(`Actor.callTask({timeout: 'inherit'}) is clamped to 1 second when the run is already past its timeout`, async () => {
             vi.setSystemTime(new Date(testStartTime.getTime() + actorTimeout + 5000));
 
-            vitest.spyOn(log, 'warning').mockImplementation(() => {});
             const callSpy = vitest.spyOn(TaskClient.prototype, 'call').mockReturnValue();
-            await expect(Actor.callTask(actId, input, { timeout: 'inherit' })).resolves.toBeUndefined();
-            expect(callSpy).not.toBeCalled();
+            await Actor.callTask(actId, input, { timeout: 'inherit' });
+            expect(callSpy).toBeCalledWith(input, {
+                timeout: 1,
+            });
         });
     });
 


### PR DESCRIPTION
**Timeout units:**
Remaining time was calculated in milliseconds, while API accepts a timeout in seconds. This led to incorrect timeout values being passed to the API. Properly pass the timeout in seconds to the API.

**No timeout left case:**
Limit the minimal timeout to 1s, as the API interprets a timeout of 0 as no timeout at all.