### PR TITLE
test: isolate on-disk storage dirs of parallel test files

### DIFF
--- a/test/isolateStorageDir.ts
+++ b/test/isolateStorageDir.ts
@@ -1,0 +1,16 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll } from 'vitest';
+
+// Vitest runs test files in parallel worker processes, but every Configuration
+// defaults to the same cwd-relative `./storage` dir — one file's purge-on-init
+// races against another file's reads/writes (ENOENT from the fs backend), so
+// this setup file (wired in vitest.config.mts) points each file at its own dir.
+const storageDir = await mkdtemp(join(tmpdir(), 'apify-sdk-test-storage-'));
+process.env.CRAWLEE_STORAGE_DIR = storageDir;
+
+afterAll(async () => {
+    await rm(storageDir, { recursive: true, force: true });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,6 +19,9 @@ export default defineConfig({
         },
         clearMocks: true,
         restoreMocks: true,
+        // Give each test file its own storage dir - parallel workers must not
+        // share (and purge) the same on-disk `./storage`.
+        setupFiles: ['./test/isolateStorageDir.ts'],
         testTimeout: 60_000,
         hookTimeout: 60_000,
         alias: [


### PR DESCRIPTION
The unit test suite was flaky when run as a whole: every few full runs, a random test (most often in `charging.test.ts` or `actor.test.ts`) failed with `I/O error: No such file or directory (os error 2)`.

The cause is a race on shared on-disk storage. Vitest runs test files in parallel worker processes, and every `Configuration` defaults to the same cwd-relative `./storage` dir. `Actor.init()` in one worker purges the default storages from disk while another worker's test is reading or writing the same paths through the fs storage backend, which then throws ENOENT. Any test file that touches real disk storage can be either the culprit or the victim, which is why the failing test varies between runs.

The fix adds a vitest setup file that points `CRAWLEE_STORAGE_DIR` at a fresh temp dir before each test file runs and removes it again afterwards, so parallel workers never share storage paths. The test assertions are unchanged.

I verified this by running the full suite in a loop: without the fix it failed within 6 attempts in both tries, with the fix all 20 runs passed. Unit tests also no longer create the repo-root `./storage` dir, and the temp dirs get cleaned up after each file.
