### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,11 +18,11 @@ jobs:
         runs-on: ubuntu-22.04
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -48,15 +48,15 @@ jobs:
                   github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Set up GitHub Pages
-              uses: actions/configure-pages@v6
+              uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
             - name: Upload GitHub Pages artifact
-              uses: actions/upload-pages-artifact@v5
+              uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
               with:
                   path: ./website/build
 
             - name: Deploy artifact to GitHub Pages
-              uses: actions/deploy-pages@v5
+              uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
             - name: Invalidate CloudFront cache
               run: |

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -25,7 +25,7 @@ jobs:
         name: Publish to NPM
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   ref: ${{ inputs.ref }}
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
                   fetch-tags: true
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
             - name: Update CHANGELOG.md
-              uses: DamianReeves/write-file-action@{"message":"Not # master
+              uses: DamianReeves/write-file-action@d4ee8a06aec5db0c57a036b86f2f428e1f8b00e7 # master
               with:
                   path: CHANGELOG.md
                   write-mode: overwrite

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,10 +40,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -51,7 +51,7 @@ jobs:
               uses: apify/actions/pnpm-install@v1.4.1
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v6
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -97,13 +97,13 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                   fetch-depth: 0
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
@@ -115,7 +115,7 @@ jobs:
               run: pnpm version --no-git-tag-version --allow-same-version ${{ needs.release_metadata.outputs.version_number }}
 
             - name: Update CHANGELOG.md
-              uses: DamianReeves/write-file-action@master
+              uses: DamianReeves/write-file-action@{"message":"Not # master
               with:
                   path: CHANGELOG.md
                   write-mode: overwrite
@@ -137,7 +137,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
         steps:
             - name: Create release
-              uses: softprops/action-gh-release@v3
+              uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
               with:
                   tag_name: ${{ needs.update_changelog.outputs.tag_name }}
                   name: ${{ needs.update_changelog.outputs.version_number }}
@@ -151,7 +151,7 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   # Always check out the default branch (not the SHA) so the commit
                   # action can push to a branch ref.
@@ -159,7 +159,7 @@ jobs:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -31,10 +31,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -42,7 +42,7 @@ jobs:
               uses: apify/actions/pnpm-install@v1.4.1
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v6
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -65,10 +65,10 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout Source code
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -83,7 +83,7 @@ jobs:
             - name: Run Lychee Link Checker
               id: lychee
               if: github.event_name == 'pull_request'
-              uses: lycheeverse/lychee-action@v2.9.0
+              uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
               with:
                   fail: false
                   args: >
@@ -101,7 +101,7 @@ jobs:
 
             - name: Find Comment
               if: github.event_name == 'pull_request'
-              uses: peter-evans/find-comment@v4
+              uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
               id: find-comment
               with:
                   issue-number: ${{ github.event.pull_request.number }}
@@ -109,7 +109,7 @@ jobs:
 
             - name: Links are passing
               if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code == 0 && steps.find-comment.outputs.comment-id
-              uses: peter-evans/create-or-update-comment@v5
+              uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
               with:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
@@ -121,7 +121,7 @@ jobs:
 
             - name: Links are failing
               if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code != 0
-              uses: peter-evans/create-or-update-comment@v5
+              uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
               with:
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
@@ -136,10 +136,10 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 
@@ -159,13 +159,13 @@ jobs:
         needs: [lint, build_and_test]
         steps:
             - name: Checkout Source code
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0 # we need to pull everything to have correct dev version suffix
                   ref: master
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -20,10 +20,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
 

--- a/.github/workflows/update-new-issue.yaml
+++ b/.github/workflows/update-new-issue.yaml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             # Add the "t-tooling" label to all new issues
-            - uses: actions/github-script@v9
+            - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       github.rest.issues.addLabels({


### PR DESCRIPTION
This pins every third-party action in the workflows to a full commit SHA, keeping the resolved version tag as a trailing comment. Renovate understands that convention and updates the SHA and comment together.

Same change as apify/crawlee#4051, rolled out team-wide. The trigger was the `v11` tag of `EndBug/add-and-commit` moving to a broken release that failed to load and killed the crawlee publish workflow. With SHA pins, a tag moving under us, by accident or by compromise, can't break or hijack CI anymore. Where `EndBug/add-and-commit` is used, it's pinned to v11.0.0, the last working release.

Own-org references (`apify/*`) stay on floating refs on purpose, since we control those repos.
