### PR TITLE
ci: run docs job on ubuntu-24.04

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -62,7 +62,7 @@ jobs:
     docs:
         name: Docs build
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout Source code
               uses: actions/checkout@v7


### PR DESCRIPTION
lychee v0.24.2's prebuilt gnu binary needs GLIBC 2.38/2.39; ubuntu-22.04 has 2.35, so the link checker never ran and every PR got a false "broken links" comment.