### PR TITLE
docs: Fix capitalization in topic titles

### DIFF
--- a/docs/02_concepts/02_request_storage.mdx
+++ b/docs/02_concepts/02_request_storage.mdx
@@ -1,6 +1,6 @@
 ---
 id: request-storage
-title: Request Storage
+title: Request storage
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/docs/02_concepts/03_result_storage.mdx
+++ b/docs/02_concepts/03_result_storage.mdx
@@ -1,6 +1,6 @@
 ---
 id: result-storage
-title: Result Storage
+title: Result storage
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/docs/02_concepts/04_proxy_management.mdx
+++ b/docs/02_concepts/04_proxy_management.mdx
@@ -1,6 +1,6 @@
 ---
 id: proxy-management
-title: Proxy Management
+title: Proxy management
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/docs/02_concepts/05_session_management.mdx
+++ b/docs/02_concepts/05_session_management.mdx
@@ -1,6 +1,6 @@
 ---
 id: session-management
-title: Session Management
+title: Session management
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/docs/02_concepts/06_environment_variables.mdx
+++ b/docs/02_concepts/06_environment_variables.mdx
@@ -1,6 +1,6 @@
 ---
 id: environment-variables
-title: Environment Variables
+title: Environment variables
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/website/versioned_docs/version-3.7/02_concepts/02_request_storage.mdx
+++ b/website/versioned_docs/version-3.7/02_concepts/02_request_storage.mdx
@@ -1,6 +1,6 @@
 ---
 id: request-storage
-title: Request Storage
+title: Request storage
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/website/versioned_docs/version-3.7/02_concepts/03_result_storage.mdx
+++ b/website/versioned_docs/version-3.7/02_concepts/03_result_storage.mdx
@@ -1,6 +1,6 @@
 ---
 id: result-storage
-title: Result Storage
+title: Result storage
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/website/versioned_docs/version-3.7/02_concepts/04_proxy_management.mdx
+++ b/website/versioned_docs/version-3.7/02_concepts/04_proxy_management.mdx
@@ -1,6 +1,6 @@
 ---
 id: proxy-management
-title: Proxy Management
+title: Proxy management
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/website/versioned_docs/version-3.7/02_concepts/05_session_management.mdx
+++ b/website/versioned_docs/version-3.7/02_concepts/05_session_management.mdx
@@ -1,6 +1,6 @@
 ---
 id: session-management
-title: Session Management
+title: Session management
 ---
 
 import ApiLink from '@site/src/components/ApiLink';

--- a/website/versioned_docs/version-3.7/02_concepts/06_environment_variables.mdx
+++ b/website/versioned_docs/version-3.7/02_concepts/06_environment_variables.mdx
@@ -1,6 +1,6 @@
 ---
 id: environment-variables
-title: Environment Variables
+title: Environment variables
 ---
 
 import ApiLink from '@site/src/components/ApiLink';


### PR DESCRIPTION
Makes the topic titles in the last and next versions follow the style guide.