### PR TITLE
refactor: Subscribe to crawlee status message events to restore Actor status message functionality

### DIFF
--- a/src/actor.ts
+++ b/src/actor.ts
@@ -2,6 +2,7 @@ import { createPrivateKey } from 'node:crypto';
 
 import type {
     EventManager,
+    EventStatusMessageData,
     EventTypeName,
     IStorage,
     RecordOptions,
@@ -463,6 +464,11 @@ export class Actor<Data extends Dictionary = Dictionary> {
         migrating?: () => void;
     } = {};
 
+    /**
+     * Reference to the crawlee status message forwarder, so it can be removed during cleanup.
+     */
+    #statusMessageForwarder?: (data: EventStatusMessageData) => Promise<ClientActorRun>;
+
     private chargingManager: ChargingManager;
 
     /**
@@ -656,6 +662,11 @@ export class Actor<Data extends Dictionary = Dictionary> {
             this.on(ACTOR_EVENT_NAMES.MIGRATING, this.gracefulShutdownHandlers.migrating);
         }
 
+        // Crawlee crawlers, for instance, broadcast their status messages as `statusMessage` events.
+        this.#statusMessageForwarder = async ({ message, isStatusMessageTerminal }: EventStatusMessageData) =>
+            this.#updateRunStatusMessage(message, isStatusMessageTerminal);
+        this.on(EventType.STATUS_MESSAGE, this.#statusMessageForwarder);
+
         await purgeDefaultStorages({
             configuration: this.configuration,
             onlyPurgeOnce: true,
@@ -721,6 +732,12 @@ export class Actor<Data extends Dictionary = Dictionary> {
         await addTimeoutToPromise(
             async () => {
                 await events.waitForAllListenersToComplete();
+
+                // The final status messages have been forwarded by now; stop listening so
+                // that a periodic one can't overwrite the terminal message set below.
+                if (this.#statusMessageForwarder) {
+                    this.off(EventType.STATUS_MESSAGE, this.#statusMessageForwarder);
+                }
 
                 if (client.teardown) {
                     let finished = false;
@@ -1062,6 +1079,13 @@ export class Actor<Data extends Dictionary = Dictionary> {
                 break;
         }
 
+        return this.#updateRunStatusMessage(statusMessage, isStatusMessageTerminal);
+    }
+
+    /**
+     * Propagates a status message to the current run, without logging it locally.
+     */
+    async #updateRunStatusMessage(statusMessage: string, isStatusMessageTerminal?: boolean): Promise<ClientActorRun> {
         const runId = this.configuration.actorRunId!;
 
         if (runId) {

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -4,8 +4,9 @@ import { EventType, MemoryStorageBackend, serviceLocator } from '@crawlee/core';
 import { sleep } from '@crawlee/utils';
 import type { ApifyEnv } from 'apify';
 import { Actor, Configuration, Dataset, KeyValueStore, ProxyConfiguration, RequestQueue } from 'apify';
-import type { WebhookUpdateData } from 'apify-client';
+import type { ActorRun, WebhookUpdateData } from 'apify-client';
 import { ActorClient, ApifyClient, RunClient, TaskClient } from 'apify-client';
+import { BasicCrawler } from 'crawlee';
 
 import {
     ACT_JOB_STATUSES,
@@ -1332,6 +1333,66 @@ describe('Actor', () => {
             ).rejects.toThrow('Environment variable ACTOR_RUN_ID is not set!');
 
             delete process.env[APIFY_ENV_VARS.IS_AT_HOME];
+        });
+    });
+
+    describe('Actor.setStatusMessage()', () => {
+        const runId = 'status-message-run-id';
+        // A `RunClient.update()` stub — the tests only assert on the payload it receives,
+        // so the resolved run is never inspected.
+        const stubRun = {} as unknown as ActorRun;
+
+        beforeEach(() => {
+            process.env[ACTOR_ENV_VARS.RUN_ID] = runId;
+        });
+
+        afterEach(() => {
+            delete process.env[ACTOR_ENV_VARS.RUN_ID];
+        });
+
+        test('updates the run', async () => {
+            const { actor } = createIsolatedActor();
+            const updateSpy = vitest.spyOn(RunClient.prototype, 'update').mockResolvedValue(stubRun);
+
+            await actor.init();
+            await actor.setStatusMessage('almost there', { isStatusMessageTerminal: true });
+
+            expect(updateSpy).toHaveBeenCalledWith({ statusMessage: 'almost there', isStatusMessageTerminal: true });
+        });
+
+        test('forwards crawlee status messages to the run', async () => {
+            const { actor, events } = createIsolatedActor();
+            const updateSpy = vitest.spyOn(RunClient.prototype, 'update').mockResolvedValue(stubRun);
+            const infoSpy = vitest.spyOn(log, 'info');
+
+            await actor.init();
+
+            const crawler = new BasicCrawler({ eventManager: events, requestHandler: async () => {} });
+            crawler.setStatusMessage('Finished! Total 10 requests', { isStatusMessageTerminal: true, level: 'INFO' });
+            await events.waitForAllListenersToComplete();
+
+            expect(updateSpy).toHaveBeenCalledWith({
+                statusMessage: 'Finished! Total 10 requests',
+                isStatusMessageTerminal: true,
+            });
+            // The crawler logs the message itself, so the SDK must not log it a second time.
+            expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('Finished! Total 10 requests'));
+        });
+
+        test('stops forwarding crawlee status messages once the actor exits', async () => {
+            const { actor, events } = createIsolatedActor();
+            const updateSpy = vitest.spyOn(RunClient.prototype, 'update').mockResolvedValue(stubRun);
+            const crawler = new BasicCrawler({ eventManager: events, requestHandler: async () => {} });
+
+            await actor.init();
+            await actor.exit({ exit: false, statusMessage: 'All done' });
+            updateSpy.mockClear();
+
+            // A straggling periodic message must not overwrite the terminal one.
+            crawler.setStatusMessage('Crawled 3/10 pages');
+            await events.waitForAllListenersToComplete();
+
+            expect(updateSpy).not.toHaveBeenCalledWith();
         });
     });
 


### PR DESCRIPTION
- closes #696

- crawlee doesn't call `StorageClient.setStatusMessage()` anymore (https://github.com/apify/crawlee/pull/3818), it broadcasts a `statusMessage` event instead, and nothing in the SDK listened - so crawler progress stopped reaching the run
- `Actor.init()` now forwards those events, without re-logging the message (the crawler already logged it, at its own level)
- `Actor.exit()` drops the listener after the drain, so a straggling periodic message can't overwrite the terminal status message
- the `crawlerId` property of the event is not utilized in any way at this point
