### PR TITLE
refactor!: use native private class fields and remove underscore prefixes

### DIFF
--- a/docs/04_upgrading/upgrading_v4.md
+++ b/docs/04_upgrading/upgrading_v4.md
@@ -87,6 +87,15 @@ Session continuity (reusing the same IP across multiple requests) is now handled
 
 The `tieredProxyUrls` and `tieredProxyConfig` options on `ProxyConfigurationOptions` were dropped in Crawlee v4 ([apify/crawlee#3599](https://github.com/apify/crawlee/pull/3599)) and the SDK no longer threads them through. Migrate to named sessions via `SessionPool` if you relied on tiered rotation.
 
+The `protected` methods of `ProxyConfiguration` lost their underscore prefix, which matters only if you subclassed it and overrode one of them:
+
+- `_getUsername()` -> `getUsername()`
+- `_checkAccess()` -> `checkAccess()`
+- `_fetchStatus()` -> `fetchStatus()`
+- `_throwCannotCombineCustomWithApify()` -> `throwCannotCombineCustomWithApify()`
+
+In addition, `_setPasswordIfToken()` is now `private setPasswordIfToken()` (it was never meant to be part of the subclassing surface), and `_throwCannotCombineCustomMethods()` was removed — the Crawlee base class already performs the same validation with the same error message.
+
 ## EventManager
 
 `PlatformEventManager` now extends Crawlee v4's `EventManager` and integrates with the new service locator. Use `Configuration.getGlobalConfiguration()` (or pass a `Configuration` instance explicitly) when constructing it directly — the constructor no longer accepts a `config` override via the `override` keyword pattern because Crawlee's base class manages the configuration through `serviceLocator` instead of a `config` field.
@@ -160,6 +169,19 @@ try {
 ```
 
 The original `ZodError` is also kept on `error.cause`.
+
+## Private properties are now native `#` fields
+
+Classes across the SDK (`Actor`, `ProxyConfiguration`, `ChargingManager`, `ApifyStorageBackend`, the request queue backends, `PlatformEventManager`, ...) declare their private properties as native JavaScript `#` fields instead of TypeScript's `private` keyword. TypeScript's `private` is erased at compile time, so those properties used to be reachable at runtime — via a cast, bracket access, `Object.keys()`, or `JSON.stringify()`. Native `#` fields are not: they are invisible to enumeration and serialization, and reading one from outside the class is a syntax error. If you (or a test) reached into an SDK internal this way, use the public API instead.
+
+`protected` members keep the `protected` keyword and stay overridable in subclasses; they only lost their underscore prefixes.
+
+One internal that tests commonly reached for was the static `Actor._instance`, the cached instance behind `Actor.getDefaultInstance()`. It is now `#`-private, with an `@internal` seam for replacing or clearing it:
+
+```ts
+Actor.setDefaultInstance(myActor); // install a custom default instance
+Actor.setDefaultInstance(); // drop the cached one
+```
 
 ## Dependencies
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
         'typescript/ban-ts-comment': 'off',
         'no-param-reassign': 'off',
         'no-void': 'off',
+        'no-underscore-dangle': ['error', { enforceInClassFields: true, enforceInMethodNames: true }],
     },
     overrides: [
         {
@@ -20,6 +21,7 @@ export default defineConfig({
             files: ['test/**'],
             rules: {
                 'no-console': 'off',
+                'no-underscore-dangle': 'off',
                 'no-useless-constructor': 'off',
                 'typescript/no-empty-function': 'off',
                 'typescript/no-unused-vars': 'off',

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -411,8 +411,7 @@ export const EXIT_CODES = {
  */
 export class Actor<Data extends Dictionary = Dictionary> {
     /** @internal */
-
-    static _instance: Actor;
+    static #instance?: Actor;
 
     /**
      * Configuration of this SDK instance (provided to its constructor). See {@apilink Configuration} for details.
@@ -441,22 +440,22 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * Set if the Actor called a method that requires the instance to be initialized, but did not do so.
      * A call to `init` after this warning is emitted is considered  an invalid state and will throw an error.
      */
-    private warnedAboutMissingInitCall = false;
+    #warnedAboutMissingInitCall = false;
 
     /**
      * Set if the Actor is currently rebooting.
      */
-    private isRebooting = false;
+    #isRebooting = false;
 
     /**
      * Set if the Actor is currently exiting. Prevents double-exit from graceful shutdown handlers.
      */
-    private isExiting = false;
+    #isExiting = false;
 
     /**
      * References to graceful shutdown handlers so they can be removed during cleanup.
      */
-    private gracefulShutdownHandlers: {
+    #gracefulShutdownHandlers: {
         aborting?: () => void;
         migrating?: () => void;
     } = {};
@@ -466,10 +465,10 @@ export class Actor<Data extends Dictionary = Dictionary> {
      */
     #statusMessageForwarder?: (data: EventStatusMessageData) => Promise<ClientActorRun>;
 
-    private chargingManager: ChargingManager;
+    #chargingManager: ChargingManager;
 
     /** How Apify platform request queues are consumed; set from {@link InitOptions.requestQueueAccess}. */
-    private requestQueueAccess: RequestQueueAccessMode = 'single';
+    #requestQueueAccess: RequestQueueAccessMode = 'single';
 
     constructor(options: ActorOptions = {}) {
         const { configuration, ...configOptions } = options;
@@ -495,7 +494,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         }
         this.apifyClient = this.newClient();
         this.eventManager = new PlatformEventManager(this.configuration);
-        this.chargingManager = new ChargingManager(this.configuration, this.apifyClient);
+        this.#chargingManager = new ChargingManager(this.configuration, this.apifyClient);
     }
 
     /**
@@ -593,7 +592,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         }
 
         // If the warning about forgotten init call was emitted, we will not continue the init procedure.
-        if (this.warnedAboutMissingInitCall) {
+        if (this.#warnedAboutMissingInitCall) {
             throw new Error(
                 [
                     'Actor.init() was called after a method that would access a storage client was used.',
@@ -613,7 +612,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         // `disableBrowserSandbox` at-home defaults now live in `Configuration`).
         serviceLocator.setConfiguration(this.configuration);
 
-        this.requestQueueAccess = options.requestQueueAccess ?? 'single';
+        this.#requestQueueAccess = options.requestQueueAccess ?? 'single';
 
         if (this.isAtHome()) {
             serviceLocator.setStorageBackend(this.createApifyStorageBackend());
@@ -633,23 +632,23 @@ export class Actor<Data extends Dictionary = Dictionary> {
         if (options.gracefulShutdown !== false) {
             const delay = options.gracefulShutdownDelayMillis ?? 0;
 
-            this.gracefulShutdownHandlers.aborting = () => {
+            this.#gracefulShutdownHandlers.aborting = () => {
                 setTimeout(() => {
                     this.exit().catch((err) => {
                         log.exception(err as Error, 'Failed to exit gracefully');
                     });
                 }, delay);
             };
-            this.on(ACTOR_EVENT_NAMES.ABORTING, this.gracefulShutdownHandlers.aborting);
+            this.on(ACTOR_EVENT_NAMES.ABORTING, this.#gracefulShutdownHandlers.aborting);
 
-            this.gracefulShutdownHandlers.migrating = () => {
+            this.#gracefulShutdownHandlers.migrating = () => {
                 setTimeout(() => {
                     this.reboot().catch((err) => {
                         log.exception(err as Error, 'Failed to reboot on migration');
                     });
                 }, delay);
             };
-            this.on(ACTOR_EVENT_NAMES.MIGRATING, this.gracefulShutdownHandlers.migrating);
+            this.on(ACTOR_EVENT_NAMES.MIGRATING, this.#gracefulShutdownHandlers.migrating);
         }
 
         // Crawlee crawlers, for instance, broadcast their status messages as `statusMessage` events.
@@ -663,8 +662,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
         });
         log.debug(`Default storages purged`);
 
-        await this.chargingManager.init();
-        log.debug(`ChargingManager initialized`, this.chargingManager.getPricingInfo());
+        await this.#chargingManager.init();
+        log.debug(`ChargingManager initialized`, this.#chargingManager.getPricingInfo());
     }
 
     /**
@@ -672,11 +671,11 @@ export class Actor<Data extends Dictionary = Dictionary> {
      */
     async exit(messageOrOptions?: string | ExitOptions, options: ExitOptions = {}): Promise<void> {
         // Prevent double-exit from graceful shutdown handlers
-        if (this.isExiting) {
+        if (this.#isExiting) {
             log.debug('Actor.exit() called while already exiting, skipping');
             return;
         }
-        this.isExiting = true;
+        this.#isExiting = true;
 
         options =
             typeof messageOrOptions === 'string'
@@ -686,17 +685,17 @@ export class Actor<Data extends Dictionary = Dictionary> {
         options.exitCode ??= EXIT_CODES.SUCCESS;
         options.timeoutSecs ??= 30;
 
-        this._ensureActorInit('exit');
+        this.ensureActorInit('exit');
 
         const client = serviceLocator.getStorageBackend();
         const events = serviceLocator.getEventManager();
 
         // Remove graceful shutdown handlers to prevent them from interfering with exit
-        if (this.gracefulShutdownHandlers.aborting) {
-            this.off(ACTOR_EVENT_NAMES.ABORTING, this.gracefulShutdownHandlers.aborting);
+        if (this.#gracefulShutdownHandlers.aborting) {
+            this.off(ACTOR_EVENT_NAMES.ABORTING, this.#gracefulShutdownHandlers.aborting);
         }
-        if (this.gracefulShutdownHandlers.migrating) {
-            this.off(ACTOR_EVENT_NAMES.MIGRATING, this.gracefulShutdownHandlers.migrating);
+        if (this.#gracefulShutdownHandlers.migrating) {
+            this.off(ACTOR_EVENT_NAMES.MIGRATING, this.#gracefulShutdownHandlers.migrating);
         }
 
         // Close the event manager and emit the final PERSIST_STATE event
@@ -759,7 +758,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
         // Reset the flag so the instance can be reused (e.g., in tests or when exit is false).
         // When process.exit() actually terminates the process, this line is never reached - which is fine.
-        this.isExiting = false;
+        this.#isExiting = false;
 
         if (!options.exit) {
             return;
@@ -950,19 +949,19 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async reboot(options: RebootOptions = {}): Promise<void> {
-        this._ensureActorInit('reboot');
+        this.ensureActorInit('reboot');
 
         if (!this.isAtHome()) {
             log.warning('Actor.reboot() is only supported when running on the Apify platform.');
             return;
         }
 
-        if (this.isRebooting) {
+        if (this.#isRebooting) {
             log.debug('Actor is already rebooting, skipping the additional reboot call.');
             return;
         }
 
-        this.isRebooting = true;
+        this.#isRebooting = true;
 
         // Waiting for all the listeners to finish, as `.reboot()` kills the container.
         await Promise.all([
@@ -1050,7 +1049,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         parseArgument(statusMessage, z.string());
         parseArgument(isStatusMessageTerminal, z.boolean().optional());
 
-        this._ensureActorInit('setStatusMessage');
+        this.ensureActorInit('setStatusMessage');
 
         const loggedStatusMessage = `[Status message]: ${statusMessage}`;
 
@@ -1120,7 +1119,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async pushData(item: Data | Data[], eventName?: string | undefined): Promise<ChargeResult> {
-        this._ensureActorInit('pushData');
+        this.ensureActorInit('pushData');
 
         if (eventName?.startsWith('apify-')) {
             throw new Error(`Cannot charge for synthetic event '${eventName}' manually`);
@@ -1164,7 +1163,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
     ): Promise<Dataset<Data>> {
         parseArgument(options, z.object({ forceCloud: z.boolean().optional() }).strict());
 
-        this._ensureActorInit('openDataset');
+        this.ensureActorInit('openDataset');
 
         return Dataset.open<Data>(datasetIdOrName ?? null, {
             storageBackend: options.forceCloud ? this.createApifyStorageBackend() : undefined,
@@ -1200,7 +1199,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async getValue<T = unknown>(key: string): Promise<T | null> {
-        this._ensureActorInit('getValue');
+        this.ensureActorInit('getValue');
 
         const store = await this.openKeyValueStore();
         return store.getValue<T>(key);
@@ -1238,7 +1237,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async setValue<T>(key: string, value: T | null, options: RecordOptions = {}): Promise<void> {
-        this._ensureActorInit('setValue');
+        this.ensureActorInit('setValue');
 
         const store = await this.openKeyValueStore();
         return store.setValue(key, value, options);
@@ -1274,7 +1273,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async getInput<T = Dictionary | string | Buffer>(): Promise<T | null> {
-        this._ensureActorInit('getInput');
+        this.ensureActorInit('getInput');
 
         const { inputSecretsPrivateKeyFile, inputSecretsPrivateKeyPassphrase } = this.configuration;
         const rawInput = await this.getValue<T>(this.configuration.inputKey);
@@ -1334,7 +1333,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
     ): Promise<KeyValueStore> {
         parseArgument(options, z.object({ forceCloud: z.boolean().optional() }).strict());
 
-        this._ensureActorInit('openKeyValueStore');
+        this.ensureActorInit('openKeyValueStore');
 
         return KeyValueStore.open(storeIdOrName ?? null, {
             storageBackend: options.forceCloud ? this.createApifyStorageBackend() : undefined,
@@ -1366,7 +1365,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
     ): Promise<RequestQueue> {
         parseArgument(options, z.object({ forceCloud: z.boolean().optional() }).strict());
 
-        this._ensureActorInit('openRequestQueue');
+        this.ensureActorInit('openRequestQueue');
 
         return RequestQueue.open(queueIdOrName ?? null, {
             storageBackend: options.forceCloud ? this.createApifyStorageBackend() : undefined,
@@ -1455,8 +1454,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     async charge(options: ChargeOptions): Promise<ChargeResult> {
-        this._ensureActorInit('charge');
-        return this.chargingManager.charge(options);
+        this.ensureActorInit('charge');
+        return this.#chargingManager.charge(options);
     }
 
     /**
@@ -1464,8 +1463,8 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * @ignore
      */
     getChargingManager(): ChargingManager {
-        this._ensureActorInit('getChargingManager');
-        return this.chargingManager;
+        this.ensureActorInit('getChargingManager');
+        return this.#chargingManager;
     }
 
     /**
@@ -1564,7 +1563,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         defaultValue = {} as State,
         options?: UseStateOptions,
     ) {
-        this._ensureActorInit('useState');
+        this.ensureActorInit('useState');
 
         const kvStore = await KeyValueStore.open(options?.keyValueStoreName, {
             configuration: options?.configuration || Configuration.getGlobalConfiguration(),
@@ -2239,8 +2238,16 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
     /** @internal */
     static getDefaultInstance(): Actor {
-        this._instance ??= new Actor();
-        return this._instance;
+        Actor.#instance ??= new Actor();
+        return Actor.#instance;
+    }
+
+    /**
+     * Replaces or clears the cached default instance returned by {@apilink Actor.getDefaultInstance}.
+     * @internal
+     */
+    static setDefaultInstance(instance?: Actor): void {
+        Actor.#instance = instance;
     }
 
     private usesPushDataInterception(dataset: Dataset): boolean {
@@ -2290,7 +2297,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
         const isDefaultDataset = dataset.id === this.configuration.defaultDatasetId;
 
         return pushDataAndCharge({
-            chargingManager: this.chargingManager,
+            chargingManager: this.#chargingManager,
             items,
             eventName: explicitEventName,
             isDefaultDataset,
@@ -2301,14 +2308,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
     private createApifyStorageBackend(): ApifyStorageBackend {
         return new ApifyStorageBackend(this.apifyClient, {
             configuration: this.configuration,
-            requestQueueAccess: this.requestQueueAccess,
-            getChargingManager: () => this.chargingManager,
+            requestQueueAccess: this.#requestQueueAccess,
+            getChargingManager: () => this.#chargingManager,
         });
     }
 
-    private _ensureActorInit(methodCalled: string) {
+    private ensureActorInit(methodCalled: string) {
         // If we already warned the user once, don't do it again to prevent spam
-        if (this.warnedAboutMissingInitCall) {
+        if (this.#warnedAboutMissingInitCall) {
             return;
         }
 
@@ -2316,7 +2323,7 @@ export class Actor<Data extends Dictionary = Dictionary> {
             return;
         }
 
-        this.warnedAboutMissingInitCall = true;
+        this.#warnedAboutMissingInitCall = true;
 
         log.warning(
             [

--- a/src/apify_dataset_backend.ts
+++ b/src/apify_dataset_backend.ts
@@ -18,10 +18,14 @@ const MAX_ITEM_BYTES = EFFECTIVE_LIMIT_BYTES - 2;
  * @internal
  */
 export class ApifyDatasetBackend implements DatasetBackend {
-    constructor(private readonly client: DatasetClient) {}
+    readonly #client: DatasetClient;
+
+    constructor(client: DatasetClient) {
+        this.#client = client;
+    }
 
     async getMetadata(): Promise<DatasetInfo> {
-        const metadata = await this.client.get();
+        const metadata = await this.#client.get();
         if (!metadata) {
             throw new Error('Dataset not found or has been deleted.');
         }
@@ -29,7 +33,7 @@ export class ApifyDatasetBackend implements DatasetBackend {
     }
 
     async drop(): Promise<void> {
-        await this.client.delete();
+        await this.#client.delete();
     }
 
     async purge(): Promise<void> {
@@ -44,12 +48,12 @@ export class ApifyDatasetBackend implements DatasetBackend {
         // that fit, pushed sequentially to preserve item order.
         const payloads = items.map((item, index) => serializeToSizeLimit(item, index));
         for (const chunk of chunkBySize(payloads, EFFECTIVE_LIMIT_BYTES)) {
-            await this.client.pushItems(chunk);
+            await this.#client.pushItems(chunk);
         }
     }
 
     async getData(options?: DatasetBackendListOptions): Promise<PaginatedList<Dictionary>> {
-        return await this.client.listItems(options);
+        return await this.#client.listItems(options);
     }
 }
 

--- a/src/apify_key_value_store_backend.ts
+++ b/src/apify_key_value_store_backend.ts
@@ -18,10 +18,14 @@ import type { KeyValueStoreClient } from 'apify-client';
  * @internal
  */
 export class ApifyKeyValueStoreBackend implements KeyValueStoreBackend {
-    constructor(private readonly client: KeyValueStoreClient) {}
+    readonly #client: KeyValueStoreClient;
+
+    constructor(client: KeyValueStoreClient) {
+        this.#client = client;
+    }
 
     async getMetadata(): Promise<KeyValueStoreInfo> {
-        const metadata = await this.client.get();
+        const metadata = await this.#client.get();
         if (!metadata) {
             throw new Error('Key-value store not found or has been deleted.');
         }
@@ -29,7 +33,7 @@ export class ApifyKeyValueStoreBackend implements KeyValueStoreBackend {
     }
 
     async drop(): Promise<void> {
-        await this.client.delete();
+        await this.#client.delete();
     }
 
     async purge(): Promise<void> {
@@ -42,19 +46,19 @@ export class ApifyKeyValueStoreBackend implements KeyValueStoreBackend {
     async getValue(key: string): Promise<KeyValueStoreRecord | undefined> {
         // Storage backends are byte transports — the KeyValueStore frontend parses values
         // according to their content type, so the record must be returned unparsed.
-        return this.client.getRecord(key, { buffer: true });
+        return this.#client.getRecord(key, { buffer: true });
     }
 
     async setValue(record: KeyValueStoreInputRecord): Promise<void> {
-        await this.client.setRecord(record as Parameters<KeyValueStoreClient['setRecord']>[0]);
+        await this.#client.setRecord(record as Parameters<KeyValueStoreClient['setRecord']>[0]);
     }
 
     async deleteValue(key: string): Promise<void> {
-        await this.client.deleteRecord(key);
+        await this.#client.deleteRecord(key);
     }
 
     async listKeys(options?: KeyValueStoreListKeysOptions): Promise<KeyValueStoreListKeysResult> {
-        const result = await this.client.listKeys(options);
+        const result = await this.#client.listKeys(options);
         // The API does not report a content type for listed keys; crawlee's item shape
         // requires the field, so it is left undefined via the cast.
         return {
@@ -64,10 +68,10 @@ export class ApifyKeyValueStoreBackend implements KeyValueStoreBackend {
     }
 
     async getPublicUrl(key: string): Promise<string | undefined> {
-        return this.client.getRecordPublicUrl(key);
+        return this.#client.getRecordPublicUrl(key);
     }
 
     async recordExists(key: string): Promise<boolean> {
-        return this.client.recordExists(key);
+        return this.#client.recordExists(key);
     }
 }

--- a/src/apify_request_queue_backend.ts
+++ b/src/apify_request_queue_backend.ts
@@ -172,12 +172,12 @@ export abstract class ApifyRequestQueueBackend implements RequestQueueBackend {
  * @internal
  */
 export class AsyncLock {
-    private tail: Promise<unknown> = Promise.resolve();
+    #tail: Promise<unknown> = Promise.resolve();
 
     async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
-        const run = this.tail.then(fn);
+        const run = this.#tail.then(fn);
         // Keep the chain alive even when the critical section throws.
-        this.tail = run.catch(() => {});
+        this.#tail = run.catch(() => {});
         return run;
     }
 }

--- a/src/apify_request_queue_shared_backend.ts
+++ b/src/apify_request_queue_shared_backend.ts
@@ -39,30 +39,30 @@ interface CachedRequestInfo {
  */
 export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
     /** Ids of requests locked by this client and waiting to be handed out by `fetchNextRequest`. */
-    private readonly headIds: string[] = [];
+    readonly #headIds: string[] = [];
 
     /** Dedup records for requests known to exist on the platform, keyed by id. */
-    private readonly cachedRequestInfo = new LruCache<CachedRequestInfo>({ maxLength: MAX_CACHED_REQUESTS });
+    readonly #cachedRequestInfo = new LruCache<CachedRequestInfo>({ maxLength: MAX_CACHED_REQUESTS });
 
     /** Ids of requests currently being processed by this client. */
-    private readonly inProgressIds = new Set<string>();
+    readonly #inProgressIds = new Set<string>();
 
     /** Whether the last head read reported any locked requests left in the queue (any client's). */
-    private queueHasLockedRequests?: boolean;
+    #queueHasLockedRequests?: boolean;
 
     /** Set after a forefront insert — the next head read starts fresh so the insert is honored. */
-    private shouldCheckForefrontRequests = false;
+    #shouldCheckForefrontRequests = false;
 
     /** Lock duration applied to fetched requests; raised via `setExpectedRequestProcessingTimeSecs`. */
-    private lockSecs = DEFAULT_REQUEST_LOCK_SECS;
+    #lockSecs = DEFAULT_REQUEST_LOCK_SECS;
 
     /** Serializes head reads and reclaims — both reorder the shared head state. */
-    private readonly headLock = new AsyncLock();
+    readonly #headLock = new AsyncLock();
 
     override async setExpectedRequestProcessingTimeSecs(secs: number): Promise<void> {
         // Only ever raise the lock duration — several consumers may share this client, and a
         // short-lived one must not cut the reservation of a long-running one short.
-        this.lockSecs = Math.max(this.lockSecs, secs);
+        this.#lockSecs = Math.max(this.#lockSecs, secs);
     }
 
     async addBatchOfRequests(
@@ -78,7 +78,7 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
         const newRequests: RequestSchema[] = [];
         for (const request of requests) {
             const id = this.requestIdFromUniqueKey(request.uniqueKey);
-            const cached = this.cachedRequestInfo.get(id);
+            const cached = this.#cachedRequestInfo.get(id);
             if (cached) {
                 alreadyPresent.push({
                     requestId: id,
@@ -100,7 +100,7 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
             // A forefront insert changes the head order — have the next head read re-fetch the
             // front of the queue instead of draining the local buffer first.
             if (forefront) {
-                this.shouldCheckForefrontRequests = true;
+                this.#shouldCheckForefrontRequests = true;
             }
         }
 
@@ -116,9 +116,9 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
     }
 
     async fetchNextRequest(): Promise<UpdateRequestSchema | undefined> {
-        const id = await this.headLock.runExclusive(async () => {
+        const id = await this.#headLock.runExclusive(async () => {
             await this.ensureHeadIsNonEmpty();
-            return this.headIds.shift();
+            return this.#headIds.shift();
         });
         if (!id) return undefined;
 
@@ -136,7 +136,7 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
             this.cacheRequestInfo(id, { wasAlreadyHandled: true });
             return undefined;
         }
-        this.inProgressIds.add(id);
+        this.#inProgressIds.add(id);
         return request;
     }
 
@@ -145,14 +145,14 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
         // Contract: marking a request that does not exist in the queue is a no-op — it must not be
         // added as a side effect (the platform update endpoint would upsert it).
         if (!(await this.isKnownOrExists(id))) {
-            this.inProgressIds.delete(id);
+            this.#inProgressIds.delete(id);
             return undefined;
         }
 
         const handledAt = request.handledAt ?? new Date().toISOString();
         const info = await this.updateRequestOnPlatform({ ...request, id, handledAt });
 
-        this.inProgressIds.delete(id);
+        this.#inProgressIds.delete(id);
         this.cacheRequestInfo(id, { wasAlreadyHandled: true });
         if (!info.wasAlreadyHandled) {
             this.estimatedHandledRequestCount += 1;
@@ -168,11 +168,11 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
         const id = this.requestIdFromUniqueKey(request.uniqueKey);
         // Same contract as `markRequestAsHandled` — never insert as a side effect.
         if (!(await this.isKnownOrExists(id))) {
-            this.inProgressIds.delete(id);
+            this.#inProgressIds.delete(id);
             return undefined;
         }
 
-        return this.headLock.runExclusive(async () => {
+        return this.#headLock.runExclusive(async () => {
             const info = await this.updateRequestOnPlatform({ ...request, id, handledAt: undefined }, forefront);
 
             // Release the server-side lock so the request becomes fetchable again immediately —
@@ -183,10 +183,10 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
                 log.debug(`Failed to delete the lock of a reclaimed request (id: ${id}): ${(err as Error).message}`);
             }
 
-            this.inProgressIds.delete(id);
+            this.#inProgressIds.delete(id);
             this.cacheRequestInfo(id, { wasAlreadyHandled: false });
             if (forefront) {
-                this.shouldCheckForefrontRequests = true;
+                this.#shouldCheckForefrontRequests = true;
             }
             if (info.wasAlreadyHandled) {
                 this.estimatedHandledRequestCount -= 1;
@@ -196,25 +196,25 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
     }
 
     async isEmpty(): Promise<boolean> {
-        return this.headLock.runExclusive(async () => {
-            if (this.headIds.length > 0) return false;
+        return this.#headLock.runExclusive(async () => {
+            if (this.#headIds.length > 0) return false;
             await this.listAndLockHead(1);
-            return this.headIds.length === 0;
+            return this.#headIds.length === 0;
         });
     }
 
     async isFinished(): Promise<boolean> {
-        return this.headLock.runExclusive(async () => {
-            if (this.headIds.length > 0) return false;
+        return this.#headLock.runExclusive(async () => {
+            if (this.#headIds.length > 0) return false;
             // The head read also refreshes `queueHasLockedRequests`, so the order matters here.
             await this.listAndLockHead(1);
-            return this.headIds.length === 0 && !this.queueHasLockedRequests;
+            return this.#headIds.length === 0 && !this.#queueHasLockedRequests;
         });
     }
 
     /** Must be called with the head lock held. */
     private async ensureHeadIsNonEmpty(): Promise<void> {
-        if (this.headIds.length > 1 && !this.shouldCheckForefrontRequests) {
+        if (this.#headIds.length > 1 && !this.#shouldCheckForefrontRequests) {
             return;
         }
         await this.listAndLockHead(HEAD_LOCK_LIMIT);
@@ -225,25 +225,25 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
         // After a forefront insert the local buffer no longer starts at the true front of the
         // queue — re-fetch the front and keep the already-locked leftovers for afterwards.
         let leftoverIds: string[] = [];
-        if (this.shouldCheckForefrontRequests) {
-            leftoverIds = this.headIds.splice(0);
-            this.shouldCheckForefrontRequests = false;
+        if (this.#shouldCheckForefrontRequests) {
+            leftoverIds = this.#headIds.splice(0);
+            this.#shouldCheckForefrontRequests = false;
         }
 
-        const head = await this.client.listAndLockHead({ limit, lockSecs: this.lockSecs });
-        this.queueHasLockedRequests = head.queueHasLockedRequests;
+        const head = await this.client.listAndLockHead({ limit, lockSecs: this.#lockSecs });
+        this.#queueHasLockedRequests = head.queueHasLockedRequests;
 
         for (const item of head.items) {
-            if (this.inProgressIds.has(item.id)) continue;
-            if (this.headIds.includes(item.id) || leftoverIds.includes(item.id)) continue;
+            if (this.#inProgressIds.has(item.id)) continue;
+            if (this.#headIds.includes(item.id) || leftoverIds.includes(item.id)) continue;
             this.cacheRequestInfo(item.id, { wasAlreadyHandled: false });
-            this.headIds.push(item.id);
+            this.#headIds.push(item.id);
         }
-        this.headIds.push(...leftoverIds);
+        this.#headIds.push(...leftoverIds);
     }
 
     private async isKnownOrExists(id: string): Promise<boolean> {
-        if (this.inProgressIds.has(id) || this.cachedRequestInfo.get(id)) {
+        if (this.#inProgressIds.has(id) || this.#cachedRequestInfo.get(id)) {
             return true;
         }
         return (await this.getRequestById(id)) !== undefined;
@@ -251,7 +251,7 @@ export class ApifyRequestQueueSharedBackend extends ApifyRequestQueueBackend {
 
     private cacheRequestInfo(id: string, info: CachedRequestInfo): void {
         // `LruCache.add` does not overwrite existing entries, so remove first.
-        this.cachedRequestInfo.remove(id);
-        this.cachedRequestInfo.add(id, info);
+        this.#cachedRequestInfo.remove(id);
+        this.#cachedRequestInfo.add(id, info);
     }
 }

--- a/src/apify_request_queue_single_backend.ts
+++ b/src/apify_request_queue_single_backend.ts
@@ -46,26 +46,26 @@ const INIT_CACHES_REQUEST_LIMIT = 10_000;
  */
 export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
     /** Local estimate of the queue head — request ids in the order they should be fetched. */
-    private readonly headIds: string[] = [];
+    readonly #headIds: string[] = [];
 
     /** Unhandled full request objects added by (or fetched through) this client, keyed by id. */
-    private readonly cachedRequests = new LruCache<UpdateRequestSchema>({ maxLength: MAX_CACHED_REQUESTS });
+    readonly #cachedRequests = new LruCache<UpdateRequestSchema>({ maxLength: MAX_CACHED_REQUESTS });
 
     /** Ids of requests known to be already handled — cheap dedup without caching full objects. */
-    private readonly handledIds = new Set<string>();
+    readonly #handledIds = new Set<string>();
 
     /** Ids of requests currently being processed by this client. */
-    private readonly inProgressIds = new Set<string>();
+    readonly #inProgressIds = new Set<string>();
 
     /** Memoized one-time prefetch of existing queue contents into the local caches. */
-    private initCachesPromise?: Promise<void>;
+    #initCachesPromise?: Promise<void>;
 
     async addBatchOfRequests(
         requests: RequestSchema[],
         options: RequestQueueOperationOptions = {},
     ): Promise<BatchAddRequestsResult> {
         const { forefront = false } = options;
-        await (this.initCachesPromise ??= this.initCaches());
+        await (this.#initCachesPromise ??= this.initCaches());
 
         // Split the batch into requests we already know about (dedup them locally — a platform
         // write costs an API call and a paid write operation) and genuinely new ones.
@@ -73,14 +73,14 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
         const newRequests: RequestSchema[] = [];
         for (const request of requests) {
             const id = this.requestIdFromUniqueKey(request.uniqueKey);
-            if (this.handledIds.has(id)) {
+            if (this.#handledIds.has(id)) {
                 alreadyPresent.push({
                     requestId: id,
                     uniqueKey: request.uniqueKey,
                     wasAlreadyPresent: true,
                     wasAlreadyHandled: true,
                 });
-            } else if (this.cachedRequests.get(id)) {
+            } else if (this.#cachedRequests.get(id)) {
                 alreadyPresent.push({
                     requestId: id,
                     uniqueKey: request.uniqueKey,
@@ -107,14 +107,14 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
                 const processed = processedByKey.get(request.uniqueKey);
                 if (!processed) continue; // rejected by the platform, reported in `unprocessedRequests`
                 if (processed.wasAlreadyHandled) {
-                    this.handledIds.add(processed.requestId);
+                    this.#handledIds.add(processed.requestId);
                     continue;
                 }
                 this.cacheRequest({ ...request, id: processed.requestId });
                 if (forefront) {
-                    this.headIds.unshift(processed.requestId);
+                    this.#headIds.unshift(processed.requestId);
                 } else {
-                    this.headIds.push(processed.requestId);
+                    this.#headIds.push(processed.requestId);
                 }
             }
         }
@@ -126,16 +126,16 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
 
     async getRequest(uniqueKey: string): Promise<UpdateRequestSchema | undefined> {
         const id = this.requestIdFromUniqueKey(uniqueKey);
-        const cached = this.cachedRequests.get(id);
+        const cached = this.#cachedRequests.get(id);
         if (cached) return cached;
 
         const request = await this.getRequestById(id);
         if (!request) return undefined;
 
         // Requests already in progress are ones the client knows about — no caching needed.
-        if (!this.inProgressIds.has(id)) {
+        if (!this.#inProgressIds.has(id)) {
             if (request.handledAt) {
-                this.handledIds.add(id);
+                this.#handledIds.add(id);
             } else {
                 this.cacheRequest(request);
             }
@@ -146,24 +146,24 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
     async fetchNextRequest(): Promise<UpdateRequestSchema | undefined> {
         await this.ensureHeadIsNonEmpty();
 
-        while (this.headIds.length > 0) {
-            const id = this.headIds.shift()!;
-            if (this.inProgressIds.has(id) || this.handledIds.has(id)) {
+        while (this.#headIds.length > 0) {
+            const id = this.#headIds.shift()!;
+            if (this.#inProgressIds.has(id) || this.#handledIds.has(id)) {
                 continue;
             }
-            this.inProgressIds.add(id);
+            this.#inProgressIds.add(id);
             // Requests added by this client are served straight from the cache; only requests
             // discovered via `listHead` (added by another producer) need a round-trip.
-            const request = this.cachedRequests.get(id) ?? (await this.getRequestById(id));
+            const request = this.#cachedRequests.get(id) ?? (await this.getRequestById(id));
             if (!request) {
-                this.inProgressIds.delete(id);
+                this.#inProgressIds.delete(id);
                 continue;
             }
             if (request.handledAt) {
                 // Handled elsewhere in the meantime — skip it and remember the outcome.
-                this.inProgressIds.delete(id);
-                this.handledIds.add(id);
-                this.cachedRequests.remove(id);
+                this.#inProgressIds.delete(id);
+                this.#handledIds.add(id);
+                this.#cachedRequests.remove(id);
                 continue;
             }
             return request;
@@ -176,16 +176,16 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
         // Contract: marking a request that does not exist in the queue is a no-op — it must not be
         // added as a side effect (the platform update endpoint would upsert it).
         if (!(await this.isKnownOrExists(id))) {
-            this.inProgressIds.delete(id);
+            this.#inProgressIds.delete(id);
             return undefined;
         }
 
         const handledAt = request.handledAt ?? new Date().toISOString();
         const info = await this.updateRequestOnPlatform({ ...request, id, handledAt });
 
-        this.inProgressIds.delete(id);
-        this.handledIds.add(id);
-        this.cachedRequests.remove(id);
+        this.#inProgressIds.delete(id);
+        this.#handledIds.add(id);
+        this.#cachedRequests.remove(id);
         if (!info.wasAlreadyHandled) {
             this.estimatedHandledRequestCount += 1;
         }
@@ -200,7 +200,7 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
         const id = this.requestIdFromUniqueKey(request.uniqueKey);
         // Same contract as `markRequestAsHandled` — never insert as a side effect.
         if (!(await this.isKnownOrExists(id))) {
-            this.inProgressIds.delete(id);
+            this.#inProgressIds.delete(id);
             return undefined;
         }
 
@@ -208,17 +208,17 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
         const reclaimed: UpdateRequestSchema = { ...request, id, handledAt: undefined };
         const info = await this.updateRequestOnPlatform(reclaimed, forefront);
 
-        this.inProgressIds.delete(id);
-        this.handledIds.delete(id);
+        this.#inProgressIds.delete(id);
+        this.#handledIds.delete(id);
         this.cacheRequest(reclaimed);
         // Return the id to the local head estimate right away — the platform head read can lag a
         // few seconds behind the update, and `isFinished` must never report `true` while a
         // reclaimed request is still waiting to be reprocessed.
-        if (!this.headIds.includes(id)) {
+        if (!this.#headIds.includes(id)) {
             if (forefront) {
-                this.headIds.unshift(id);
+                this.#headIds.unshift(id);
             } else {
-                this.headIds.push(id);
+                this.#headIds.push(id);
             }
         }
         if (info.wasAlreadyHandled) {
@@ -229,31 +229,31 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
 
     async isEmpty(): Promise<boolean> {
         await this.ensureHeadIsNonEmpty();
-        return this.headIds.length === 0;
+        return this.#headIds.length === 0;
     }
 
     async isFinished(): Promise<boolean> {
-        return (await this.isEmpty()) && this.inProgressIds.size === 0;
+        return (await this.isEmpty()) && this.#inProgressIds.size === 0;
     }
 
     private async ensureHeadIsNonEmpty(): Promise<void> {
-        if (this.headIds.length <= 1) {
+        if (this.#headIds.length <= 1) {
             await this.listHead();
         }
     }
 
     private async listHead(): Promise<void> {
         // The head read returns in-progress requests too, so fetch enough to find new ones.
-        const limit = Math.min(MAX_HEAD_ITEMS, DESIRED_NEW_HEAD_ITEMS + this.inProgressIds.size);
+        const limit = Math.min(MAX_HEAD_ITEMS, DESIRED_NEW_HEAD_ITEMS + this.#inProgressIds.size);
         const head = await this.client.listHead({ limit });
         for (const item of head.items) {
-            if (this.inProgressIds.has(item.id) || this.handledIds.has(item.id)) {
+            if (this.#inProgressIds.has(item.id) || this.#handledIds.has(item.id)) {
                 continue;
             }
             // `headIds` is nearly drained whenever this runs (see `ensureHeadIsNonEmpty`), so the
             // linear dedup scan stays cheap.
-            if (!this.headIds.includes(item.id)) {
-                this.headIds.push(item.id);
+            if (!this.#headIds.includes(item.id)) {
+                this.#headIds.push(item.id);
             }
         }
     }
@@ -268,7 +268,7 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
             const response = await this.client.listRequests({ limit: INIT_CACHES_REQUEST_LIMIT });
             for (const request of response.items) {
                 if (request.handledAt) {
-                    this.handledIds.add(request.id);
+                    this.#handledIds.add(request.id);
                 } else {
                     this.cacheRequest(request as unknown as UpdateRequestSchema);
                 }
@@ -283,7 +283,7 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
     }
 
     private async isKnownOrExists(id: string): Promise<boolean> {
-        if (this.inProgressIds.has(id) || this.handledIds.has(id) || this.cachedRequests.get(id)) {
+        if (this.#inProgressIds.has(id) || this.#handledIds.has(id) || this.#cachedRequests.get(id)) {
             return true;
         }
         return (await this.getRequestById(id)) !== undefined;
@@ -291,7 +291,7 @@ export class ApifyRequestQueueSingleBackend extends ApifyRequestQueueBackend {
 
     private cacheRequest(request: UpdateRequestSchema): void {
         // `LruCache.add` does not overwrite existing entries, so remove first.
-        this.cachedRequests.remove(request.id);
-        this.cachedRequests.add(request.id, request);
+        this.#cachedRequests.remove(request.id);
+        this.#cachedRequests.add(request.id, request);
     }
 }

--- a/src/apify_storage_backend.ts
+++ b/src/apify_storage_backend.ts
@@ -92,11 +92,14 @@ export const pushDataChargingContext = new AsyncLocalStorage<PpeAwarePushDataCon
 class PpeAwareDatasetClient<
     Data extends Record<string | number, any> = Record<string | number, unknown>,
 > extends ApifyDatasetClient<Data> {
+    readonly #getChargingManager: () => ChargingManager;
+
     constructor(
         options: ConstructorParameters<typeof ApifyDatasetClient<Data>>[0],
-        private readonly getChargingManager: () => ChargingManager,
+        getChargingManager: () => ChargingManager,
     ) {
         super(options);
+        this.#getChargingManager = getChargingManager;
     }
 
     private normalizeItems(items: string | Data | string[] | Data[]): Data[] {
@@ -121,7 +124,7 @@ class PpeAwareDatasetClient<
         const normalizedItems = this.normalizeItems(items);
 
         const result = await pushDataAndCharge({
-            chargingManager: this.getChargingManager(),
+            chargingManager: this.#getChargingManager(),
             items: normalizedItems,
             eventName: context?.eventName,
             isDefaultDataset: true,
@@ -183,29 +186,28 @@ export interface ApifyStorageBackendOptions {
  * ```
  */
 export class ApifyStorageBackend implements StorageBackend {
-    private readonly config?: Configuration;
-    private readonly requestQueueAccess: RequestQueueAccessMode;
-    private readonly getChargingManager?: () => ChargingManager;
+    readonly #client: ApifyClient;
+    readonly #config?: Configuration;
+    readonly #requestQueueAccess: RequestQueueAccessMode;
+    readonly #getChargingManager?: () => ChargingManager;
 
     /** Unnamed storages resolved for aliases in this process, keyed like {@link AliasMapping}. */
-    private readonly aliasIdCache = new Map<string, string>();
+    readonly #aliasIdCache = new Map<string, string>();
 
     /** The alias mapping read from the run's default key-value store; `undefined` until first read. */
-    private persistedAliasIds?: AliasMapping;
+    #persistedAliasIds?: AliasMapping;
 
     /** Serializes alias resolution — see `resolveAliasId`. */
-    private readonly aliasLock = new AsyncLock();
+    readonly #aliasLock = new AsyncLock();
 
     /** Fallback request queue client key when the run id is unavailable — one per backend. */
-    private fallbackClientKey?: string;
+    #fallbackClientKey?: string;
 
-    constructor(
-        private readonly client: ApifyClient,
-        options: ApifyStorageBackendOptions = {},
-    ) {
-        this.config = options.configuration;
-        this.requestQueueAccess = options.requestQueueAccess ?? 'single';
-        this.getChargingManager = options.getChargingManager;
+    constructor(client: ApifyClient, options: ApifyStorageBackendOptions = {}) {
+        this.#client = client;
+        this.#config = options.configuration;
+        this.#requestQueueAccess = options.requestQueueAccess ?? 'single';
+        this.#getChargingManager = options.getChargingManager;
     }
 
     /**
@@ -221,7 +223,7 @@ export class ApifyStorageBackend implements StorageBackend {
     /** Short digest of the API base URL and token — identifies the credentials a storage was opened with. */
     private credentialsHash(): string {
         return createHash('sha256')
-            .update(`${this.client.publicBaseUrl}${this.client.token ?? ''}`)
+            .update(`${this.#client.publicBaseUrl}${this.#client.token ?? ''}`)
             .digest('hex')
             .slice(0, 8);
     }
@@ -239,7 +241,7 @@ export class ApifyStorageBackend implements StorageBackend {
     async createDatasetBackend(options?: StorageIdentifier): Promise<DatasetBackend> {
         const id = await this.resolveId(options, 'Dataset');
         const chargingClient = this.chargingDatasetClient(id);
-        const backend = new ApifyDatasetBackend(chargingClient ?? this.client.dataset(id));
+        const backend = new ApifyDatasetBackend(chargingClient ?? this.#client.dataset(id));
         if (chargingClient) {
             // `Actor.pushData()` looks for this marker on the dataset's backend to know the
             // pay-per-event charging happens inside the intercepted `pushItems()` calls.
@@ -250,13 +252,13 @@ export class ApifyStorageBackend implements StorageBackend {
 
     async createKeyValueStoreBackend(options?: StorageIdentifier): Promise<KeyValueStoreBackend> {
         const id = await this.resolveId(options, 'KeyValueStore');
-        return new ApifyKeyValueStoreBackend(this.client.keyValueStore(id));
+        return new ApifyKeyValueStoreBackend(this.#client.keyValueStore(id));
     }
 
     async createRequestQueueBackend(options?: StorageIdentifier): Promise<RequestQueueBackend> {
         const id = await this.resolveId(options, 'RequestQueue');
-        const client = this.client.requestQueue(id, { clientKey: this.requestQueueClientKey() });
-        return this.requestQueueAccess === 'shared'
+        const client = this.#client.requestQueue(id, { clientKey: this.requestQueueClientKey() });
+        return this.#requestQueueAccess === 'shared'
             ? new ApifyRequestQueueSharedBackend(client)
             : new ApifyRequestQueueSingleBackend(client);
     }
@@ -266,7 +268,8 @@ export class ApifyStorageBackend implements StorageBackend {
      * migrated or resurrected run re-acquire the request locks of its previous incarnation.
      */
     private requestQueueClientKey(): string {
-        const key = this.config?.actorRunId ?? (this.fallbackClientKey ??= cryptoRandomObjectId(MAX_CLIENT_KEY_LENGTH));
+        const key =
+            this.#config?.actorRunId ?? (this.#fallbackClientKey ??= cryptoRandomObjectId(MAX_CLIENT_KEY_LENGTH));
         return key.slice(0, MAX_CLIENT_KEY_LENGTH);
     }
 
@@ -276,9 +279,9 @@ export class ApifyStorageBackend implements StorageBackend {
      * `undefined` (caller uses the plain client).
      */
     private chargingDatasetClient(id: string): ApifyDatasetClient | undefined {
-        const { getChargingManager } = this;
+        const getChargingManager = this.#getChargingManager;
         if (!getChargingManager) return undefined;
-        if (id !== this.config?.defaultDatasetId) return undefined;
+        if (id !== this.#config?.defaultDatasetId) return undefined;
 
         const hasDefaultDatasetItemEvent =
             DEFAULT_DATASET_ITEM_EVENT in getChargingManager().getPricingInfo().perEventPrices;
@@ -287,10 +290,10 @@ export class ApifyStorageBackend implements StorageBackend {
         return new PpeAwareDatasetClient(
             {
                 id,
-                baseUrl: this.client.baseUrl,
-                publicBaseUrl: this.client.publicBaseUrl,
-                apifyClient: this.client,
-                httpClient: this.client.httpClient,
+                baseUrl: this.#client.baseUrl,
+                publicBaseUrl: this.#client.publicBaseUrl,
+                apifyClient: this.#client,
+                httpClient: this.#client.httpClient,
             },
             getChargingManager,
         );
@@ -314,7 +317,7 @@ export class ApifyStorageBackend implements StorageBackend {
         const alias = (options && 'alias' in options && options.alias) || DEFAULT_STORAGE_ALIAS;
 
         if (alias === DEFAULT_STORAGE_ALIAS) {
-            const defaultId = this.config?.[DEFAULT_ID_CONFIG_KEY[type]];
+            const defaultId = this.#config?.[DEFAULT_ID_CONFIG_KEY[type]];
             if (defaultId) return defaultId;
         } else {
             const declaredId = this.aliasFromActorStorages(alias, type);
@@ -336,22 +339,22 @@ export class ApifyStorageBackend implements StorageBackend {
         // differently-authenticated backends maps to two storages.
         const key = [type, alias, this.credentialsHash()].join(',');
 
-        return this.aliasLock.runExclusive(async () => {
-            const knownId = this.aliasIdCache.get(key);
+        return this.#aliasLock.runExclusive(async () => {
+            const knownId = this.#aliasIdCache.get(key);
             if (knownId) return knownId;
 
             const store = this.aliasMappingStore();
-            this.persistedAliasIds ??= store ? await readAliasMapping(store) : {};
+            this.#persistedAliasIds ??= store ? await readAliasMapping(store) : {};
 
             // A persisted id can point at a storage the user has since deleted.
-            const persistedId = this.persistedAliasIds[key];
+            const persistedId = this.#persistedAliasIds[key];
             if (persistedId && (await this.resourceClient(persistedId, type).get())) {
-                this.aliasIdCache.set(key, persistedId);
+                this.#aliasIdCache.set(key, persistedId);
                 return persistedId;
             }
 
             const { id } = await this.collectionClient(type).getOrCreate();
-            this.aliasIdCache.set(key, id);
+            this.#aliasIdCache.set(key, id);
             if (store) await this.persistAliasId(store, key, id);
             return id;
         });
@@ -366,7 +369,7 @@ export class ApifyStorageBackend implements StorageBackend {
             const mapping = await readAliasMapping(store);
             mapping[key] = id;
             await store.setRecord({ key: ALIAS_MAPPING_RECORD_KEY, value: mapping });
-            this.persistedAliasIds = mapping;
+            this.#persistedAliasIds = mapping;
         } catch (error) {
             log.warning(`Failed to persist the storage alias mapping: ${(error as Error).message}`);
         }
@@ -374,12 +377,12 @@ export class ApifyStorageBackend implements StorageBackend {
 
     /** The run's default key-value store, where the mapping lives — `undefined` off the platform. */
     private aliasMappingStore(): KeyValueStoreClient | undefined {
-        return this.config?.isAtHome ? this.client.keyValueStore(this.config.defaultKeyValueStoreId) : undefined;
+        return this.#config?.isAtHome ? this.#client.keyValueStore(this.#config.defaultKeyValueStoreId) : undefined;
     }
 
     /** Looks an alias up in the Actor's schema storages (the `ACTOR_STORAGES_JSON` env var). */
     private aliasFromActorStorages(alias: string, type: StorageType): string | undefined {
-        const storagesJson = this.config?.actorStoragesJson;
+        const storagesJson = this.#config?.actorStoragesJson;
         if (!storagesJson) return undefined;
         let storages: ActorStorages;
         try {
@@ -391,14 +394,14 @@ export class ApifyStorageBackend implements StorageBackend {
     }
 
     private resourceClient(id: string, type: StorageType) {
-        if (type === 'Dataset') return this.client.dataset(id);
-        if (type === 'KeyValueStore') return this.client.keyValueStore(id);
-        return this.client.requestQueue(id);
+        if (type === 'Dataset') return this.#client.dataset(id);
+        if (type === 'KeyValueStore') return this.#client.keyValueStore(id);
+        return this.#client.requestQueue(id);
     }
 
     private collectionClient(type: StorageType) {
-        if (type === 'Dataset') return this.client.datasets();
-        if (type === 'KeyValueStore') return this.client.keyValueStores();
-        return this.client.requestQueues();
+        if (type === 'Dataset') return this.#client.datasets();
+        if (type === 'KeyValueStore') return this.#client.keyValueStores();
+        return this.#client.requestQueues();
     }
 }

--- a/src/charging.ts
+++ b/src/charging.ts
@@ -83,38 +83,37 @@ export function mergeChargeResults(a: ChargeResult, b: ChargeResult): ChargeResu
  * Handles pay-per-event charging.
  */
 export class ChargingManager {
-    private readonly LOCAL_CHARGING_LOG_DATASET_NAME = 'charging_log';
-    private readonly PLATFORM_CHARGING_LOG_DATASET_ID_KEY = 'CHARGING_LOG_DATASET_ID';
+    readonly #LOCAL_CHARGING_LOG_DATASET_NAME = 'charging_log';
+    readonly #PLATFORM_CHARGING_LOG_DATASET_ID_KEY = 'CHARGING_LOG_DATASET_ID';
 
-    private maxTotalChargeUsd: number;
-    private isAtHome: boolean;
-    private actorRunId?: string;
-    private pricingModel?: ActorRunPricingInfo['pricingModel'];
-    private purgeChargingLogDataset: boolean;
-    private useChargingLogDataset: boolean;
-    private notPpeWarningPrinted = false;
+    #maxTotalChargeUsd: number;
+    #isAtHome: boolean;
+    #actorRunId?: string;
+    #pricingModel?: ActorRunPricingInfo['pricingModel'];
+    #purgeChargingLogDataset: boolean;
+    #useChargingLogDataset: boolean;
+    #notPpeWarningPrinted = false;
 
-    private pricingInfo: Record<string, { price: number; title: string }> = {};
-    private chargingState?: Record<string, ChargingStateItem>;
-    private chargingLogDataset?: Dataset;
+    #pricingInfo: Record<string, { price: number; title: string }> = {};
+    #chargingState?: Record<string, ChargingStateItem>;
+    #chargingLogDataset?: Dataset;
 
-    private apifyClient: ApifyClient;
+    #apifyClient: ApifyClient;
+    #configuration: Configuration;
 
-    constructor(
-        private configuration: Configuration,
-        apifyClient: ApifyClient,
-    ) {
-        this.maxTotalChargeUsd = configuration.maxTotalChargeUsd || Infinity; // convert `0` to `Infinity` in case the value is an empty string
-        this.isAtHome = configuration.isAtHome;
-        this.actorRunId = configuration.actorRunId;
-        this.purgeChargingLogDataset = configuration.purgeOnStart;
-        this.useChargingLogDataset = configuration.useChargingLogDataset;
+    constructor(configuration: Configuration, apifyClient: ApifyClient) {
+        this.#configuration = configuration;
+        this.#maxTotalChargeUsd = configuration.maxTotalChargeUsd || Infinity; // convert `0` to `Infinity` in case the value is an empty string
+        this.#isAtHome = configuration.isAtHome;
+        this.#actorRunId = configuration.actorRunId;
+        this.#purgeChargingLogDataset = configuration.purgeOnStart;
+        this.#useChargingLogDataset = configuration.useChargingLogDataset;
 
-        this.apifyClient = apifyClient;
+        this.#apifyClient = apifyClient;
     }
 
     private get isPayPerEvent() {
-        return this.pricingModel === 'PAY_PER_EVENT';
+        return this.#pricingModel === 'PAY_PER_EVENT';
     }
 
     private async fetchPricingInfo(): Promise<{
@@ -122,20 +121,20 @@ export class ChargingManager {
         chargedEventCounts?: Record<string, number>;
         maxTotalChargeUsd: number;
     }> {
-        if (this.configuration.actorPricingInfo && this.configuration.chargedEventCounts) {
+        if (this.#configuration.actorPricingInfo && this.#configuration.chargedEventCounts) {
             return {
-                pricingInfo: JSON.parse(this.configuration.actorPricingInfo) as ActorRunPricingInfo,
-                chargedEventCounts: JSON.parse(this.configuration.chargedEventCounts) as Record<string, number>,
-                maxTotalChargeUsd: this.configuration.maxTotalChargeUsd || Infinity,
+                pricingInfo: JSON.parse(this.#configuration.actorPricingInfo) as ActorRunPricingInfo,
+                chargedEventCounts: JSON.parse(this.#configuration.chargedEventCounts) as Record<string, number>,
+                maxTotalChargeUsd: this.#configuration.maxTotalChargeUsd || Infinity,
             };
         }
 
-        if (this.isAtHome) {
-            if (this.actorRunId === undefined) {
+        if (this.#isAtHome) {
+            if (this.#actorRunId === undefined) {
                 throw new Error('Actor run ID not found even though the Actor is running on Apify');
             }
 
-            const run = await this.apifyClient.run(this.actorRunId).get();
+            const run = await this.#apifyClient.run(this.#actorRunId).get();
             if (run === undefined) {
                 throw new Error('Actor run not found');
             }
@@ -150,7 +149,7 @@ export class ChargingManager {
         return {
             pricingInfo: undefined,
             chargedEventCounts: {},
-            maxTotalChargeUsd: this.configuration.maxTotalChargeUsd || Infinity,
+            maxTotalChargeUsd: this.#configuration.maxTotalChargeUsd || Infinity,
         };
     }
 
@@ -159,14 +158,14 @@ export class ChargingManager {
      */
     async init(): Promise<void> {
         // Validate config - it may have changed since the instantiation
-        if (this.useChargingLogDataset && this.isAtHome) {
+        if (this.#useChargingLogDataset && this.#isAtHome) {
             throw new Error(
                 'Using the ACTOR_USE_CHARGING_LOG_DATASET environment variable is only supported in a local development environment',
             );
         }
 
-        if (this.configuration.testPayPerEvent) {
-            if (this.isAtHome) {
+        if (this.#configuration.testPayPerEvent) {
+            if (this.#isAtHome) {
                 throw new Error(
                     'Using the ACTOR_TEST_PAY_PER_EVENT environment variable is only supported in a local development environment',
                 );
@@ -176,62 +175,62 @@ export class ChargingManager {
         // Retrieve pricing information
         const { pricingInfo, chargedEventCounts, maxTotalChargeUsd } = await this.fetchPricingInfo();
 
-        if (this.configuration.testPayPerEvent) {
-            this.pricingModel = 'PAY_PER_EVENT';
+        if (this.#configuration.testPayPerEvent) {
+            this.#pricingModel = 'PAY_PER_EVENT';
         } else {
-            this.pricingModel ??= pricingInfo?.pricingModel;
+            this.#pricingModel ??= pricingInfo?.pricingModel;
         }
 
         // Load per-event pricing information
         if (pricingInfo?.pricingModel === 'PAY_PER_EVENT') {
             for (const [eventName, eventPricing] of Object.entries(pricingInfo.pricingPerEvent.actorChargeEvents)) {
-                this.pricingInfo[eventName] = {
+                this.#pricingInfo[eventName] = {
                     price: eventPricing.eventPriceUsd,
                     title: eventPricing.eventTitle,
                 };
             }
 
-            this.maxTotalChargeUsd = maxTotalChargeUsd;
+            this.#maxTotalChargeUsd = maxTotalChargeUsd;
         }
 
-        this.chargingState = {};
+        this.#chargingState = {};
 
         for (const [eventName, chargeCount] of Object.entries(chargedEventCounts ?? {})) {
-            this.chargingState[eventName] = {
+            this.#chargingState[eventName] = {
                 chargeCount,
-                totalChargedAmount: chargeCount * (this.pricingInfo[eventName]?.price ?? 0),
+                totalChargedAmount: chargeCount * (this.#pricingInfo[eventName]?.price ?? 0),
             };
         }
 
-        if (!this.isPayPerEvent || !this.useChargingLogDataset) {
+        if (!this.isPayPerEvent || !this.#useChargingLogDataset) {
             return;
         }
 
         // Set up charging log dataset
-        if (this.isAtHome) {
+        if (this.#isAtHome) {
             const datasetId = await this.ensureChargingLogDatasetOnPlatform();
 
-            this.chargingLogDataset = await Dataset.open(datasetId);
+            this.#chargingLogDataset = await Dataset.open(datasetId);
         } else {
-            if (this.purgeChargingLogDataset) {
-                const dataset = await Dataset.open(this.LOCAL_CHARGING_LOG_DATASET_NAME);
+            if (this.#purgeChargingLogDataset) {
+                const dataset = await Dataset.open(this.#LOCAL_CHARGING_LOG_DATASET_NAME);
                 await dataset.drop();
             }
 
-            this.chargingLogDataset = await Dataset.open(this.LOCAL_CHARGING_LOG_DATASET_NAME);
+            this.#chargingLogDataset = await Dataset.open(this.#LOCAL_CHARGING_LOG_DATASET_NAME);
         }
     }
 
     private async ensureChargingLogDatasetOnPlatform(): Promise<string> {
         const defaultStore = await KeyValueStore.open();
 
-        const storedDatasetId = await defaultStore.getValue<string>(this.PLATFORM_CHARGING_LOG_DATASET_ID_KEY);
+        const storedDatasetId = await defaultStore.getValue<string>(this.#PLATFORM_CHARGING_LOG_DATASET_ID_KEY);
         if (storedDatasetId !== null) {
             return storedDatasetId;
         }
 
-        const dataset = await this.apifyClient.datasets().getOrCreate();
-        await defaultStore.setValue(this.PLATFORM_CHARGING_LOG_DATASET_ID_KEY, dataset.id);
+        const dataset = await this.#apifyClient.datasets().getOrCreate();
+        await defaultStore.setValue(this.#PLATFORM_CHARGING_LOG_DATASET_ID_KEY, dataset.id);
         return dataset.id;
     }
 
@@ -240,23 +239,23 @@ export class ChargingManager {
      * {@link ChargingManager.getPricingInfo}) require an initialized manager.
      */
     get isInitialized(): boolean {
-        return this.chargingState !== undefined;
+        return this.#chargingState !== undefined;
     }
 
     /**
      * Get information about the pricing for this Actor.
      */
     getPricingInfo(): ActorPricingInfo {
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
         return {
-            pricingModel: this.pricingModel,
+            pricingModel: this.#pricingModel,
             isPayPerEvent: this.isPayPerEvent,
-            maxTotalChargeUsd: this.maxTotalChargeUsd,
+            maxTotalChargeUsd: this.#maxTotalChargeUsd,
             perEventPrices: Object.fromEntries(
-                Object.entries(this.pricingInfo).map(([eventName, { price }]) => [eventName, price]),
+                Object.entries(this.#pricingInfo).map(([eventName, { price }]) => [eventName, price]),
             ),
         };
     }
@@ -280,15 +279,18 @@ export class ChargingManager {
     async charge({ eventName, count = 1 }: ChargeOptions): Promise<ChargeResult> {
         const calculateChargeableWithinLimit = () =>
             Object.fromEntries(
-                Object.keys(this.pricingInfo).map((name) => [name, this.calculateMaxEventChargeCountWithinLimit(name)]),
+                Object.keys(this.#pricingInfo).map((name) => [
+                    name,
+                    this.calculateMaxEventChargeCountWithinLimit(name),
+                ]),
             );
 
         if (!this.isPayPerEvent) {
-            if (!this.notPpeWarningPrinted) {
+            if (!this.#notPpeWarningPrinted) {
                 log.warning(
                     'Ignored attempt to charge for an event - the Actor does not use the pay-per-event pricing',
                 );
-                this.notPpeWarningPrinted = true;
+                this.#notPpeWarningPrinted = true;
             }
 
             return {
@@ -298,7 +300,7 @@ export class ChargingManager {
             };
         }
 
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
@@ -313,7 +315,7 @@ export class ChargingManager {
             // If the caller tries to charge more than the budget allows, overcharge by one event
             // so that the Actor is detected by the platform and terminated.
             // But don't do this if already strictly over the budget - no point piling on charges.
-            if (this.calculateTotalChargedAmount() <= this.maxTotalChargeUsd) {
+            if (this.calculateTotalChargedAmount() <= this.#maxTotalChargeUsd) {
                 return maxEventChargeCount + 1;
             }
 
@@ -328,26 +330,26 @@ export class ChargingManager {
             };
         }
 
-        const pricingInfo = this.pricingInfo[eventName] ?? {
-            price: this.isAtHome ? 0 : 1, // Use a nonzero price for local development so that the maximum budget can be reached
+        const pricingInfo = this.#pricingInfo[eventName] ?? {
+            price: this.#isAtHome ? 0 : 1, // Use a nonzero price for local development so that the maximum budget can be reached
             title: `Unknown event '${eventName}'`,
         };
 
-        this.chargingState[eventName] ??= {
+        this.#chargingState[eventName] ??= {
             chargeCount: 0,
             totalChargedAmount: 0,
         };
-        this.chargingState[eventName].chargeCount += chargedCount;
-        this.chargingState[eventName].totalChargedAmount += chargedCount * pricingInfo.price;
+        this.#chargingState[eventName].chargeCount += chargedCount;
+        this.#chargingState[eventName].totalChargedAmount += chargedCount * pricingInfo.price;
 
         /* END OF CRITICAL SECTION */
 
-        if (this.isAtHome) {
+        if (this.#isAtHome) {
             if (eventName.startsWith('apify-')) {
                 // Synthetic events (e.g. apify-default-dataset-item) are tracked locally only,
                 // the platform handles them automatically based on dataset writes.
-            } else if (this.pricingInfo[eventName] !== undefined) {
-                await this.apifyClient.run(this.actorRunId!).charge({ eventName, count: chargedCount });
+            } else if (this.#pricingInfo[eventName] !== undefined) {
+                await this.#apifyClient.run(this.#actorRunId!).charge({ eventName, count: chargedCount });
             } else {
                 log.warning(`Attempting to charge for an unknown event '${eventName}'`);
             }
@@ -355,8 +357,8 @@ export class ChargingManager {
 
         const timestamp = new Date().toISOString();
 
-        if (this.chargingLogDataset !== undefined) {
-            await this.chargingLogDataset.pushData({
+        if (this.#chargingLogDataset !== undefined) {
+            await this.#chargingLogDataset.pushData({
                 eventName,
                 eventTitle: pricingInfo.title,
                 eventPriceUsd: pricingInfo.price,
@@ -383,30 +385,30 @@ export class ChargingManager {
      * Get the number of events with given name that the Actor has charged for so far.
      */
     getChargedEventCount(eventName: string): number {
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
-        return this.chargingState[eventName]?.chargeCount ?? 0;
+        return this.#chargingState[eventName]?.chargeCount ?? 0;
     }
 
     /**
      * Get the maximum amount of money that the Actor is allowed to charge.
      */
     getMaxTotalChargeUsd(): number {
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
-        return this.maxTotalChargeUsd;
+        return this.#maxTotalChargeUsd;
     }
 
     private calculateTotalChargedAmount(): number {
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
-        const result = Object.values(this.chargingState)
+        const result = Object.values(this.#chargingState)
             .map(({ totalChargedAmount }) => totalChargedAmount)
             .reduce((sum, inc) => sum + inc, 0);
 
@@ -419,7 +421,7 @@ export class ChargingManager {
      * If the event is not registered, returns Infinity (free of charge)
      */
     calculateMaxEventChargeCountWithinLimit(eventName: string): number {
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
@@ -433,12 +435,12 @@ export class ChargingManager {
     }
 
     private calculateEventPrice(eventName: string): number | undefined {
-        return this.isAtHome ? this.pricingInfo[eventName]?.price : 1; // Use a nonzero price for local development so that the maximum budget can be reached
+        return this.#isAtHome ? this.#pricingInfo[eventName]?.price : 1; // Use a nonzero price for local development so that the maximum budget can be reached
     }
 
     private calculateMaxChargesByPrice(price: number): number {
         // The raw number of events allowed by the budget
-        const unroundedResult = (this.maxTotalChargeUsd - this.calculateTotalChargedAmount()) / price;
+        const unroundedResult = (this.#maxTotalChargeUsd - this.calculateTotalChargedAmount()) / price;
 
         // First round as Math.floor(4.9999999999999999) will incorrectly return 5
         const roundedResult = Math.floor(Number(unroundedResult.toFixed(4)));
@@ -459,7 +461,7 @@ export class ChargingManager {
         eventName: string | undefined;
         isDefaultDataset: boolean;
     }): { limitedItems: T[]; eventsToCharge: Record<string, number> } {
-        if (this.chargingState === undefined) {
+        if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
@@ -489,7 +491,7 @@ export class ChargingManager {
             if (
                 itemsArray.length > 0 &&
                 maxChargedCount === 0 &&
-                this.calculateTotalChargedAmount() <= this.maxTotalChargeUsd
+                this.calculateTotalChargedAmount() <= this.#maxTotalChargeUsd
             ) {
                 return 1;
             }

--- a/src/platform_event_manager.ts
+++ b/src/platform_event_manager.ts
@@ -46,7 +46,7 @@ import { Configuration } from './configuration.js';
  */
 export class PlatformEventManager extends EventManager {
     /** Websocket connection to Actor events. */
-    private eventsWs?: WebSocket;
+    #eventsWs?: WebSocket;
 
     constructor(readonly configuration = Configuration.getGlobalConfiguration()) {
         super({
@@ -78,8 +78,8 @@ export class PlatformEventManager extends EventManager {
     }
 
     private createWebSocketConnection(eventsWsUrl: string) {
-        this.eventsWs = new WebSocket(eventsWsUrl);
-        this.eventsWs.on('message', (message) => {
+        this.#eventsWs = new WebSocket(eventsWsUrl);
+        this.#eventsWs.on('message', (message) => {
             if (!message) return;
 
             try {
@@ -96,15 +96,15 @@ export class PlatformEventManager extends EventManager {
                 this.log.exception(err as Error, 'Cannot parse Actor event');
             }
         });
-        this.eventsWs.on('error', (err) => {
+        this.#eventsWs.on('error', (err) => {
             // Don't print this error as this happens in the case of very short Actor.main().
             if (err.message === 'WebSocket was closed before the connection was established') return;
 
             this.log.exception(err, 'web socket connection failed');
         });
-        this.eventsWs.on('close', () => {
+        this.#eventsWs.on('close', () => {
             this.log.debug('web socket has been closed');
-            this.eventsWs = undefined;
+            this.#eventsWs = undefined;
         });
     }
 
@@ -119,6 +119,6 @@ export class PlatformEventManager extends EventManager {
         }
 
         await super.close();
-        this.eventsWs?.close();
+        this.#eventsWs?.close();
     }
 }

--- a/src/proxy_configuration.ts
+++ b/src/proxy_configuration.ts
@@ -189,13 +189,13 @@ export interface ProxyInfo extends CoreProxyInfo {
  * @category Scaling
  */
 export class ProxyConfiguration extends CoreProxyConfiguration {
-    private groups: string[];
-    private countryCode?: string;
-    private subdivisionCode?: string;
-    private password?: string;
-    private hostname: string;
-    private port?: number;
-    private usesApifyProxy?: boolean;
+    #groups: string[];
+    #countryCode?: string;
+    #subdivisionCode?: string;
+    #password?: string;
+    #hostname: string;
+    #port?: number;
+    #usesApifyProxy?: boolean;
 
     protected readonly log = defaultLog.child({ prefix: 'ProxyConfiguration' });
 
@@ -251,17 +251,16 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
 
         // Validation
         if ((proxyUrls || newUrlFunction) && (groupsToUse.length || countryCodeToUse || subdivisionCodeToUse)) {
-            this._throwCannotCombineCustomWithApify();
+            this.throwCannotCombineCustomWithApify();
         }
-        if (proxyUrls && newUrlFunction) this._throwCannotCombineCustomMethods();
 
-        this.groups = groupsToUse;
-        this.countryCode = countryCodeToUse;
-        this.subdivisionCode = subdivisionCodeToUse;
-        this.password = password;
-        this.hostname = hostname!;
-        this.port = port;
-        this.usesApifyProxy = !proxyUrls && !newUrlFunction;
+        this.#groups = groupsToUse;
+        this.#countryCode = countryCodeToUse;
+        this.#subdivisionCode = subdivisionCodeToUse;
+        this.#password = password;
+        this.#hostname = hostname!;
+        this.#port = port;
+        this.#usesApifyProxy = !proxyUrls && !newUrlFunction;
 
         if (proxyUrls && proxyUrls.some((url) => url?.includes('apify.com'))) {
             this.log.warning(
@@ -280,12 +279,12 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * `ProxyConfiguration` instance instead of calling this manually.
      */
     async initialize(options?: { checkAccess?: boolean }): Promise<boolean> {
-        if (this.usesApifyProxy) {
-            if (!this.password) {
-                await this._setPasswordIfToken();
+        if (this.#usesApifyProxy) {
+            if (!this.#password) {
+                await this.setPasswordIfToken();
             }
 
-            if (!this.password) {
+            if (!this.#password) {
                 if (Actor.isAtHome()) {
                     throw new Error(
                         `Apify Proxy password must be provided using options.password or the "${APIFY_ENV_VARS.PROXY_PASSWORD}" environment variable. ` +
@@ -303,7 +302,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
             }
 
             if (options?.checkAccess !== false) {
-                return this._checkAccess();
+                return this.checkAccess();
             }
         }
 
@@ -327,10 +326,10 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
             hostname: parsed.hostname,
             port: parsed.port,
         };
-        if (this.usesApifyProxy) {
-            result.groups = this.groups;
-            if (this.countryCode !== undefined) result.countryCode = this.countryCode;
-            if (this.subdivisionCode !== undefined) result.subdivisionCode = this.subdivisionCode;
+        if (this.#usesApifyProxy) {
+            result.groups = this.#groups;
+            if (this.#countryCode !== undefined) result.countryCode = this.#countryCode;
+            if (this.#subdivisionCode !== undefined) result.subdivisionCode = this.#subdivisionCode;
         }
         return result;
     }
@@ -341,7 +340,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * `proxyUrls`, the URLs are rotated round-robin.
      */
     override async newUrl(options?: NewUrlOptions): Promise<string | undefined> {
-        if (!this.usesApifyProxy) {
+        if (!this.#usesApifyProxy) {
             return super.newUrl(options);
         }
         return this.composeDefaultUrl(cryptoRandomObjectId(SESSION_ID_LENGTH));
@@ -350,28 +349,27 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
     /**
      * Returns proxy username.
      */
-    protected _getUsername(sessionId: string): string {
-        const { groups, countryCode, subdivisionCode } = this;
+    protected getUsername(sessionId: string): string {
         const parts: string[] = [];
 
-        if (groups && groups.length) {
-            parts.push(`groups-${groups.join('+')}`);
+        if (this.#groups && this.#groups.length) {
+            parts.push(`groups-${this.#groups.join('+')}`);
         }
         parts.push(`session-${sessionId}`);
-        if (subdivisionCode) {
-            parts.push(`country-${countryCode}_${subdivisionCode}`);
-        } else if (countryCode) {
-            parts.push(`country-${countryCode}`);
+        if (this.#subdivisionCode) {
+            parts.push(`country-${this.#countryCode}_${this.#subdivisionCode}`);
+        } else if (this.#countryCode) {
+            parts.push(`country-${this.#countryCode}`);
         }
 
         return parts.join(',');
     }
 
     protected composeDefaultUrl(sessionId: string): string {
-        const username = this._getUsername(sessionId);
-        const url = new URL(`http://${this.hostname}:${this.port}`);
+        const username = this.getUsername(sessionId);
+        const url = new URL(`http://${this.#hostname}:${this.#port}`);
         url.username = `${username}`;
-        url.password = `${this.password}`;
+        url.password = `${this.#password}`;
         const urlString = url.toString();
 
         return urlString.substring(0, urlString.length - 1);
@@ -380,14 +378,13 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
     /**
      * Fetch & set the proxy password from Apify API if an Apify token is provided.
      */
-    // TODO: Make this private
-    protected async _setPasswordIfToken(): Promise<void> {
+    private async setPasswordIfToken(): Promise<void> {
         const { token } = this.configuration;
 
         if (!token) return;
         try {
             const user = await Actor.apifyClient.user().get();
-            this.password = user.proxy?.password;
+            this.#password = user.proxy?.password;
         } catch (error) {
             if (Actor.isAtHome()) {
                 throw error;
@@ -404,8 +401,8 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * If the check can not be made, it only prints a warning and allows the program to continue. This is to
      * prevent program crashes caused by short downtimes of Proxy.
      */
-    protected async _checkAccess(): Promise<boolean> {
-        const status = await this._fetchStatus();
+    protected async checkAccess(): Promise<boolean> {
+        const status = await this.fetchStatus();
 
         if (!status) {
             this.log.warning(
@@ -438,7 +435,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
     /**
      * Apify Proxy can be down for a second or a minute, but this should not crash processes.
      */
-    protected async _fetchStatus(): Promise<ProxyStatus | undefined> {
+    protected async fetchStatus(): Promise<ProxyStatus | undefined> {
         const { proxyStatusUrl } = this.configuration;
         const statusUrl = `${proxyStatusUrl}/?format=json`;
 
@@ -448,7 +445,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
 
         for (let attempt = 1; attempt <= CHECK_ACCESS_MAX_ATTEMPTS; attempt++) {
             try {
-                return await this._requestStatus(statusUrl, proxyUrl);
+                return await this.requestStatus(statusUrl, proxyUrl);
             } catch {
                 // retry connection errors
             }
@@ -465,7 +462,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * plus a `Proxy-Authorization` header — so no proxy-agent dependency is
      * needed. The status endpoint (`http://proxy.apify.com`) is plain HTTP.
      */
-    protected async _requestStatus(statusUrl: string, proxyUrl: string): Promise<ProxyStatus> {
+    protected async requestStatus(statusUrl: string, proxyUrl: string): Promise<ProxyStatus> {
         const target = new URL(statusUrl);
         const proxy = new URL(proxyUrl);
 
@@ -486,7 +483,7 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
         request.end();
 
         // `once` rejects if the request emits `error` first (connection refused,
-        // timeout/abort), so failures propagate to the retry loop in `_fetchStatus`.
+        // timeout/abort), so failures propagate to the retry loop in `fetchStatus`.
         const [response] = (await once(request, 'response')) as [IncomingMessage];
 
         const statusCode = response.statusCode ?? 0;
@@ -502,22 +499,12 @@ export class ProxyConfiguration extends CoreProxyConfiguration {
      * Throws cannot combine custom proxies with Apify Proxy
      * @internal
      */
-    protected _throwCannotCombineCustomWithApify() {
+    protected throwCannotCombineCustomWithApify() {
         throw new Error(
             'Cannot combine custom proxies with Apify Proxy! ' +
                 'It is not allowed to set "options.proxyUrls" or "options.newUrlFunction" combined with ' +
                 '"options.groups", "options.apifyProxyGroups", "options.countryCode", "options.apifyProxyCountry", ' +
                 '"options.subdivisionCode" or "options.apifyProxySubdivision".',
-        );
-    }
-
-    /**
-     * Throws cannot combine custom proxies with custom generating function
-     * @internal
-     */
-    protected _throwCannotCombineCustomMethods() {
-        throw new Error(
-            'Cannot combine custom proxies "options.proxyUrls" with custom generating function "options.newUrlFunction".',
         );
     }
 }

--- a/test/apify/charging.test.ts
+++ b/test/apify/charging.test.ts
@@ -783,8 +783,8 @@ describe('ChargingManager', () => {
 
 describe('Actor.newClient()', () => {
     afterEach(() => {
-        // @ts-expect-error reset the singleton between tests
-        Actor._instance = undefined; // eslint-disable-line no-underscore-dangle
+        // reset the singleton between tests
+        Actor.setDefaultInstance();
     });
 
     test('dataset() works without calling Actor.init()', () => {

--- a/test/apify/charging.test.ts
+++ b/test/apify/charging.test.ts
@@ -783,7 +783,6 @@ describe('ChargingManager', () => {
 
 describe('Actor.newClient()', () => {
     afterEach(() => {
-        // reset the singleton between tests
         Actor.setDefaultInstance();
     });
 

--- a/test/apify/proxy_configuration.test.ts
+++ b/test/apify/proxy_configuration.test.ts
@@ -24,7 +24,7 @@ const apifyProxyUrlPattern =
     /^http:\/\/groups-GROUP1\+GROUP2,session-[A-Za-z0-9]+,country-CZ:test12345@proxy\.apify\.com:8000$/;
 
 // The proxy status check is a `node:http` request through the proxy, encapsulated
-// in `_requestStatus(statusUrl, proxyUrl)`. Spy on it to stub the status response
+// in `requestStatus(statusUrl, proxyUrl)`. Spy on it to stub the status response
 // and to assert the (session/groups/country) proxy URL the request is routed
 // through — without touching the network.
 //
@@ -35,7 +35,7 @@ const apifyProxyUrlPattern =
 let requestStatusSpy: MockInstance;
 
 beforeEach(() => {
-    requestStatusSpy = vitest.spyOn(ProxyConfiguration.prototype as never, '_requestStatus');
+    requestStatusSpy = vitest.spyOn(ProxyConfiguration.prototype as never, 'requestStatus');
     requestStatusSpy.mockRejectedValue(new Error('Proxy status unavailable in tests'));
 });
 
@@ -48,20 +48,16 @@ afterEach(() => {
 });
 
 describe('ProxyConfiguration', () => {
-    test('should accept all options', () => {
+    test('should accept all options', async () => {
         const proxyConfiguration = new ProxyConfiguration(basicOpts);
 
         expect(proxyConfiguration).toBeInstanceOf(ProxyConfiguration);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.groups).toBe(groups);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.countryCode).toBe(countryCode);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.password).toBe(password);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.hostname).toBe(hostname);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.port).toBe(port);
+        const info = (await proxyConfiguration.newProxyInfo())!;
+        expect(info.groups).toBe(groups);
+        expect(info.countryCode).toBe(countryCode);
+        expect(info.password).toBe(password);
+        expect(info.hostname).toBe(hostname);
+        expect(info.port).toBe(String(port));
     });
 
     test('newUrl() returns an Apify Proxy URL with a random session id', async () => {
@@ -103,7 +99,7 @@ describe('ProxyConfiguration', () => {
         });
     });
 
-    test('actor UI input schema should work', () => {
+    test('actor UI input schema should work', async () => {
         const apifyProxyGroups = ['GROUP1', 'GROUP2'];
         const apifyProxyCountry = 'CZ';
 
@@ -114,10 +110,9 @@ describe('ProxyConfiguration', () => {
 
         const proxyConfiguration = new ProxyConfiguration(input);
 
-        // @ts-expect-error
-        expect(proxyConfiguration.groups).toStrictEqual(apifyProxyGroups);
-        // @ts-expect-error
-        expect(proxyConfiguration.countryCode).toStrictEqual(apifyProxyCountry);
+        const info = (await proxyConfiguration.newProxyInfo())!;
+        expect(info.groups).toStrictEqual(apifyProxyGroups);
+        expect(info.countryCode).toStrictEqual(apifyProxyCountry);
     });
 
     describe('subdivisionCode', () => {
@@ -134,7 +129,7 @@ describe('ProxyConfiguration', () => {
             expect(info.username).toMatch(/^groups-GROUP1\+GROUP2,session-[A-Za-z0-9]+,country-US_CA$/);
         });
 
-        test('can be supplied via the apifyProxySubdivision alias', () => {
+        test('can be supplied via the apifyProxySubdivision alias', async () => {
             const proxyConfiguration = new ProxyConfiguration({
                 groups,
                 apifyProxyCountry: 'US',
@@ -142,8 +137,7 @@ describe('ProxyConfiguration', () => {
                 password,
             });
 
-            // @ts-expect-error private
-            expect(proxyConfiguration.subdivisionCode).toBe('TX');
+            expect((await proxyConfiguration.newProxyInfo())!.subdivisionCode).toBe('TX');
         });
 
         test('requires countryCode to be set', () => {
@@ -418,16 +412,12 @@ describe('Actor.createProxyConfiguration()', () => {
         const proxyConfiguration = await Actor.createProxyConfiguration(basicOpts);
 
         expect(proxyConfiguration).toBeInstanceOf(ProxyConfiguration);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.groups).toBe(groups);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.countryCode).toBe(countryCode);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.password).toBe(password);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.hostname).toBe(hostname);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.port).toBe(port);
+        const info = (await proxyConfiguration!.newProxyInfo())!;
+        expect(info.groups).toBe(groups);
+        expect(info.countryCode).toBe(countryCode);
+        expect(info.password).toBe(password);
+        expect(info.hostname).toBe(hostname);
+        expect(info.port).toBe(String(port));
 
         // The status endpoint is fetched through a proxy whose URL carries the
         // groups/country/session built from the options.
@@ -459,14 +449,13 @@ describe('Actor.createProxyConfiguration()', () => {
         const proxyConfiguration = await Actor.createProxyConfiguration(opts);
 
         expect(proxyConfiguration).toBeInstanceOf(ProxyConfiguration);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.groups).toBe(groups);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.countryCode).toBe(countryCode);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.hostname).toBe(hostname);
-        // @ts-expect-error private property
-        expect(proxyConfiguration.port).toBe(port);
+        const info = (await proxyConfiguration!.newProxyInfo())!;
+        expect(info.groups).toBe(groups);
+        expect(info.countryCode).toBe(countryCode);
+        expect(info.hostname).toBe(hostname);
+        expect(info.port).toBe(String(port));
+        // The password was fetched from the API via the token.
+        expect(info.password).toBe(password);
 
         getUserSpy.mockRestore();
     });

--- a/test/createIsolatedActor.ts
+++ b/test/createIsolatedActor.ts
@@ -59,13 +59,11 @@ export function createIsolatedActor(
  */
 export async function initIsolatedDefaultActor(options: { config?: Configuration } = {}): Promise<IsolatedActor> {
     const isolated = createIsolatedActor(options);
-    // eslint-disable-next-line no-underscore-dangle
-    Actor._instance = isolated.actor;
+    Actor.setDefaultInstance(isolated.actor);
 
     onTestFinished(async () => {
         await isolated.actor.exit({ exit: false }).catch(() => {});
-        // eslint-disable-next-line no-underscore-dangle
-        delete (Actor as { _instance?: Actor })._instance;
+        Actor.setDefaultInstance();
     });
 
     await isolated.actor.init();

--- a/test/resetGlobalState.ts
+++ b/test/resetGlobalState.ts
@@ -10,7 +10,8 @@ import { Actor, Configuration } from 'apify';
  * cached instance is dropped. Three caches need clearing for that to work
  * end-to-end:
  *
- * - `Actor._instance` — lazy default `Actor` created by `Actor.getDefaultInstance()`.
+ * - The cached default `Actor` created by `Actor.getDefaultInstance()`, dropped via
+ *   `Actor.setDefaultInstance()`.
  * - `Configuration.globalConfig` — the SDK's own static singleton (its
  *   Apify-typed default fallback for `getGlobalConfiguration()`).
  * - `serviceLocator` — crawlee's cache for `Configuration` / `EventManager` /
@@ -20,9 +21,8 @@ import { Actor, Configuration } from 'apify';
  * per-instance. Kept in the test tree so it doesn't pollute the public SDK
  * surface.
  */
-/* eslint-disable no-underscore-dangle */
 export function resetGlobalState(): void {
-    delete (Actor as { _instance?: Actor })._instance;
+    Actor.setDefaultInstance();
     delete (Configuration as unknown as { globalConfig?: Configuration }).globalConfig;
     serviceLocator.reset();
 }


### PR DESCRIPTION
Applies the same convention that landed in crawlee v4 (apify/crawlee#3980, apify/crawlee#3108) to the SDK: native `#` private fields for private class properties, no `_` prefixes on members.

- 52 private properties across `Actor`, `ChargingManager`, `ProxyConfiguration`, the storage/request-queue backends, `PlatformEventManager` and `AsyncLock` are now native `#` fields (hard-private at runtime, invisible to enumeration and `JSON.stringify`). Private and protected methods keep their keyword and lose the `_` prefix; six private constructor parameter properties became explicit `#` fields.
- `ProxyConfiguration` protected helpers renamed: `_getUsername` → `getUsername`, `_checkAccess` → `checkAccess`, `_fetchStatus` → `fetchStatus`, `_requestStatus` → `requestStatus`, `_throwCannotCombineCustomWithApify` → `throwCannotCombineCustomWithApify`. `_setPasswordIfToken` is now `private` (honoring its TODO). `_throwCannotCombineCustomMethods` is deleted: the crawlee base-class constructor already performs the identical check with the same message, so the SDK copy was unreachable.
- `Actor._instance` (public `@internal` static) is now `static #instance`, with an `@internal` `Actor.setDefaultInstance()` seam replacing the test helpers' `delete`-based resets.
- Tests that poked `ProxyConfiguration`'s private fields via `@ts-expect-error` now assert through the public `newProxyInfo()` result; the token-fetched password path gained an assertion it previously lacked.
- A `no-underscore-dangle` oxlint rule (class fields + method names) enforces the convention; the upgrading guide documents the renames and the `#` semantics change.

The methods stay on the prototype deliberately: the test harness routes `Actor` methods through crawlee's `bindMethodsToServiceLocator`, which only wraps prototype members.
