### PR TITLE
chore: point apify-client at the OpenAPI-generated models branch [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "@crawlee/core": "^4.0.0-rc.0",
         "@crawlee/types": "^4.0.0-rc.0",
         "@crawlee/utils": "^4.0.0-rc.0",
-        "apify-client": "^2.25.0",
+        "apify-client": "github:apify/apify-client-js#feat/openapi-generated-models",
         "minimatch": "^10.2.6",
         "semver": "^7.8.5",
         "tslib": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^4.0.0-rc.0
         version: 4.0.0-rc.0
       apify-client:
-        specifier: ^2.25.0
-        version: 2.25.0
+        specifier: github:apify/apify-client-js#feat/openapi-generated-models
+        version: https://codeload.github.com/apify/apify-client-js/tar.gz/ed639b78a4a2c1a84555d59f146cdf770f3f23aa
       minimatch:
         specifier: ^10.2.6
         version: 10.2.6
@@ -4310,8 +4310,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  apify-client@2.25.0:
-    resolution: {integrity: sha512-g6ttHJ4Au/Gg0iDHIevN3CvTbJfey9DUXUXJxe0ORF6JIYaVVfKdyJjINGb6/49gOpt/62ZFPw+HSEVIzrwR5w==}
+  apify-client@https://codeload.github.com/apify/apify-client-js/tar.gz/ed639b78a4a2c1a84555d59f146cdf770f3f23aa:
+    resolution: {gitHosted: true, integrity: sha512-FyleR48JpTfv87n85zpPbUgub13YRtygNttFGZFjt1nr2Gy59eOTOZdobkPIO6DeE3vZ7sS4Sm+o2S6GPlJjfA==, tarball: https://codeload.github.com/apify/apify-client-js/tar.gz/ed639b78a4a2c1a84555d59f146cdf770f3f23aa}
+    version: 2.25.1
+    engines: {node: '>=22.0.0'}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -14370,7 +14372,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  apify-client@2.25.0:
+  apify-client@https://codeload.github.com/apify/apify-client-js/tar.gz/ed639b78a4a2c1a84555d59f146cdf770f3f23aa:
     dependencies:
       '@apify/consts': 2.57.2
       '@apify/log': 2.5.50
@@ -14380,10 +14382,10 @@ snapshots:
       async-retry: 1.3.3
       axios: 1.19.0
       content-type: 1.0.5
-      ow: 0.28.2
       proxy-agent: 6.5.0
       tslib: 2.8.1
       type-fest: 4.41.0
+      zod: 4.4.3
     transitivePeerDependencies:
       - debug
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ minimumReleaseAgeExclude:
 onlyBuiltDependencies:
   - '@playwright/browser-chromium'
   - '@swc/core'
+  - apify-client
   - esbuild
   - playwright
   - puppeteer

--- a/src/apify_dataset_backend.ts
+++ b/src/apify_dataset_backend.ts
@@ -25,7 +25,8 @@ export class ApifyDatasetBackend implements DatasetBackend {
         if (!metadata) {
             throw new Error('Dataset not found or has been deleted.');
         }
-        return metadata;
+        // The API reports an unnamed store as `null`; crawlee spells that absence as `undefined`.
+        return { ...metadata, name: metadata.name ?? undefined };
     }
 
     async drop(): Promise<void> {

--- a/src/apify_key_value_store_backend.ts
+++ b/src/apify_key_value_store_backend.ts
@@ -25,7 +25,8 @@ export class ApifyKeyValueStoreBackend implements KeyValueStoreBackend {
         if (!metadata) {
             throw new Error('Key-value store not found or has been deleted.');
         }
-        return metadata;
+        // The API reports an unnamed store as `null`; crawlee spells that absence as `undefined`.
+        return { ...metadata, name: metadata.name ?? undefined };
     }
 
     async drop(): Promise<void> {
@@ -59,6 +60,8 @@ export class ApifyKeyValueStoreBackend implements KeyValueStoreBackend {
         // requires the field, so it is left undefined via the cast.
         return {
             ...result,
+            exclusiveStartKey: result.exclusiveStartKey ?? undefined,
+            nextExclusiveStartKey: result.nextExclusiveStartKey ?? undefined,
             items: result.items.map(({ key, size }) => ({ key, size }) as KeyValueStoreItemData),
         };
     }

--- a/src/apify_request_queue_backend.ts
+++ b/src/apify_request_queue_backend.ts
@@ -89,7 +89,7 @@ export abstract class ApifyRequestQueueBackend implements RequestQueueBackend {
         }
         return {
             id: metadata.id,
-            name: metadata.name,
+            name: metadata.name ?? undefined,
             createdAt: metadata.createdAt,
             modifiedAt: metadata.modifiedAt,
             accessedAt: metadata.accessedAt,

--- a/src/charging.ts
+++ b/src/charging.ts
@@ -184,9 +184,12 @@ export class ChargingManager {
 
         // Load per-event pricing information
         if (pricingInfo?.pricingModel === 'PAY_PER_EVENT') {
-            for (const [eventName, eventPricing] of Object.entries(pricingInfo.pricingPerEvent.actorChargeEvents)) {
+            // The specification marks the event map and its per-event price optional, so an absent
+            // price counts as no charge for that event.
+            const chargeEvents = pricingInfo.pricingPerEvent.actorChargeEvents ?? {};
+            for (const [eventName, eventPricing] of Object.entries(chargeEvents)) {
                 this.pricingInfo[eventName] = {
-                    price: eventPricing.eventPriceUsd,
+                    price: eventPricing.eventPriceUsd ?? 0,
                     title: eventPricing.eventTitle,
                 };
             }


### PR DESCRIPTION
Experiment, not for merge. Points `apify-client` at the branch of apify/apify-client-js#985 (all output models generated from the OpenAPI spec) to see what the change does to the v4 SDK.

## How the dependency is referenced

`"apify-client": "github:apify/apify-client-js#feat/openapi-generated-models"`, the npm equivalent of `pip install git+...`. Two things make it work:

- apify-client-js gained a `prepare` script, so a git checkout builds its own `dist/`. Without it the install lands with no `dist/` while `main`/`types` point into it.
- `apify-client` is added to `onlyBuiltDependencies`, since pnpm refuses build scripts for git-hosted packages otherwise.

## What broke, and why

Six type errors, from two changes in the generated models:

| Change | Sites |
|---|---|
| Storage `name` and the key-value store's `exclusiveStartKey`/`nextExclusiveStartKey` gain `null` | 4 |
| `pricingPerEvent.actorChargeEvents` and `ActorChargeEvent.eventPriceUsd` become optional | 2 |

The first group is normalised where the client meets Crawlee, in the backend adapters: the API spells absence as `null`, Crawlee spells it `undefined`. The second is handled in `ChargingManager`; an absent per-event price counts as no charge, which is worth a second opinion.

Notably `handledAt` and `retryCount` do **not** break here. On the v3/master line they do, because the SDK relies on `ApifyClient` structurally satisfying Crawlee's `StorageClient`; v4's explicit backend adapters map those fields instead.

## Status

`tsc` (src and tests), build, unit tests, oxlint and oxfmt all pass. Platform e2e is dispatch-only, so it has to be triggered by hand on this branch.

*✍️ Drafted by Claude Code*
