### PR TITLE
chore: support RC releases in the publish workflow

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -13,17 +13,20 @@ const PACKAGE_NAME = pkgJson.name;
 // package.json stays on the current major (3.x) and we publish betas of the
 // *next* major (4.0.0-beta.N) under that tag. (The tag isn't a bare `v4`
 // because npm refuses dist-tags that parse as a semver range.)
+// The `rc` tag works the same way but publishes release candidates of the
+// next major (e.g. 4.0.0-rc.N).
 const distTag = process.argv[2];
 const premajorMatch = /v(\d+)$/.exec(distTag ?? '');
 const premajor = premajorMatch ? Number(premajorMatch[1]) : null;
+const preid = distTag === 'rc' ? 'rc' : 'beta';
 
-const nextVersion = computeNextBetaVersion(pkgJson.version, premajor);
+const nextVersion = computeNextPrereleaseVersion(pkgJson.version, premajor);
 console.log(`before-deploy: Setting version to ${nextVersion}`);
 pkgJson.version = nextVersion;
 
 fs.writeFileSync(PKG_JSON_PATH, `${JSON.stringify(pkgJson, null, 2)}\n`);
 
-function computeNextBetaVersion(version, premajorVersion) {
+function computeNextPrereleaseVersion(version, premajorVersion) {
     const versionsString = execSync(`npm show ${PACKAGE_NAME} versions --json`, {
         encoding: 'utf8',
     });
@@ -31,7 +34,12 @@ function computeNextBetaVersion(version, premajorVersion) {
 
     let base = version;
 
-    if (premajorVersion !== null) {
+    if (distTag === 'rc') {
+        // Release candidates of the next major: package.json stays on the
+        // current major (e.g. 3.7.2) and we publish 4.0.0-rc.N.
+        const [major] = base.split('.').map(Number);
+        base = `${major + 1}.0.0`;
+    } else if (premajorVersion !== null) {
         // Pre-major release line: keep package.json on the current major and
         // publish betas of the next major (e.g. 3.7.2 -> 4.0.0-beta.N). Only the
         // -beta.N suffix advances between publishes.
@@ -44,11 +52,13 @@ function computeNextBetaVersion(version, premajorVersion) {
         console.log(`before-deploy: Version ${version} already exists on npm, bumping to ${base}`);
     }
 
+    // Only consider the same pre-release series, so the beta and rc counters
+    // advance independently (4.0.0-rc.N must not push 4.0.0-beta.N forward).
     const prereleaseNumbers = versions
-        .filter((v) => v.startsWith(`${base}-`))
+        .filter((v) => v.startsWith(`${base}-${preid}.`))
         .map((v) => Number(v.match(/\.(\d+)$/)?.[1]))
         .filter((n) => !Number.isNaN(n));
     const lastPrereleaseNumber = Math.max(-1, ...prereleaseNumbers);
 
-    return `${base}-beta.${lastPrereleaseNumber + 1}`;
+    return `${base}-${preid}.${lastPrereleaseNumber + 1}`;
 }

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -16,6 +16,7 @@ on:
                     - latest
                     - next
                     - next-v4
+                    - rc
 
 permissions:
     id-token: write # Required for OIDC
@@ -46,8 +47,17 @@ jobs:
               run: pnpm build
 
             - name: Check version consistency and bump pre-release version (pre-release tags only)
-              if: ${{ inputs.tag == 'next' || inputs.tag == 'next-v4' }}
+              if: ${{ inputs.tag != 'latest' }}
               run: node ./.github/scripts/before-beta-release.js ${{ inputs.tag }}
 
             - name: Publish to NPM
               run: pnpm publish --tag ${{ inputs.tag }} --no-git-checks
+
+            # RC releases produce no changelog and no commit on the branch, only a git
+            # tag pointing at the released commit (the version bump lives only on npm).
+            - name: Create git tag
+              if: ${{ inputs.tag == 'rc' }}
+              run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  git tag "v$VERSION"
+                  git push origin "refs/tags/v$VERSION"


### PR DESCRIPTION
Adds an `rc` option to the `publish-to-npm.yaml` workflow so we can publish v4 release candidates, same setup as in crawlee (apify/crawlee#4009) and mikro-orm.

Dispatching the workflow with `tag: rc` from the `v4` branch will:

- compute the next free `4.0.0-rc.N` from npm via `before-beta-release.js` (first run produces `4.0.0-rc.0`; `package.json` stays on the current major, same as the `next-v4` flow)
- publish under the `rc` dist-tag
- create and push a `v4.0.0-rc.N` git tag pointing at the released commit

No changelog is generated and nothing is committed to the branch; the version bump lives only on npm.

The prerelease scan in `before-beta-release.js` now filters by preid (`beta.` vs `rc.`) so the two counters advance independently; before this change, a published `4.0.0-rc.30` would have pushed the next `next-v4` beta number past 30. Verified all three series against live npm data: `rc` computes 4.0.0-rc.0, `next-v4` computes 4.0.0-beta.28, `next` computes 3.7.3-beta.67.

This only needs to live on the `v4` branch: `workflow_dispatch` uses the workflow file from the branch selected in the run dropdown (confirmed with the crawlee RC yesterday), so `master` needs no changes.
