### PR TITLE
feat: add explicit platform detection helper

### DIFF
--- a/src/actor.ts
+++ b/src/actor.ts
@@ -2190,8 +2190,17 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
     /**
      * Returns `true` when code is running on Apify platform and `false` otherwise (for example locally).
+     *
+     * @deprecated Use {@link isRunningOnApify} instead.
      */
     static isAtHome(): boolean {
+        return Actor.getDefaultInstance().isAtHome();
+    }
+
+    /**
+     * Returns `true` when code is running on the Apify platform and `false` otherwise (for example locally).
+     */
+    static isRunningOnApify(): boolean {
         return Actor.getDefaultInstance().isAtHome();
     }
 

--- a/test/apify/utils.test.ts
+++ b/test/apify/utils.test.ts
@@ -8,13 +8,16 @@ import semver from 'semver';
 import { APIFY_ENV_VARS } from '@apify/consts';
 import log from '@apify/log';
 
-describe('Actor.isAtHome()', () => {
+describe('Actor platform detection', () => {
     test('works', () => {
         expect(Actor.isAtHome()).toBe(false);
+        expect(Actor.isRunningOnApify()).toBe(false);
         process.env[APIFY_ENV_VARS.IS_AT_HOME] = '1';
         expect(Actor.isAtHome()).toBe(true);
+        expect(Actor.isRunningOnApify()).toBe(true);
         delete process.env[APIFY_ENV_VARS.IS_AT_HOME];
         expect(Actor.isAtHome()).toBe(false);
+        expect(Actor.isRunningOnApify()).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary

- add `Actor.isRunningOnApify()` as the clearer platform-detection helper
- keep `Actor.isAtHome()` available and mark it deprecated
- verify both methods return the same result for local and platform environments

## Why

`isAtHome()` is a legacy name that does not clearly describe what it checks. The new name communicates the platform condition directly without breaking existing callers.

Closes #537

## Validation

- `corepack pnpm test` (126 passed, 14 skipped)
- `corepack pnpm vitest run test/apify/utils.test.ts --silent`
- `corepack pnpm compile`
- `corepack pnpm lint`
- `corepack pnpm exec oxfmt --check src/actor.ts test/apify/utils.test.ts`
- `git diff --check`