### PR TITLE
feat: add key-value record public URL

### DIFF
--- a/src/key_value_store.ts
+++ b/src/key_value_store.ts
@@ -16,6 +16,8 @@ export class KeyValueStore extends CoreKeyValueStore {
     /**
      * Returns a URL for the given key that may be used to publicly
      * access the value in the remote key-value store.
+     *
+     * @deprecated Use {@link getRecordPublicUrl} instead.
      */
     override getPublicUrl(key: string): string {
         const config = this.config as Configuration;
@@ -39,6 +41,26 @@ export class KeyValueStore extends CoreKeyValueStore {
         }
 
         return publicUrl.toString();
+    }
+
+    /**
+     * Returns a URL for the given key that may be used to publicly
+     * access the value in the remote key-value store.
+     *
+     * Unlike {@link getPublicUrl}, this method uses the API client to
+     * generate signed URLs for remote stores.
+     */
+    async getRecordPublicUrl(key: string): Promise<string> {
+        const isLocalStore = !(
+            // eslint-disable-next-line dot-notation
+            (this['client'] instanceof RemoteKeyValueStoreClient)
+        );
+
+        if (isLocalStore) {
+            return getPublicUrl.call(this, key);
+        }
+
+        return this['client'].getRecordPublicUrl(key);
     }
 
     /**

--- a/test/apify/key_value_store.test.ts
+++ b/test/apify/key_value_store.test.ts
@@ -1,0 +1,22 @@
+import { KeyValueStoreClient } from 'apify-client';
+import { describe, expect, test, vi } from 'vitest';
+
+import { KeyValueStore } from '../../src/key_value_store.ts';
+
+describe('KeyValueStore', () => {
+    test('delegates remote record URLs to the API client', async () => {
+        const client = Object.create(KeyValueStoreClient.prototype) as KeyValueStoreClient;
+        const getRecordPublicUrl = vi
+            .fn()
+            .mockResolvedValue('https://api.apify.com/v2/key-value-stores/store/records/OUTPUT');
+        Object.defineProperty(client, 'getRecordPublicUrl', { value: getRecordPublicUrl });
+
+        const store = Object.create(KeyValueStore.prototype) as KeyValueStore;
+        Object.defineProperty(store, 'client', { value: client });
+
+        await expect(store.getRecordPublicUrl('OUTPUT')).resolves.toBe(
+            'https://api.apify.com/v2/key-value-stores/store/records/OUTPUT',
+        );
+        expect(getRecordPublicUrl).toHaveBeenCalledWith('OUTPUT');
+    });
+});


### PR DESCRIPTION
## Summary

- add `KeyValueStore.getRecordPublicUrl()` for remote key-value stores
- delegate signed URL creation to the corresponding `apify-client` method
- deprecate the ambiguous synchronous `getPublicUrl()` API while keeping it available
- add a regression test for the SDK-to-client delegation

## Why

The SDK constructed record URLs itself, duplicating logic that now belongs in `apify-client`. The new asynchronous method exposes the client-backed path and keeps local-store behavior unchanged.

Closes #433

## Validation

- `corepack pnpm test` (127 passed, 14 skipped)
- `corepack pnpm vitest run test/apify/key_value_store.test.ts --silent`
- `corepack pnpm compile`
- `corepack pnpm lint`
- `corepack pnpm exec oxfmt --check src/key_value_store.ts test/apify/key_value_store.test.ts`
- `git diff --check`