### PR TITLE
refactor: Simplify per-dataset-item PPE

### DIFF
--- a/docs/02_concepts/08_pay_per_event.mdx
+++ b/docs/02_concepts/08_pay_per_event.mdx
@@ -60,13 +60,15 @@ The user spending limit for the run is available in your Actor code as the `ACTO
 
 When the charge limit is reached, <ApiLink to="class/Actor#charge">`Actor.charge`</ApiLink> stops charging and <ApiLink to="class/Actor#pushData">`Actor.pushData`</ApiLink> stops pushing data. The platform then aborts the run automatically. However, the run keeps consuming platform resources for a short time before it stops. For details, see [Handle graceful shutdown](https://docs.apify.com/platform/actors/publishing/monetize/pay-per-event#handle-graceful-shutdown).
 
-### Charging inside a request handler
+### Charge inside a request handler
 
-By default, crawlee runs each request handler in a storage transaction: dataset writes are buffered and applied when the handler finishes. Charging for dataset items follows the items, so a push inside a handler is billed at commit, and a handler that throws is retried without being billed for the items it discarded.
+By default, crawlee runs each request handler in a storage transaction: dataset writes are buffered and applied when the handler finishes. Charging for dataset items follows the items. If you push items in a handler, crawlee makes the charge at the commit. If the handler throws an error, crawlee retries the request. Crawlee doesn't charge for the items that it discarded.
 
-<ApiLink to="class/Actor#charge">`Actor.charge`</ApiLink> is not part of the transaction and takes effect immediately. It therefore consumes budget that dataset items buffered by the handler would otherwise be charged for - those items are dropped at commit if the budget no longer covers them.
+<ApiLink to="class/Actor#charge">`Actor.charge`</ApiLink> isn't part of the transaction and takes effect immediately. It therefore consumes budget that dataset items buffered by the handler would otherwise be charged for. If the budget isn't large enough to cover these items, crawlee discards them at the commit.
 
-For the same reason, <ApiLink to="class/Actor#pushData">`Actor.pushData`</ApiLink> with an event name throws inside a transaction: the charge cannot wait for the commit. Either wrap the call in crawlee's `withDirectStorageAccess()` to store and charge right away, accepting that a retried request pushes the items again, or push without an event name and charge separately.
+For the same reason, <ApiLink to="class/Actor#pushData">`Actor.pushData`</ApiLink> with an event name throws inside a transaction: the charge cannot wait for the commit. You have two options:
+- Wrap the call in crawlee's `withDirectStorageAccess()` function. It stores the items and charges immediately. However,  if crawlee retries the request, it pushes the items again.
+- Push the items without an event name. Then, make the charge separately.
 
 ## Test monetization locally
 

--- a/docs/02_concepts/08_pay_per_event.mdx
+++ b/docs/02_concepts/08_pay_per_event.mdx
@@ -9,6 +9,7 @@ import ConditionalActorChargeSource from '!!raw-loader!./code/conditional_actor_
 import ChargeLimitCheckSource from '!!raw-loader!./code/charge_limit_check.ts';
 import PerUnitChargingSource from '!!raw-loader!./code/per_unit_charging.ts';
 import ChargingManagerSource from '!!raw-loader!./code/charging_manager.ts';
+import ChargeInRequestHandlerSource from '!!raw-loader!./code/charge_in_request_handler.ts';
 import ApiLink from '@site/src/components/ApiLink';
 import CodeBlock from '@theme/CodeBlock';
 
@@ -68,7 +69,9 @@ By default, crawlee runs each request handler in a storage transaction: dataset 
 
 For the same reason, <ApiLink to="class/Actor#pushData">`Actor.pushData`</ApiLink> with an event name throws inside a transaction: the charge cannot wait for the commit. You have two options:
 - Wrap the call in crawlee's `withDirectStorageAccess()` function. It stores the items and charges immediately. However,  if crawlee retries the request, it pushes the items again.
-- Push the items without an event name. Then, make the charge separately.
+- Push the items without an event name and charge separately. <ApiLink to="class/Actor#charge">`Actor.charge`</ApiLink> takes effect immediately and isn't rolled back, so pass an `idempotencyKey` that a retry reproduces. The platform then bills the event once.
+
+<CodeBlock language="typescript">{ChargeInRequestHandlerSource}</CodeBlock>
 
 ## Test monetization locally
 

--- a/docs/02_concepts/08_pay_per_event.mdx
+++ b/docs/02_concepts/08_pay_per_event.mdx
@@ -60,6 +60,14 @@ The user spending limit for the run is available in your Actor code as the `ACTO
 
 When the charge limit is reached, <ApiLink to="class/Actor#charge">`Actor.charge`</ApiLink> stops charging and <ApiLink to="class/Actor#pushData">`Actor.pushData`</ApiLink> stops pushing data. The platform then aborts the run automatically. However, the run keeps consuming platform resources for a short time before it stops. For details, see [Handle graceful shutdown](https://docs.apify.com/platform/actors/publishing/monetize/pay-per-event#handle-graceful-shutdown).
 
+### Charging inside a request handler
+
+By default, crawlee runs each request handler in a storage transaction: dataset writes are buffered and applied when the handler finishes. Charging for dataset items follows the items, so a push inside a handler is billed at commit, and a handler that throws is retried without being billed for the items it discarded.
+
+<ApiLink to="class/Actor#charge">`Actor.charge`</ApiLink> is not part of the transaction and takes effect immediately. It therefore consumes budget that dataset items buffered by the handler would otherwise be charged for - those items are dropped at commit if the budget no longer covers them.
+
+For the same reason, <ApiLink to="class/Actor#pushData">`Actor.pushData`</ApiLink> with an event name throws inside a transaction: the charge cannot wait for the commit. Either wrap the call in crawlee's `withDirectStorageAccess()` to store and charge right away, accepting that a retried request pushes the items again, or push without an event name and charge separately.
+
 ## Test monetization locally
 
 Before releasing your monetization code to the public, test it locally. To make your Actor work in pay-per-event mode, pass it the `ACTOR_TEST_PAY_PER_EVENT` environment variable:

--- a/docs/02_concepts/code/charge_in_request_handler.ts
+++ b/docs/02_concepts/code/charge_in_request_handler.ts
@@ -1,0 +1,23 @@
+import { Actor } from 'apify';
+import { CheerioCrawler } from 'crawlee';
+
+await Actor.init();
+
+const crawler = new CheerioCrawler({
+    async requestHandler({ request, pushData }) {
+        // highlight-start
+        // Buffered until the handler finishes, so a retried request stores the item once
+        await pushData({ url: request.url });
+
+        // Charged immediately - the key keeps a retry of this request from charging again
+        await Actor.charge({
+            eventName: 'result-item',
+            idempotencyKey: `result-item-${request.uniqueKey}`,
+        });
+        // highlight-end
+    },
+});
+
+await crawler.run(['https://crawlee.dev']);
+
+await Actor.exit();

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -7,7 +7,15 @@ import type {
     RecordOptions,
     UseStateOptions,
 } from '@crawlee/core';
-import { Dataset, EventType, KeyValueStore, purgeDefaultStorages, RequestQueue, serviceLocator } from '@crawlee/core';
+import {
+    Dataset,
+    EventType,
+    KeyValueStore,
+    purgeDefaultStorages,
+    RequestQueue,
+    ServiceLocator,
+    serviceLocator,
+} from '@crawlee/core';
 import type { Awaitable, Dictionary, StorageBackend } from '@crawlee/types';
 import { sleep } from '@crawlee/utils';
 import type {
@@ -35,14 +43,10 @@ import { addTimeoutToPromise } from '@apify/timeout';
 import { parseArgument } from '@apify/validations';
 
 import type { RequestQueueAccessMode } from './apify_request_queue_backend.js';
-import {
-    ApifyStorageBackend,
-    type PpeAwarePushDataContext,
-    pushDataChargingContext,
-    USES_PUSH_DATA_INTERCEPTION,
-} from './apify_storage_backend.js';
+import { ApifyStorageBackend } from './apify_storage_backend.js';
 import type { ChargeOptions, ChargeResult } from './charging.js';
-import { ChargingManager, pushDataAndCharge } from './charging.js';
+import { ChargingManager, DEFAULT_DATASET_ITEM_EVENT } from './charging.js';
+import { ChargingDatasetBackend, ChargingStorageBackend } from './charging_storage_backend.js';
 import type { ConfigurationOptions } from './configuration.js';
 import { Configuration } from './configuration.js';
 import { getDefaultsFromInputSchema, noActorInputSchemaDefinedMarker, readInputSchema } from './input-schemas.js';
@@ -59,6 +63,14 @@ import {
 } from './utils.js';
 
 export interface InitOptions {
+    /**
+     * Storage backend to use, in place of the Apify platform storage (on the platform) or crawlee's
+     * local storage (outside of it).
+     *
+     * Items pushed to the default dataset are then not charged for under the pay-per-event pricing
+     * model: the platform counts an `apify-default-dataset-item` per item it stores itself, and a
+     * backend of your own stores them elsewhere.
+     */
     storage?: StorageBackend;
     /**
      * Determines how request queues opened on the Apify platform are consumed.
@@ -615,10 +627,13 @@ export class Actor<Data extends Dictionary = Dictionary> {
         this.#requestQueueAccess = options.requestQueueAccess ?? 'single';
 
         if (this.isAtHome()) {
-            serviceLocator.setStorageBackend(this.createApifyStorageBackend());
             serviceLocator.setEventManager(this.eventManager);
+        }
+
+        if (!serviceLocator.getServicesIfSet().storageBackend) {
+            this.installStorageBackend(this.createStorageBackend(options.storage));
         } else if (options.storage) {
-            serviceLocator.setStorageBackend(options.storage);
+            this.installStorageBackend(options.storage);
         }
 
         // Init the event manager the config uses
@@ -664,6 +679,18 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
         await this.#chargingManager.init();
         log.debug(`ChargingManager initialized`, this.#chargingManager.getPricingInfo());
+
+        // Only knowable once the pricing is loaded. Reachable with a caller-supplied backend or one
+        // registered with crawlee directly; the storages the Actor installs itself are wrapped.
+        if (
+            this.#chargingManager.isPayPerEvent &&
+            !(serviceLocator.getStorageBackend() instanceof ChargingStorageBackend)
+        ) {
+            log.warning(
+                'Items pushed to the default dataset will not be charged for, because this run does not use Apify ' +
+                    'storage - the platform only counts items it stores itself.',
+            );
+        }
     }
 
     /**
@@ -1126,18 +1153,52 @@ export class Actor<Data extends Dictionary = Dictionary> {
         }
 
         const dataset = await this.openDataset();
+        const items = Array.isArray(item) ? item : [item];
 
-        // Two code paths for charging:
-        // 1. Intercepted client: PpeAwareDatasetClient intercepts pushItems() calls, handling charging
-        //    internally. This is needed because Crawlee's Dataset may call pushItems() directly,
-        //    bypassing Actor.pushData(). We propagate eventName via AsyncLocalStorage context.
-        // 2. Direct charging: When using a non-patched client (e.g., forceCloud option or custom client),
-        //    we handle charging here before delegating to the dataset.
-        if (this.usesPushDataInterception(dataset)) {
-            return await this.pushDataViaInterceptedClient(dataset, item, eventName);
+        // `Actor.pushData()` historically worked even without calling `Actor.init()`.
+        // In that case, charging isn't configured, so just push the data through.
+        if (!this.#chargingManager.isInitialized) {
+            await dataset.pushData(items);
+            return { eventChargeLimitReached: false, chargedCount: 0, chargeableWithinLimit: {} };
         }
 
-        return await this.pushDataWithExplicitCharging(dataset, item, eventName);
+        // The reservation below and the charge that acts on it have to stay under one lock, so that
+        // a concurrent push cannot charge in between. The dataset backend re-enters the same lock to
+        // charge the synthetic per-item event.
+        return await this.#chargingManager.withChargeLock(async () => {
+            if (eventName === undefined) {
+                // Nothing to charge here - the dataset backend charges the synthetic event for
+                // whatever it stores, so the result is read back off the charging state.
+                const chargedBefore = this.#chargingManager.getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT);
+                await dataset.pushData(items);
+
+                return {
+                    eventChargeLimitReached:
+                        this.#chargingManager.isEventChargeLimitReached(DEFAULT_DATASET_ITEM_EVENT),
+                    chargedCount:
+                        this.#chargingManager.getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT) - chargedBefore,
+                    chargeableWithinLimit: this.#chargingManager.calculateChargeableWithinLimit(),
+                };
+            }
+
+            const limit = this.#chargingManager.calculatePushDataLimit(items.length, {
+                eventName,
+                // Pushing one item charges the synthetic per-item event too when the dataset backend
+                // is the charging one, so that price is part of what an item costs here.
+                isDefaultDataset: dataset.backend instanceof ChargingDatasetBackend,
+            });
+
+            if (limit === 0) {
+                return {
+                    eventChargeLimitReached: items.length > 0,
+                    chargedCount: 0,
+                    chargeableWithinLimit: this.#chargingManager.calculateChargeableWithinLimit(),
+                };
+            }
+
+            await dataset.pushData(limit < items.length ? items.slice(0, limit) : items);
+            return await this.#chargingManager.charge({ eventName, count: limit });
+        });
     }
 
     /**
@@ -2250,67 +2311,62 @@ export class Actor<Data extends Dictionary = Dictionary> {
         Actor.#instance = instance;
     }
 
-    private usesPushDataInterception(dataset: Dataset): boolean {
-        return Boolean((dataset.backend as any)[USES_PUSH_DATA_INTERCEPTION]);
-    }
-
-    private async pushDataViaInterceptedClient(
-        dataset: Dataset,
-        item: Data | Data[],
-        eventName: string | undefined,
-    ): Promise<ChargeResult> {
-        // PpeAwareDatasetClient will handle charging and item limiting.
-        // We only need to propagate `eventName` and (optionally) return aggregated charge info.
-        const context: PpeAwarePushDataContext = {
-            eventName,
-        };
-
-        await pushDataChargingContext.run(context, async () => {
-            await dataset.pushData(item);
-        });
-
-        return (
-            context.chargeResult ?? {
-                eventChargeLimitReached: false,
-                chargedCount: 0,
-                chargeableWithinLimit: {},
-            }
-        );
-    }
-
-    private async pushDataWithExplicitCharging(
-        dataset: Dataset,
-        items: Data | Data[],
-        explicitEventName: string | undefined,
-    ): Promise<ChargeResult> {
-        // `Actor.pushData()` historically worked even without calling `Actor.init()`.
-        // In that case, charging isn't configured, so just push the data through.
-        if (!this.initialized && explicitEventName === undefined) {
-            await dataset.pushData(items);
-            return {
-                eventChargeLimitReached: false,
-                chargedCount: 0,
-                chargeableWithinLimit: {},
-            };
+    /**
+     * The backend the Actor installs: the caller's, the platform's, or crawlee's local default.
+     *
+     * Only the last two are wrapped for dataset-item charging. The platform counts an
+     * `apify-default-dataset-item` per item written to the run's default dataset through Apify
+     * storage, so a caller-supplied backend is billed nothing and must not be accounted for -
+     * charging for it would spend a budget nobody is consuming and trim the caller's items to fit
+     * it. crawlee's local default stands in for Apify storage, so it is wrapped to keep local
+     * pay-per-event testing faithful.
+     *
+     * Wrapping means owning the instance, which is why the local default is constructed here
+     * rather than left to be created lazily on first use.
+     */
+    private createStorageBackend(storage?: StorageBackend): StorageBackend {
+        if (storage) {
+            return storage;
         }
 
-        const isDefaultDataset = dataset.id === this.configuration.defaultDatasetId;
+        if (this.isAtHome()) {
+            return this.createApifyStorageBackend();
+        }
 
-        return pushDataAndCharge({
-            chargingManager: this.#chargingManager,
-            items,
-            eventName: explicitEventName,
-            isDefaultDataset,
-            pushFn: async (limitedItems) => dataset.pushData(limitedItems),
+        return new ChargingStorageBackend(new ServiceLocator(this.configuration).getStorageBackend(), {
+            configuration: this.configuration,
+            getChargingManager: () => this.#chargingManager,
         });
     }
 
-    private createApifyStorageBackend(): ApifyStorageBackend {
-        return new ApifyStorageBackend(this.apifyClient, {
+    /** Wrapped here rather than at the `init()` call site so that `forceCloud` storages are charged too. */
+    private createApifyStorageBackend(): StorageBackend {
+        const backend = new ApifyStorageBackend(this.apifyClient, {
             configuration: this.configuration,
             requestQueueAccess: this.#requestQueueAccess,
+        });
+
+        return new ChargingStorageBackend(backend, {
+            configuration: this.configuration,
             getChargingManager: () => this.#chargingManager,
         });
+    }
+
+    /**
+     * crawlee's service locator is set-once, so a backend registered before `init()` wins and the
+     * Actor cannot install its own over it. Replaces the resulting `ServiceConflictError` with the
+     * way out.
+     */
+    private installStorageBackend(backend: StorageBackend): void {
+        try {
+            serviceLocator.setStorageBackend(backend);
+        } catch (error) {
+            throw new Error(
+                'A storage backend is already registered with crawlee, so the Actor cannot install its own. Pass it ' +
+                    'as `Actor.init({ storage })` instead of calling `serviceLocator.setStorageBackend()`.',
+                { cause: error },
+            );
+        }
     }
 
     private ensureActorInit(methodCalled: string) {

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -12,6 +12,7 @@ import {
     EventType,
     KeyValueStore,
     purgeDefaultStorages,
+    rejectOperationInTransaction,
     RequestQueue,
     ServiceLocator,
     serviceLocator,
@@ -1140,6 +1141,9 @@ export class Actor<Data extends Dictionary = Dictionary> {
      * **IMPORTANT**: Make sure to use the `await` keyword when calling `pushData()`,
      * otherwise the Actor process might finish before the data are stored!
      *
+     * Inside a crawlee storage transaction, the items are stored - and charged for - at commit time,
+     * so the returned counts are zero and charging for an explicit `eventName` is rejected outright.
+     *
      * @param item Object or array of objects containing data to be stored in the default dataset.
      * The objects must be serializable to JSON and the JSON representation of each object must be smaller than 9MB.
      * @param eventName If provided, the method will attempt to charge for the event for each pushed item.
@@ -1150,6 +1154,14 @@ export class Actor<Data extends Dictionary = Dictionary> {
 
         if (eventName?.startsWith('apify-')) {
             throw new Error(`Cannot charge for synthetic event '${eventName}' manually`);
+        }
+
+        if (eventName !== undefined) {
+            rejectOperationInTransaction(
+                `Actor.pushData() with the event name '${eventName}'`,
+                'the items are stored when the transaction commits, but the charge happens right away, ' +
+                    'so a rolled-back request would be billed for items that were never stored.',
+            );
         }
 
         const dataset = await this.openDataset();
@@ -1968,6 +1980,10 @@ export class Actor<Data extends Dictionary = Dictionary> {
      *
      * **IMPORTANT**: Make sure to use the `await` keyword when calling `pushData()`,
      * otherwise the Actor process might finish before the data are stored!
+     *
+     * Charging is rejected inside a crawlee storage transaction, where the items would only be stored
+     * at commit while the charge happens immediately - use `withDirectStorageAccess()` to opt out of
+     * the transaction, or push without an event name and charge separately.
      *
      * @param item Object or array of objects containing data to be stored in the default dataset.
      * The objects must be serializable to JSON and the JSON representation of each object must be smaller than 9MB.

--- a/src/apify_storage_backend.ts
+++ b/src/apify_storage_backend.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-classes-per-file */
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
 
 import type {
@@ -10,7 +8,6 @@ import type {
     StorageIdentifier,
 } from '@crawlee/types';
 import type { ApifyClient, KeyValueStoreClient } from 'apify-client';
-import { DatasetClient as ApifyDatasetClient } from 'apify-client';
 import log from '@apify/log';
 import { cryptoRandomObjectId } from '@apify/utilities';
 
@@ -19,19 +16,12 @@ import { ApifyKeyValueStoreBackend } from './apify_key_value_store_backend.js';
 import { AsyncLock, type RequestQueueAccessMode } from './apify_request_queue_backend.js';
 import { ApifyRequestQueueSharedBackend } from './apify_request_queue_shared_backend.js';
 import { ApifyRequestQueueSingleBackend } from './apify_request_queue_single_backend.js';
-import {
-    type ChargeResult,
-    type ChargingManager,
-    DEFAULT_DATASET_ITEM_EVENT,
-    mergeChargeResults,
-    pushDataAndCharge,
-} from './charging.js';
 import type { Configuration } from './configuration.js';
 
 type StorageType = 'Dataset' | 'KeyValueStore' | 'RequestQueue';
 
 /** The reserved alias crawlee uses for the default (unnamed) storage. */
-const DEFAULT_STORAGE_ALIAS = '__default__';
+export const DEFAULT_STORAGE_ALIAS = '__default__';
 
 /** The key of the default key-value store record holding this run's alias -> storage id mapping. */
 const ALIAS_MAPPING_RECORD_KEY = '__STORAGE_ALIASES_MAPPING';
@@ -66,80 +56,6 @@ interface ActorStorages {
     requestQueues?: Record<string, string>;
 }
 
-/** Marks a dataset backend whose underlying client charges for pushed items (pay-per-event). @internal */
-export const USES_PUSH_DATA_INTERCEPTION = Symbol('apify:uses-push-data-interception');
-
-/**
- * Context of a single `Actor.pushData()` call, shared with the intercepted
- * `pushItems()` calls so they can (1) know which event to charge and
- * (2) aggregate the {@link ChargeResult} across the multiple `pushItems()`
- * calls a single `pushData()` may trigger (the backend splits pushes exceeding
- * the API's payload size limit).
- */
-export interface PpeAwarePushDataContext {
-    eventName: string | undefined;
-    chargeResult?: ChargeResult;
-}
-
-export const pushDataChargingContext = new AsyncLocalStorage<PpeAwarePushDataContext>();
-
-/**
- * Default `DatasetClient` that charges for pushed items (pay-per-event). Used
- * only for the run's default dataset when a `apify-default-dataset-item` price
- * is configured; for everything else the plain `apify-client` dataset client is
- * used.
- */
-class PpeAwareDatasetClient<
-    Data extends Record<string | number, any> = Record<string | number, unknown>,
-> extends ApifyDatasetClient<Data> {
-    readonly #getChargingManager: () => ChargingManager;
-
-    constructor(
-        options: ConstructorParameters<typeof ApifyDatasetClient<Data>>[0],
-        getChargingManager: () => ChargingManager,
-    ) {
-        super(options);
-        this.#getChargingManager = getChargingManager;
-    }
-
-    private normalizeItems(items: string | Data | string[] | Data[]): Data[] {
-        if (typeof items === 'string') {
-            const parsed = JSON.parse(items);
-            return Array.isArray(parsed) ? parsed : [parsed];
-        }
-        if (Array.isArray(items)) {
-            return items.flatMap((item) =>
-                typeof item === 'string' ? (JSON.parse(item) as Data | Data[]) : item,
-            ) as Data[];
-        }
-        return [items];
-    }
-
-    override async pushItems(items: string | Data | string[] | Data[]): Promise<void> {
-        const context = pushDataChargingContext.getStore();
-
-        // A single JSON string may encode multiple items (e.g. '[{...},{...}]'),
-        // which the charging logic would miscount — parse strings into arrays so
-        // each logical item is counted individually.
-        const normalizedItems = this.normalizeItems(items);
-
-        const result = await pushDataAndCharge({
-            chargingManager: this.#getChargingManager(),
-            items: normalizedItems,
-            eventName: context?.eventName,
-            isDefaultDataset: true,
-            // stringify for faster validation in the Apify client
-            pushFn: async (limitedItems) => super.pushItems(JSON.stringify(limitedItems)),
-        });
-
-        if (!context) return;
-
-        // One `Actor.pushData()` may map to several `pushItems()` calls — aggregate.
-        context.chargeResult =
-            context.chargeResult === undefined ? result : mergeChargeResults(context.chargeResult, result);
-    }
-}
-
 export interface ApifyStorageBackendOptions {
     /**
      * SDK configuration providing the run's default storage ids and related environment values.
@@ -154,13 +70,6 @@ export interface ApifyStorageBackendOptions {
      * consumers can process the same queue safely.
      */
     requestQueueAccess?: RequestQueueAccessMode;
-
-    /**
-     * Supplies the charging manager for pay-per-event runs, enabling the charging-aware default
-     * dataset client.
-     * @internal
-     */
-    getChargingManager?: () => ChargingManager;
 }
 
 /**
@@ -168,10 +77,6 @@ export interface ApifyStorageBackendOptions {
  * `keyValueStore(id)`, `requestQueue(id, options?)`) to crawlee v4's
  * `StorageBackend` interface (async factory methods accepting an `id`,
  * a `name`, or an `alias`).
- *
- * For the run's default dataset it transparently swaps in a charging-aware
- * dataset client (pay-per-event on `Actor.pushData()`), provided a charging
- * manager is supplied and a default-dataset-item price is configured.
  *
  * `Actor` wires this up automatically; construct it directly only to use Apify
  * platform storage with crawlee's storage classes outside of `Actor` — e.g. to
@@ -189,7 +94,6 @@ export class ApifyStorageBackend implements StorageBackend {
     readonly #client: ApifyClient;
     readonly #config?: Configuration;
     readonly #requestQueueAccess: RequestQueueAccessMode;
-    readonly #getChargingManager?: () => ChargingManager;
 
     /** Unnamed storages resolved for aliases in this process, keyed like {@link AliasMapping}. */
     readonly #aliasIdCache = new Map<string, string>();
@@ -207,7 +111,6 @@ export class ApifyStorageBackend implements StorageBackend {
         this.#client = client;
         this.#config = options.configuration;
         this.#requestQueueAccess = options.requestQueueAccess ?? 'single';
-        this.#getChargingManager = options.getChargingManager;
     }
 
     /**
@@ -240,14 +143,7 @@ export class ApifyStorageBackend implements StorageBackend {
 
     async createDatasetBackend(options?: StorageIdentifier): Promise<DatasetBackend> {
         const id = await this.resolveId(options, 'Dataset');
-        const chargingClient = this.chargingDatasetClient(id);
-        const backend = new ApifyDatasetBackend(chargingClient ?? this.#client.dataset(id));
-        if (chargingClient) {
-            // `Actor.pushData()` looks for this marker on the dataset's backend to know the
-            // pay-per-event charging happens inside the intercepted `pushItems()` calls.
-            Object.assign(backend, { [USES_PUSH_DATA_INTERCEPTION]: true });
-        }
-        return backend;
+        return new ApifyDatasetBackend(this.#client.dataset(id));
     }
 
     async createKeyValueStoreBackend(options?: StorageIdentifier): Promise<KeyValueStoreBackend> {
@@ -271,32 +167,6 @@ export class ApifyStorageBackend implements StorageBackend {
         const key =
             this.#config?.actorRunId ?? (this.#fallbackClientKey ??= cryptoRandomObjectId(MAX_CLIENT_KEY_LENGTH));
         return key.slice(0, MAX_CLIENT_KEY_LENGTH);
-    }
-
-    /**
-     * Returns a charging-aware dataset client when `id` is the run's default
-     * dataset and a default-dataset-item price is configured; otherwise
-     * `undefined` (caller uses the plain client).
-     */
-    private chargingDatasetClient(id: string): ApifyDatasetClient | undefined {
-        const getChargingManager = this.#getChargingManager;
-        if (!getChargingManager) return undefined;
-        if (id !== this.#config?.defaultDatasetId) return undefined;
-
-        const hasDefaultDatasetItemEvent =
-            DEFAULT_DATASET_ITEM_EVENT in getChargingManager().getPricingInfo().perEventPrices;
-        if (!hasDefaultDatasetItemEvent) return undefined;
-
-        return new PpeAwareDatasetClient(
-            {
-                id,
-                baseUrl: this.#client.baseUrl,
-                publicBaseUrl: this.#client.publicBaseUrl,
-                apifyClient: this.#client,
-                httpClient: this.#client.httpClient,
-            },
-            getChargingManager,
-        );
     }
 
     /**

--- a/src/charging.ts
+++ b/src/charging.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import { Dataset, KeyValueStore } from '@crawlee/core';
 import type { ActorRunPricingInfo, ApifyClient } from 'apify-client';
 
@@ -66,17 +68,24 @@ export interface ActorPricingInfo {
     perEventPrices: Record<string, number>;
 }
 
-export function mergeChargeResults(a: ChargeResult, b: ChargeResult): ChargeResult {
-    return {
-        eventChargeLimitReached: a.eventChargeLimitReached || b.eventChargeLimitReached,
-        chargedCount: a.chargedCount + b.chargedCount,
-        chargeableWithinLimit: Object.fromEntries(
-            Object.entries(a.chargeableWithinLimit).map(([key, oldValue]) => [
-                key,
-                Math.min(oldValue, b.chargeableWithinLimit[key]),
-            ]),
-        ),
-    };
+/**
+ * A FIFO mutex that a critical section may re-enter from a nested call — the charge lock is taken by
+ * `Actor.pushData()` and again, one level down, by the dataset backend it pushes through.
+ */
+class ReentrantAsyncLock {
+    #tail: Promise<unknown> = Promise.resolve();
+    readonly #held = new AsyncLocalStorage<true>();
+
+    async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+        if (this.#held.getStore()) {
+            return await fn();
+        }
+
+        const run = this.#tail.then(async () => this.#held.run(true, fn));
+        // Keep the chain alive even when the critical section throws.
+        this.#tail = run.catch(() => {});
+        return await run;
+    }
 }
 
 /**
@@ -98,6 +107,8 @@ export class ChargingManager {
     #chargingState?: Record<string, ChargingStateItem>;
     #chargingLogDataset?: Dataset;
 
+    readonly #chargeLock = new ReentrantAsyncLock();
+
     #apifyClient: ApifyClient;
     #configuration: Configuration;
 
@@ -112,7 +123,8 @@ export class ChargingManager {
         this.#apifyClient = apifyClient;
     }
 
-    private get isPayPerEvent() {
+    /** A shortcut - true if the Actor runs with the pay-per-event pricing model. */
+    get isPayPerEvent(): boolean {
         return this.#pricingModel === 'PAY_PER_EVENT';
     }
 
@@ -277,14 +289,6 @@ export class ChargingManager {
      * @param options The name of the event to charge for and the number of events to be charged.
      */
     async charge({ eventName, count = 1 }: ChargeOptions): Promise<ChargeResult> {
-        const calculateChargeableWithinLimit = () =>
-            Object.fromEntries(
-                Object.keys(this.#pricingInfo).map((name) => [
-                    name,
-                    this.calculateMaxEventChargeCountWithinLimit(name),
-                ]),
-            );
-
         if (!this.isPayPerEvent) {
             if (!this.#notPpeWarningPrinted) {
                 log.warning(
@@ -296,89 +300,88 @@ export class ChargingManager {
             return {
                 eventChargeLimitReached: false,
                 chargedCount: 0,
-                chargeableWithinLimit: calculateChargeableWithinLimit(),
+                chargeableWithinLimit: this.calculateChargeableWithinLimit(),
             };
         }
 
-        if (this.#chargingState === undefined) {
+        const chargingState = this.#chargingState;
+
+        if (chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
-        /* START OF CRITICAL SECTION - no awaits here */
-        const maxEventChargeCount = this.calculateMaxEventChargeCountWithinLimit(eventName);
+        return await this.withChargeLock(async () => {
+            const maxEventChargeCount = this.calculateMaxEventChargeCountWithinLimit(eventName);
 
-        const chargedCount = (() => {
-            if (count <= maxEventChargeCount) {
-                return count;
+            const chargedCount = (() => {
+                if (count <= maxEventChargeCount) {
+                    return count;
+                }
+
+                // If the caller tries to charge more than the budget allows, overcharge by one event
+                // so that the Actor is detected by the platform and terminated.
+                // But don't do this if already strictly over the budget - no point piling on charges.
+                if (this.calculateTotalChargedAmount() <= this.#maxTotalChargeUsd) {
+                    return maxEventChargeCount + 1;
+                }
+
+                return 0;
+            })();
+
+            if (chargedCount === 0) {
+                return {
+                    eventChargeLimitReached: count > 0, // Only true if user wanted to charge but couldn't
+                    chargedCount: 0,
+                    chargeableWithinLimit: this.calculateChargeableWithinLimit(),
+                };
             }
 
-            // If the caller tries to charge more than the budget allows, overcharge by one event
-            // so that the Actor is detected by the platform and terminated.
-            // But don't do this if already strictly over the budget - no point piling on charges.
-            if (this.calculateTotalChargedAmount() <= this.#maxTotalChargeUsd) {
-                return maxEventChargeCount + 1;
-            }
-
-            return 0;
-        })();
-
-        if (chargedCount === 0) {
-            return {
-                eventChargeLimitReached: count > 0, // Only true if user wanted to charge but couldn't
-                chargedCount: 0,
-                chargeableWithinLimit: calculateChargeableWithinLimit(),
+            const pricingInfo = this.#pricingInfo[eventName] ?? {
+                price: this.#isAtHome ? 0 : 1, // Use a nonzero price for local development so that the maximum budget can be reached
+                title: `Unknown event '${eventName}'`,
             };
-        }
 
-        const pricingInfo = this.#pricingInfo[eventName] ?? {
-            price: this.#isAtHome ? 0 : 1, // Use a nonzero price for local development so that the maximum budget can be reached
-            title: `Unknown event '${eventName}'`,
-        };
+            chargingState[eventName] ??= {
+                chargeCount: 0,
+                totalChargedAmount: 0,
+            };
+            chargingState[eventName].chargeCount += chargedCount;
+            chargingState[eventName].totalChargedAmount += chargedCount * pricingInfo.price;
 
-        this.#chargingState[eventName] ??= {
-            chargeCount: 0,
-            totalChargedAmount: 0,
-        };
-        this.#chargingState[eventName].chargeCount += chargedCount;
-        this.#chargingState[eventName].totalChargedAmount += chargedCount * pricingInfo.price;
-
-        /* END OF CRITICAL SECTION */
-
-        if (this.#isAtHome) {
-            if (eventName.startsWith('apify-')) {
-                // Synthetic events (e.g. apify-default-dataset-item) are tracked locally only,
-                // the platform handles them automatically based on dataset writes.
-            } else if (this.#pricingInfo[eventName] !== undefined) {
-                await this.#apifyClient.run(this.#actorRunId!).charge({ eventName, count: chargedCount });
-            } else {
-                log.warning(`Attempting to charge for an unknown event '${eventName}'`);
+            if (this.#isAtHome) {
+                if (eventName.startsWith('apify-')) {
+                    // Synthetic events (e.g. apify-default-dataset-item) are tracked locally only,
+                    // the platform handles them automatically based on dataset writes.
+                } else if (this.#pricingInfo[eventName] !== undefined) {
+                    await this.#apifyClient.run(this.#actorRunId!).charge({ eventName, count: chargedCount });
+                } else {
+                    log.warning(`Attempting to charge for an unknown event '${eventName}'`);
+                }
             }
-        }
 
-        const timestamp = new Date().toISOString();
+            if (this.#chargingLogDataset !== undefined) {
+                await this.#chargingLogDataset.pushData({
+                    eventName,
+                    eventTitle: pricingInfo.title,
+                    eventPriceUsd: pricingInfo.price,
+                    chargedCount,
+                    timestamp: new Date().toISOString(),
+                });
+            }
 
-        if (this.#chargingLogDataset !== undefined) {
-            await this.#chargingLogDataset.pushData({
-                eventName,
-                eventTitle: pricingInfo.title,
-                eventPriceUsd: pricingInfo.price,
+            if (chargedCount < count) {
+                const subject = count === 1 ? 'instance' : 'instances';
+                log.info(
+                    `Charging ${count} ${subject} of '${eventName}' event would exceed maxTotalChargeUsd - only ${chargedCount} events were charged`,
+                );
+            }
+
+            return {
+                eventChargeLimitReached: this.isEventChargeLimitReached(eventName),
                 chargedCount,
-                timestamp,
-            });
-        }
-
-        if (chargedCount < count) {
-            const subject = count === 1 ? 'instance' : 'instances';
-            log.info(
-                `Charging ${count} ${subject} of '${eventName}' event would exceed maxTotalChargeUsd - only ${chargedCount} events were charged`,
-            );
-        }
-
-        return {
-            eventChargeLimitReached: this.calculateMaxEventChargeCountWithinLimit(eventName) <= 0,
-            chargedCount,
-            chargeableWithinLimit: calculateChargeableWithinLimit(),
-        };
+                chargeableWithinLimit: this.calculateChargeableWithinLimit(),
+            };
+        });
     }
 
     /**
@@ -449,126 +452,74 @@ export class ChargingManager {
     }
 
     /**
-     * Helper to calculate how many items can be pushed within charging limits.
-     * Returns the limited items and count to charge.
+     * Whether the remaining budget is insufficient to charge even a single event of the given type.
+     * Always false when nothing is charged in the first place.
      */
-    calculatePushDataLimits<T>({
-        items,
-        eventName,
-        isDefaultDataset,
-    }: {
-        items: T | T[];
-        eventName: string | undefined;
-        isDefaultDataset: boolean;
-    }): { limitedItems: T[]; eventsToCharge: Record<string, number> } {
+    isEventChargeLimitReached(eventName: string): boolean {
+        return this.isPayPerEvent && this.calculateMaxEventChargeCountWithinLimit(eventName) <= 0;
+    }
+
+    /**
+     * How many events of each known type can still be charged within the limit.
+     */
+    calculateChargeableWithinLimit(): Record<string, number> {
+        return Object.fromEntries(
+            Object.keys(this.#pricingInfo).map((name) => [name, this.calculateMaxEventChargeCountWithinLimit(name)]),
+        );
+    }
+
+    /**
+     * How many of `itemsCount` items may be pushed to a dataset within the remaining budget.
+     *
+     * The budget is measured against the combined per-item price of the explicit `eventName` and - on
+     * the default dataset - the synthetic {@link DEFAULT_DATASET_ITEM_EVENT}, since pushing one item
+     * charges both.
+     *
+     * When the budget cannot cover a single item, one item is still allowed through so that the
+     * resulting overcharge makes the platform terminate the run - unless the run is already strictly
+     * over budget, in which case nothing is allowed through.
+     */
+    calculatePushDataLimit(
+        itemsCount: number,
+        { eventName, isDefaultDataset = false }: { eventName?: string; isDefaultDataset?: boolean } = {},
+    ): number {
         if (this.#chargingState === undefined) {
             throw new Error('ChargingManager is not initialized');
         }
 
-        const itemsArray = Array.isArray(items) ? items : [items];
-
-        if (!this.isPayPerEvent) {
-            return {
-                limitedItems: itemsArray,
-                eventsToCharge: {},
-            };
+        if (!this.isPayPerEvent || itemsCount === 0) {
+            return itemsCount;
         }
 
         const itemPrice =
-            ((eventName !== undefined ? this.calculateEventPrice(eventName) : undefined) ?? 0) +
-            ((isDefaultDataset ? this.calculateEventPrice(DEFAULT_DATASET_ITEM_EVENT) : undefined) ?? 0);
+            (eventName === undefined ? 0 : (this.calculateEventPrice(eventName) ?? 0)) +
+            (isDefaultDataset ? (this.calculateEventPrice(DEFAULT_DATASET_ITEM_EVENT) ?? 0) : 0);
 
-        const maxChargedCount = itemPrice > 0 ? this.calculateMaxChargesByPrice(itemPrice) : Infinity;
+        if (itemPrice === 0) {
+            return itemsCount;
+        }
 
-        const itemsToKeep = (() => {
-            if (maxChargedCount >= itemsArray.length) {
-                return itemsArray.length;
-            }
+        const maxChargedCount = this.calculateMaxChargesByPrice(itemPrice);
 
-            // If the caller tries to push items even though the limit is depleted, overcharge by one
-            // so that the Platform terminates the run.
-            // But don't do this if already strictly over the budget - no point piling on charges.
-            if (
-                itemsArray.length > 0 &&
-                maxChargedCount === 0 &&
-                this.calculateTotalChargedAmount() <= this.#maxTotalChargeUsd
-            ) {
-                return 1;
-            }
+        if (maxChargedCount >= itemsCount) {
+            return itemsCount;
+        }
 
+        if (maxChargedCount > 0) {
             return maxChargedCount;
-        })();
-
-        const eventsToCharge: Record<string, number> = {};
-        if (eventName !== undefined && itemsToKeep > 0) {
-            eventsToCharge[eventName] = itemsToKeep;
-        }
-        if (isDefaultDataset && itemsToKeep > 0) {
-            eventsToCharge[DEFAULT_DATASET_ITEM_EVENT] = itemsToKeep;
         }
 
-        return {
-            limitedItems: itemsToKeep >= itemsArray.length ? itemsArray : itemsArray.slice(0, itemsToKeep),
-            eventsToCharge,
-        };
-    }
-}
-
-/**
- * Helper for PPE-aware pushing of data to the dataset.
- *
- * 1. Calculate limits based on budget
- * 2. Push limited items via the provided callback
- * 3. Charge for the events
- *
- * @internal
- */
-export async function pushDataAndCharge<T>({
-    chargingManager,
-    items,
-    eventName,
-    isDefaultDataset,
-    pushFn,
-}: {
-    chargingManager: ChargingManager;
-    items: T | T[];
-    eventName: string | undefined;
-    isDefaultDataset: boolean;
-    pushFn: (limitedItems: T | T[]) => Promise<void>;
-}): Promise<ChargeResult> {
-    const { limitedItems, eventsToCharge } = chargingManager.calculatePushDataLimits({
-        items,
-        eventName,
-        isDefaultDataset,
-    });
-
-    if (limitedItems.length > 0) {
-        // Preserve original call shape for single items
-        await pushFn(Array.isArray(items) ? limitedItems : (limitedItems[0] as T | T[]));
+        return this.calculateTotalChargedAmount() <= this.#maxTotalChargeUsd ? 1 : 0;
     }
 
-    if (Object.keys(eventsToCharge).length > 0) {
-        const results: Record<string, ChargeResult> = {};
-        await Promise.all(
-            Object.entries(eventsToCharge).map(async ([name, count]) => {
-                results[name] = await chargingManager.charge({
-                    eventName: name,
-                    count,
-                });
-            }),
-        );
-
-        // Merge all charge results so that eventChargeLimitReached reflects
-        // whether ANY of the charged events hit their limit.
-        return Object.values(results).reduce(mergeChargeResults);
+    /**
+     * Runs `fn` under the charge lock, which keeps a limit reservation and the charge that acts on it
+     * atomic against concurrent pushes. Only pay-per-event runs charge anything, so for every other
+     * run there is nothing to serialize and the lock is skipped.
+     *
+     * @internal
+     */
+    async withChargeLock<T>(fn: () => Promise<T>): Promise<T> {
+        return this.isPayPerEvent ? await this.#chargeLock.runExclusive(fn) : await fn();
     }
-
-    const itemsArray = Array.isArray(items) ? items : [items];
-    const allItemsTrimmed = itemsArray.length > 0 && limitedItems.length === 0;
-
-    return {
-        eventChargeLimitReached: allItemsTrimmed,
-        chargedCount: 0,
-        chargeableWithinLimit: {},
-    };
 }

--- a/src/charging.ts
+++ b/src/charging.ts
@@ -26,6 +26,12 @@ export interface ChargeOptions {
      * @default 1
      */
     count?: number;
+
+    /**
+     * Repeated charges sharing a key are billed once - e.g. a request handler rerun by a retry.
+     * Local accounting still counts every call, so the remaining budget comes out underestimated.
+     */
+    idempotencyKey?: string;
 }
 
 export interface ChargeResult {
@@ -288,7 +294,7 @@ export class ChargingManager {
      *
      * @param options The name of the event to charge for and the number of events to be charged.
      */
-    async charge({ eventName, count = 1 }: ChargeOptions): Promise<ChargeResult> {
+    async charge({ eventName, count = 1, idempotencyKey }: ChargeOptions): Promise<ChargeResult> {
         if (!this.isPayPerEvent) {
             if (!this.#notPpeWarningPrinted) {
                 log.warning(
@@ -353,7 +359,11 @@ export class ChargingManager {
                     // Synthetic events (e.g. apify-default-dataset-item) are tracked locally only,
                     // the platform handles them automatically based on dataset writes.
                 } else if (this.#pricingInfo[eventName] !== undefined) {
-                    await this.#apifyClient.run(this.#actorRunId!).charge({ eventName, count: chargedCount });
+                    await this.#apifyClient.run(this.#actorRunId!).charge({
+                        eventName,
+                        count: chargedCount,
+                        idempotencyKey,
+                    });
                 } else {
                     log.warning(`Attempting to charge for an unknown event '${eventName}'`);
                 }

--- a/src/charging_storage_backend.ts
+++ b/src/charging_storage_backend.ts
@@ -1,0 +1,145 @@
+/* eslint-disable max-classes-per-file */
+import type {
+    DatasetBackend,
+    DatasetBackendListOptions,
+    DatasetInfo,
+    Dictionary,
+    KeyValueStoreBackend,
+    PaginatedList,
+    RequestQueueBackend,
+    StorageBackend,
+    StorageIdentifier,
+} from '@crawlee/types';
+
+import type { ChargingManager } from './charging.js';
+import { DEFAULT_DATASET_ITEM_EVENT } from './charging.js';
+import type { Configuration } from './configuration.js';
+import { DEFAULT_STORAGE_ALIAS } from './apify_storage_backend.js';
+
+export interface ChargingStorageBackendOptions {
+    /** Supplies the run's default dataset id, which is the only dataset charged for. */
+    configuration: Configuration;
+
+    /** Resolved per push, as the charging manager only knows the pricing once `Actor.init()` has run. */
+    getChargingManager: () => ChargingManager;
+}
+
+/**
+ * Charges the synthetic `apify-default-dataset-item` event for the items it stores, trimming a push
+ * that the remaining budget cannot cover.
+ *
+ * It wraps the whole dataset backend rather than its API calls, so that a push split into several
+ * payload-sized requests is still counted and charged exactly once.
+ *
+ * @internal
+ */
+export class ChargingDatasetBackend implements DatasetBackend {
+    readonly #inner: DatasetBackend;
+    readonly #getChargingManager: () => ChargingManager;
+
+    constructor(inner: DatasetBackend, getChargingManager: () => ChargingManager) {
+        this.#inner = inner;
+        this.#getChargingManager = getChargingManager;
+    }
+
+    async getMetadata(): Promise<DatasetInfo> {
+        return await this.#inner.getMetadata();
+    }
+
+    async drop(): Promise<void> {
+        await this.#inner.drop();
+    }
+
+    async purge(): Promise<void> {
+        await this.#inner.purge();
+    }
+
+    async getData(options?: DatasetBackendListOptions): Promise<PaginatedList<Dictionary>> {
+        return await this.#inner.getData(options);
+    }
+
+    async pushData(items: Dictionary[]): Promise<void> {
+        const chargingManager = this.#getChargingManager();
+
+        // `Dataset.pushData()` also works without `Actor.init()`, where there is no charging state yet.
+        if (items.length === 0 || !chargingManager.isInitialized || !chargingManager.isPayPerEvent) {
+            await this.#inner.pushData(items);
+            return;
+        }
+
+        await chargingManager.withChargeLock(async () => {
+            const limit = chargingManager.calculatePushDataLimit(items.length, { isDefaultDataset: true });
+
+            if (limit === 0) {
+                return;
+            }
+
+            await this.#inner.pushData(limit < items.length ? items.slice(0, limit) : items);
+            await chargingManager.charge({ eventName: DEFAULT_DATASET_ITEM_EVENT, count: limit });
+        });
+    }
+}
+
+/**
+ * Wraps another storage backend so that items pushed to the run's default dataset are charged for
+ * under the pay-per-event pricing model.
+ *
+ * Charging belongs here rather than in `Actor.pushData()` because `Dataset.pushData()` is also
+ * called directly - by user code and by crawlee itself (`context.pushData()`) - and every item that
+ * reaches the default dataset is billed by the platform regardless of who pushed it.
+ *
+ * @internal
+ */
+export class ChargingStorageBackend implements StorageBackend {
+    storageExists?: StorageBackend['storageExists'];
+    purge?: StorageBackend['purge'];
+    teardown?: StorageBackend['teardown'];
+
+    readonly #inner: StorageBackend;
+    readonly #options: ChargingStorageBackendOptions;
+
+    constructor(inner: StorageBackend, options: ChargingStorageBackendOptions) {
+        this.#inner = inner;
+        this.#options = options;
+
+        // Crawlee branches on the presence of these, so they have to stay absent when `inner` lacks them.
+        const { storageExists, purge, teardown } = inner;
+        if (storageExists) this.storageExists = async (id, type) => storageExists.call(inner, id, type);
+        if (purge) this.purge = async () => purge.call(inner);
+        if (teardown) this.teardown = async () => teardown.call(inner);
+    }
+
+    get stats() {
+        return this.#inner.stats;
+    }
+
+    /** Repeats crawlee's own fallback, so that wrapping a backend does not change how storages are cached. */
+    getStorageBackendCacheKey(): string {
+        return this.#inner.getStorageBackendCacheKey?.() ?? this.#inner.constructor.name;
+    }
+
+    async createDatasetBackend(options?: StorageIdentifier): Promise<DatasetBackend> {
+        const backend = await this.#inner.createDatasetBackend(options);
+
+        if (!this.isDefaultDataset(options)) {
+            return backend;
+        }
+
+        return new ChargingDatasetBackend(backend, this.#options.getChargingManager);
+    }
+
+    async createKeyValueStoreBackend(options?: StorageIdentifier): Promise<KeyValueStoreBackend> {
+        return await this.#inner.createKeyValueStoreBackend(options);
+    }
+
+    async createRequestQueueBackend(options?: StorageIdentifier): Promise<RequestQueueBackend> {
+        return await this.#inner.createRequestQueueBackend(options);
+    }
+
+    private isDefaultDataset(options?: StorageIdentifier): boolean {
+        if (!options) return true;
+        if (options.alias !== undefined) return options.alias === DEFAULT_STORAGE_ALIAS;
+        if (options.id !== undefined) return options.id === this.#options.configuration.defaultDatasetId;
+        return false;
+    }
+}

--- a/test/apify/actor.test.ts
+++ b/test/apify/actor.test.ts
@@ -666,7 +666,8 @@ describe('Actor', () => {
 
                 await sdk.pushData({ foo: 'bar' });
                 expect(pushDataSpy).toBeCalledTimes(1);
-                expect(pushDataSpy).toBeCalledWith({ foo: 'bar' });
+                // A single item is normalized to a one-item array before it reaches the dataset.
+                expect(pushDataSpy).toBeCalledWith([{ foo: 'bar' }]);
             });
 
             test('openRequestQueue should open storage', async () => {
@@ -1452,7 +1453,7 @@ describe('Actor', () => {
 
             await Actor.pushData({ hello: 'apify' });
 
-            expect(pushDataSpy).toHaveBeenCalledWith({ hello: 'apify' });
+            expect(pushDataSpy).toHaveBeenCalledWith([{ hello: 'apify' }]);
         });
     });
 

--- a/test/apify/apify_storage_backend.test.ts
+++ b/test/apify/apify_storage_backend.test.ts
@@ -1,6 +1,5 @@
 import { RequestQueue } from '@crawlee/core';
 import type { ApifyClient, DatasetClient, KeyValueStoreClient } from 'apify-client';
-import { DatasetClient as ApifyDatasetClient } from 'apify-client';
 import { describe, expect, test, vi } from 'vitest';
 
 import { MAX_PAYLOAD_SIZE_BYTES } from '@apify/consts';
@@ -9,8 +8,7 @@ import { ApifyDatasetBackend } from '../../src/apify_dataset_backend.js';
 import { ApifyKeyValueStoreBackend } from '../../src/apify_key_value_store_backend.js';
 import { ApifyRequestQueueSharedBackend } from '../../src/apify_request_queue_shared_backend.js';
 import { ApifyRequestQueueSingleBackend } from '../../src/apify_request_queue_single_backend.js';
-import { ApifyStorageBackend, USES_PUSH_DATA_INTERCEPTION } from '../../src/apify_storage_backend.js';
-import { DEFAULT_DATASET_ITEM_EVENT } from '../../src/charging.js';
+import { ApifyStorageBackend } from '../../src/apify_storage_backend.js';
 import { Configuration } from '../../src/configuration.js';
 
 /** Spelled out rather than imported: this name is visible in the user's key-value store. */
@@ -223,63 +221,6 @@ describe('ApifyStorageBackend', () => {
 
         expect(single.getStorageBackendCacheKey()).toBe(shared.getStorageBackendCacheKey());
         expect(single.getStorageBackendCacheKey()).not.toBe(otherToken.getStorageBackendCacheKey());
-    });
-
-    test('marks the default dataset backend for push-data interception on pay-per-event runs', async () => {
-        const client = createMockApifyClient();
-        const backend = new ApifyStorageBackend(asApifyClient(client), {
-            configuration: new Configuration({ defaultDatasetId: 'default-dataset' }),
-            getChargingManager: () =>
-                ({
-                    getPricingInfo: () => ({ perEventPrices: { [DEFAULT_DATASET_ITEM_EVENT]: {} } }),
-                }) as never,
-        });
-
-        const defaultDataset = await backend.createDatasetBackend({ id: 'default-dataset' });
-        const otherDataset = await backend.createDatasetBackend({ id: 'other-dataset' });
-
-        expect((defaultDataset as never)[USES_PUSH_DATA_INTERCEPTION]).toBe(true);
-        expect((otherDataset as never)[USES_PUSH_DATA_INTERCEPTION]).toBeUndefined();
-    });
-
-    test('charges per parsed item when the backend splits a push into chunks', async () => {
-        const client = createMockApifyClient();
-        const charge = vi.fn(async ({ count }: { eventName: string; count: number }) => ({
-            eventChargeLimitReached: false,
-            chargedCount: count,
-            chargeableWithinLimit: {},
-        }));
-        const calculatePushDataLimits = vi.fn(({ items }: { items: Record<string, unknown>[] }) => ({
-            limitedItems: items,
-            eventsToCharge: { [DEFAULT_DATASET_ITEM_EVENT]: items.length },
-        }));
-        const backend = new ApifyStorageBackend(asApifyClient(client), {
-            configuration: new Configuration({ defaultDatasetId: 'default-dataset' }),
-            getChargingManager: () =>
-                ({
-                    getPricingInfo: () => ({ perEventPrices: { [DEFAULT_DATASET_ITEM_EVENT]: {} } }),
-                    calculatePushDataLimits,
-                    charge,
-                }) as never,
-        });
-        const dataset = await backend.createDatasetBackend({ id: 'default-dataset' });
-
-        // Stub out the plain-client push underneath the charging wrapper.
-        const pushSpy = vi.spyOn(ApifyDatasetClient.prototype, 'pushItems').mockResolvedValue(undefined);
-        try {
-            // Four ~3MB items arrive as multiple pre-serialized JSON chunks — the charging
-            // wrapper must still count every logical item exactly once.
-            const items = Array.from({ length: 4 }, (_, i) => ({ i, payload: 'a'.repeat(3 * 1024 * 1024) }));
-            await dataset.pushData(items);
-
-            expect(pushSpy.mock.calls.length).toBeGreaterThan(1);
-            const countedItems = calculatePushDataLimits.mock.calls.map(([{ items: counted }]) => counted);
-            expect(countedItems.flat()).toEqual(items);
-            const chargedCounts = charge.mock.calls.map(([{ count }]) => count);
-            expect(chargedCounts.reduce((sum, count) => sum + count, 0)).toBe(4);
-        } finally {
-            pushSpy.mockRestore();
-        }
     });
 });
 

--- a/test/apify/charging.test.ts
+++ b/test/apify/charging.test.ts
@@ -1,11 +1,13 @@
+import { MemoryStorageBackend } from '@crawlee/core';
 import { Actor } from 'apify';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import log from '@apify/log';
 
-import { mergeChargeResults } from '../../src/charging.js';
-import { initIsolatedDefaultActor, useInMemoryStorage } from '../createIsolatedActor.js';
+import { DEFAULT_DATASET_ITEM_EVENT } from '../../src/charging.js';
+import { createIsolatedActor, initIsolatedDefaultActor, useInMemoryStorage } from '../createIsolatedActor.js';
+import { resetGlobalState } from '../resetGlobalState.js';
 
 /**
  * Sets up environment variables to simulate running on the Apify platform.
@@ -59,113 +61,12 @@ function setUpLocalTestEnv(options: { maxTotalChargeUsd?: string } = {}) {
     }
 }
 
-describe('mergeChargeResults()', () => {
-    test('should sum chargedCount values', () => {
-        const a = {
-            eventChargeLimitReached: false,
-            chargedCount: 3,
-            chargeableWithinLimit: {},
-        };
-        const b = {
-            eventChargeLimitReached: false,
-            chargedCount: 5,
-            chargeableWithinLimit: {},
-        };
-        expect(mergeChargeResults(a, b).chargedCount).toBe(8);
-    });
-
-    test('should return false when both eventChargeLimitReached are false', () => {
-        const a = {
-            eventChargeLimitReached: false,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        const b = {
-            eventChargeLimitReached: false,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        expect(mergeChargeResults(a, b).eventChargeLimitReached).toBe(false);
-    });
-
-    test('should return true when first eventChargeLimitReached is true', () => {
-        const a = {
-            eventChargeLimitReached: true,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        const b = {
-            eventChargeLimitReached: false,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        expect(mergeChargeResults(a, b).eventChargeLimitReached).toBe(true);
-    });
-
-    test('should return true when second eventChargeLimitReached is true', () => {
-        const a = {
-            eventChargeLimitReached: false,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        const b = {
-            eventChargeLimitReached: true,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        expect(mergeChargeResults(a, b).eventChargeLimitReached).toBe(true);
-    });
-
-    test('should return true when both eventChargeLimitReached are true', () => {
-        const a = {
-            eventChargeLimitReached: true,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        const b = {
-            eventChargeLimitReached: true,
-            chargedCount: 1,
-            chargeableWithinLimit: {},
-        };
-        expect(mergeChargeResults(a, b).eventChargeLimitReached).toBe(true);
-    });
-
-    test('should take minimum of chargeableWithinLimit for each key', () => {
-        const a = {
-            eventChargeLimitReached: false,
-            chargedCount: 1,
-            chargeableWithinLimit: { event1: 10, event2: 5 },
-        };
-        const b = {
-            eventChargeLimitReached: false,
-            chargedCount: 1,
-            chargeableWithinLimit: { event1: 3, event2: 8 },
-        };
-        const result = mergeChargeResults(a, b);
-        expect(result.chargeableWithinLimit).toEqual({ event1: 3, event2: 5 });
-    });
-
-    test('should handle empty chargeableWithinLimit objects', () => {
-        const a = {
-            eventChargeLimitReached: false,
-            chargedCount: 2,
-            chargeableWithinLimit: {},
-        };
-        const b = {
-            eventChargeLimitReached: false,
-            chargedCount: 3,
-            chargeableWithinLimit: {},
-        };
-        const result = mergeChargeResults(a, b);
-        expect(result.chargeableWithinLimit).toEqual({});
-    });
-});
-
 describe('ChargingManager', () => {
     beforeEach(() => {
         // Default to local test mode - individual tests can switch to platform mode.
-        // Each test installs its own isolated default Actor (initIsolatedDefaultActor),
-        // so no global state needs resetting between runs.
+        // The tests that assert on charging share one storage directory, and crawlee caches
+        // storage instances per directory, so the cache has to go between tests.
+        resetGlobalState();
         setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
     });
 
@@ -465,24 +366,16 @@ describe('ChargingManager', () => {
         });
     });
 
-    describe('calculatePushDataLimits()', () => {
-        test('should return all items when budget allows', async () => {
+    describe('calculatePushDataLimit()', () => {
+        test('allows every item when the budget covers them', async () => {
             setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
 
             await initIsolatedDefaultActor();
 
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: [{ a: 1 }, { b: 2 }, { c: 3 }],
-                eventName: 'test-event',
-                isDefaultDataset: false,
-            });
-
-            expect(result.limitedItems).toHaveLength(3);
-            expect(result.eventsToCharge).toEqual({ 'test-event': 3 });
+            expect(Actor.getChargingManager().calculatePushDataLimit(3, { eventName: 'test-event' })).toBe(3);
         });
 
-        test('should limit items when budget is insufficient', async () => {
+        test('caps the item count at what the budget covers', async () => {
             setUpPlatformEnv({
                 maxTotalChargeUsd: '0.15',
                 pricingInfo: {
@@ -495,23 +388,15 @@ describe('ChargingManager', () => {
 
             await initIsolatedDefaultActor();
 
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: [{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }, { e: 5 }],
-                eventName: 'expensive-event',
-                isDefaultDataset: false,
-            });
-
-            // Budget allows 1 item ($0.15 / $0.1 = 1), 5 are requested → caps to 1 (no overcharge since budget is not fully depleted)
-            expect(result.limitedItems).toHaveLength(1);
-            expect(result.eventsToCharge).toEqual({ 'expensive-event': 1 });
+            // $0.15 / $0.1 = 1, and the budget is not depleted yet, so there is no overcharge.
+            expect(Actor.getChargingManager().calculatePushDataLimit(5, { eventName: 'expensive-event' })).toBe(1);
         });
 
-        test('should include synthetic event for default dataset', async () => {
+        test('counts the synthetic dataset-item event towards the price', async () => {
             setUpPlatformEnv({
-                maxTotalChargeUsd: '10',
+                maxTotalChargeUsd: '0.05',
                 pricingInfo: {
-                    'apify-default-dataset-item': {
+                    [DEFAULT_DATASET_ITEM_EVENT]: {
                         eventTitle: 'Dataset Item',
                         eventPriceUsd: 0.01,
                     },
@@ -520,68 +405,36 @@ describe('ChargingManager', () => {
 
             await initIsolatedDefaultActor();
 
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: [{ a: 1 }, { b: 2 }],
-                eventName: undefined,
-                isDefaultDataset: true,
-            });
-
-            expect(result.limitedItems).toHaveLength(2);
-            expect(result.eventsToCharge).toEqual({
-                'apify-default-dataset-item': 2,
-            });
+            expect(Actor.getChargingManager().calculatePushDataLimit(10, { isDefaultDataset: true })).toBe(5);
         });
 
-        test('should include both events when pushing to default dataset with explicit eventName', async () => {
+        test('adds up the explicit and synthetic prices on the default dataset', async () => {
             setUpPlatformEnv({
-                maxTotalChargeUsd: '10',
+                maxTotalChargeUsd: '0.15',
                 pricingInfo: {
-                    'apify-default-dataset-item': {
+                    [DEFAULT_DATASET_ITEM_EVENT]: {
                         eventTitle: 'Dataset Item',
                         eventPriceUsd: 0.01,
                     },
                     'custom-event': {
                         eventTitle: 'Custom',
-                        eventPriceUsd: 0.05,
+                        eventPriceUsd: 0.04,
                     },
                 },
             });
 
             await initIsolatedDefaultActor();
 
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: [{ a: 1 }, { b: 2 }],
-                eventName: 'custom-event',
-                isDefaultDataset: true,
-            });
-
-            expect(result.limitedItems).toHaveLength(2);
-            expect(result.eventsToCharge).toEqual({
-                'apify-default-dataset-item': 2,
-                'custom-event': 2,
-            });
+            // One item costs $0.05, not $0.04 - pushing it charges both events.
+            expect(
+                Actor.getChargingManager().calculatePushDataLimit(10, {
+                    eventName: 'custom-event',
+                    isDefaultDataset: true,
+                }),
+            ).toBe(3);
         });
 
-        test('should handle single item (non-array) input', async () => {
-            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
-
-            await initIsolatedDefaultActor();
-
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: { single: 'item' },
-                eventName: 'test-event',
-                isDefaultDataset: false,
-            });
-
-            expect(result.limitedItems).toHaveLength(1);
-            expect(result.limitedItems[0]).toEqual({ single: 'item' });
-            expect(result.eventsToCharge).toEqual({ 'test-event': 1 });
-        });
-
-        test('should overcharge by one item when budget is exhausted', async () => {
+        test('lets one item through to overcharge when the budget is depleted', async () => {
             setUpPlatformEnv({
                 maxTotalChargeUsd: '0.05',
                 pricingInfo: {
@@ -594,32 +447,142 @@ describe('ChargingManager', () => {
 
             await initIsolatedDefaultActor();
 
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: [{ a: 1 }, { b: 2 }],
-                eventName: 'expensive-event',
-                isDefaultDataset: false,
-            });
-
-            // Budget allows 0 items ($0.05 / $0.1 = 0), but 2 are requested → overcharge by 1
-            expect(result.limitedItems).toHaveLength(1);
-            expect(result.eventsToCharge).toEqual({ 'expensive-event': 1 });
+            expect(Actor.getChargingManager().calculatePushDataLimit(2, { eventName: 'expensive-event' })).toBe(1);
         });
 
-        test('should not charge for events when actor is not PPE', async () => {
+        test('lets nothing through once strictly over budget', async () => {
+            setUpPlatformEnv({
+                maxTotalChargeUsd: '0.10',
+                pricingInfo: {
+                    'my-event': {
+                        eventTitle: 'My Event',
+                        eventPriceUsd: 0.1,
+                    },
+                },
+                // $0.20 charged against a $0.10 budget - an overcharge already happened.
+                chargedEventCounts: { 'my-event': 2 },
+            });
+
+            await initIsolatedDefaultActor();
+
+            expect(Actor.getChargingManager().calculatePushDataLimit(3, { eventName: 'my-event' })).toBe(0);
+        });
+
+        test('allows every item when the Actor is not pay-per-event', async () => {
             delete process.env.ACTOR_TEST_PAY_PER_EVENT;
 
             await initIsolatedDefaultActor();
 
-            const chargingManager = Actor.getChargingManager();
-            const result = chargingManager.calculatePushDataLimits({
-                items: [{ a: 1 }, { b: 2 }, { c: 3 }],
-                eventName: undefined,
-                isDefaultDataset: true,
-            });
+            expect(Actor.getChargingManager().calculatePushDataLimit(3, { isDefaultDataset: true })).toBe(3);
+        });
+    });
 
-            expect(result.limitedItems).toHaveLength(3);
-            expect(result.eventsToCharge).toEqual({});
+    describe('synthetic dataset item event', () => {
+        // These runs push through the storage the Actor installs for itself, which is what a local
+        // `ACTOR_TEST_PAY_PER_EVENT` run does. Local pay-per-event testing prices every event at
+        // $1, so a budget in dollars is also an item count.
+        test('is charged for pushes that do not go through Actor.pushData()', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            await initIsolatedDefaultActor();
+
+            const dataset = await Actor.openDataset();
+            await dataset.pushData([{ a: 1 }, { b: 2 }]);
+
+            expect(Actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(2);
+        });
+
+        test('trims a push the remaining budget cannot cover', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '2' });
+            await initIsolatedDefaultActor();
+
+            const dataset = await Actor.openDataset();
+            await dataset.pushData([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+
+            const { items } = await dataset.getData();
+            expect(items).toHaveLength(2);
+            expect(Actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(2);
+        });
+
+        test('is not charged for a named dataset', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            await initIsolatedDefaultActor();
+
+            const dataset = await Actor.openDataset('some-other-dataset');
+            await dataset.pushData([{ a: 1 }, { b: 2 }]);
+
+            expect(Actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(0);
+        });
+
+        test('is reported by pushData() without an explicit event name', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            // The static `Actor.pushData(item)` overload is typed as returning nothing, so the
+            // charge result is asserted through the instance the static API delegates to.
+            const { actor } = await initIsolatedDefaultActor();
+
+            const result = await actor.pushData([{ a: 1 }, { b: 2 }]);
+
+            expect(result.chargedCount).toBe(2);
+            expect(result.eventChargeLimitReached).toBe(false);
+        });
+
+        test('keeps concurrent pushes within the budget', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '4' });
+            await initIsolatedDefaultActor();
+
+            // Without the charge lock all four pushes reserve against the same untouched budget and
+            // 8 items land. Serialized, they get 2 + 2 + 1 + 0: the third push finds the budget spent
+            // and pushes a single item to overcharge, the fourth is already over budget.
+            await Promise.all(Array.from({ length: 4 }, async () => Actor.pushData([{ a: 1 }, { b: 2 }])));
+
+            const dataset = await Actor.openDataset();
+            const { items } = await dataset.getData();
+
+            expect(items).toHaveLength(5);
+            expect(Actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(5);
+        });
+
+        test('is not charged for a caller-supplied backend, which is left to store everything', async () => {
+            setUpPlatformEnv({
+                maxTotalChargeUsd: '0.01',
+                pricingInfo: {
+                    [DEFAULT_DATASET_ITEM_EVENT]: {
+                        eventTitle: 'Dataset Item',
+                        eventPriceUsd: 0.01,
+                    },
+                },
+            });
+            // The platform only counts items it stores itself, so a budget worth a single item must
+            // neither be spent nor trim the push.
+            const { actor } = await initIsolatedDefaultActor({ storage: new MemoryStorageBackend() });
+
+            const dataset = await actor.openDataset();
+            await dataset.pushData([{ a: 1 }, { b: 2 }, { c: 3 }]);
+
+            expect((await dataset.getData()).items).toHaveLength(3);
+            expect(actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(0);
+        });
+
+        test('warns that it is not charged when the run does not use Apify storage', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            const warnings: string[] = [];
+            vitest.spyOn(log, 'warning').mockImplementation((message) => void warnings.push(message));
+
+            const { actor } = await initIsolatedDefaultActor({ storage: new MemoryStorageBackend() });
+
+            expect(warnings.join('\n')).toContain('will not be charged for');
+
+            await actor.pushData([{ a: 1 }, { b: 2 }]);
+            expect(actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(0);
+        });
+
+        test('explains the conflict when the backend is registered twice', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            const { actor, serviceLocator } = createIsolatedActor();
+            serviceLocator.setStorageBackend(new MemoryStorageBackend());
+
+            await expect(actor.init({ storage: new MemoryStorageBackend() })).rejects.toThrow(
+                /already registered with crawlee.*Actor\.init\(\{ storage \}\)/s,
+            );
         });
     });
 

--- a/test/apify/charging.test.ts
+++ b/test/apify/charging.test.ts
@@ -1,4 +1,9 @@
-import { MemoryStorageBackend } from '@crawlee/core';
+import {
+    createStorageTransaction,
+    MemoryStorageBackend,
+    withDirectStorageAccess,
+    withStorageTransaction,
+} from '@crawlee/core';
 import { Actor } from 'apify';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
@@ -583,6 +588,68 @@ describe('ChargingManager', () => {
             await expect(actor.init({ storage: new MemoryStorageBackend() })).rejects.toThrow(
                 /already registered with crawlee.*Actor\.init\(\{ storage \}\)/s,
             );
+        });
+    });
+
+    describe('storage transactions', () => {
+        test('charges the synthetic event once, at commit, for every push the transaction buffered', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            await initIsolatedDefaultActor();
+            const chargingManager = Actor.getChargingManager();
+
+            let chargedInsideTransaction: number | undefined;
+
+            await withStorageTransaction(async () => {
+                await Actor.pushData([{ a: 1 }, { b: 2 }]);
+                await Actor.pushData([{ c: 3 }]);
+                chargedInsideTransaction = chargingManager.getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT);
+            });
+
+            expect(chargedInsideTransaction).toBe(0);
+            expect(chargingManager.getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(3);
+        });
+
+        test('charges nothing for a rolled back transaction', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            await initIsolatedDefaultActor();
+
+            // The shape of a request handler that threw: the crawler rolls its transaction back and
+            // retries the request, which must not pay for the discarded items twice.
+            const transaction = createStorageTransaction();
+            await transaction.run(async () => {
+                await Actor.pushData([{ a: 1 }, { b: 2 }]);
+            });
+            transaction.rollback();
+            transaction.dispose();
+
+            const dataset = await Actor.openDataset();
+            expect((await dataset.getData()).items).toHaveLength(0);
+            expect(Actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(0);
+        });
+
+        test('rejects pushing with an event name inside a transaction', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            const { actor } = await initIsolatedDefaultActor();
+
+            await withStorageTransaction(async () => {
+                await expect(actor.pushData([{ a: 1 }], 'my-event')).rejects.toThrow(
+                    /cannot be used inside a storage transaction/,
+                );
+            });
+
+            expect(actor.getChargingManager().getChargedEventCount('my-event')).toBe(0);
+        });
+
+        test('charges for an event name when direct storage access opts out of the transaction', async () => {
+            setUpLocalTestEnv({ maxTotalChargeUsd: '10' });
+            const { actor } = await initIsolatedDefaultActor();
+
+            const result = await withStorageTransaction(async () =>
+                withDirectStorageAccess(async () => actor.pushData([{ a: 1 }, { b: 2 }], 'my-event')),
+            );
+
+            expect(result.chargedCount).toBe(2);
+            expect(actor.getChargingManager().getChargedEventCount(DEFAULT_DATASET_ITEM_EVENT)).toBe(2);
         });
     });
 

--- a/test/apify/charging.test.ts
+++ b/test/apify/charging.test.ts
@@ -5,6 +5,7 @@ import {
     withStorageTransaction,
 } from '@crawlee/core';
 import { Actor } from 'apify';
+import type { RunClient } from 'apify-client';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
@@ -275,6 +276,33 @@ describe('ChargingManager', () => {
                 count: 1,
             });
             expect(result2.chargedCount).toBe(1);
+        });
+
+        test('forwards the idempotency key the platform deduplicates on', async () => {
+            setUpPlatformEnv({
+                maxTotalChargeUsd: '10.0',
+                pricingInfo: {
+                    'test-event': {
+                        eventTitle: 'Test Event',
+                        eventPriceUsd: 1.0,
+                    },
+                },
+            });
+
+            const { serviceLocator } = await initIsolatedDefaultActor();
+            useInMemoryStorage(serviceLocator);
+
+            const chargeSpy = vitest.fn().mockResolvedValue(undefined);
+            // Only `charge()` is exercised, so a partial stand-in is enough for the whole run client.
+            vitest.spyOn(Actor.apifyClient, 'run').mockReturnValue({ charge: chargeSpy } as unknown as RunClient);
+
+            await Actor.charge({ eventName: 'test-event', count: 2, idempotencyKey: 'request-42-test-event' });
+
+            expect(chargeSpy).toHaveBeenCalledWith({
+                eventName: 'test-event',
+                count: 2,
+                idempotencyKey: 'request-42-test-event',
+            });
         });
 
         describe('with an unknown event', () => {

--- a/test/apify/charging_storage_backend.test.ts
+++ b/test/apify/charging_storage_backend.test.ts
@@ -1,0 +1,149 @@
+import type { DatasetBackend, StorageBackend } from '@crawlee/types';
+import type { DatasetClient } from 'apify-client';
+import type { Mock } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ApifyDatasetBackend } from '../../src/apify_dataset_backend.js';
+import type { ChargingManager } from '../../src/charging.js';
+import { DEFAULT_DATASET_ITEM_EVENT } from '../../src/charging.js';
+import { ChargingStorageBackend } from '../../src/charging_storage_backend.js';
+import { Configuration } from '../../src/configuration.js';
+
+interface ChargingManagerMock {
+    isInitialized: boolean;
+    isPayPerEvent: boolean;
+    charge: Mock;
+    calculatePushDataLimit: Mock;
+    withChargeLock: Mock;
+}
+
+function createChargingManagerMock(options: { limit?: number; isPayPerEvent?: boolean } = {}): ChargingManagerMock {
+    return {
+        isInitialized: true,
+        isPayPerEvent: options.isPayPerEvent ?? true,
+        charge: vi.fn(async () => ({
+            eventChargeLimitReached: false,
+            chargedCount: 0,
+            chargeableWithinLimit: {},
+        })),
+        calculatePushDataLimit: vi.fn((itemsCount: number) => options.limit ?? itemsCount),
+        withChargeLock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    };
+}
+
+function createBackend(inner: Partial<StorageBackend>, chargingManager: ChargingManagerMock): ChargingStorageBackend {
+    return new ChargingStorageBackend(inner as StorageBackend, {
+        configuration: new Configuration({ defaultDatasetId: 'default-dataset' }),
+        getChargingManager: () => chargingManager as unknown as ChargingManager,
+    });
+}
+
+describe('ChargingStorageBackend', () => {
+    test('charges the synthetic event once for a push the inner backend splits into chunks', async () => {
+        // Four ~3MB items exceed the API's payload limit, so `ApifyDatasetBackend` sends several
+        // requests. Charging sits above that, so the run is billed for 4 items, not 4 per chunk.
+        const pushItems = vi.fn(async () => {});
+        const inner = new ApifyDatasetBackend({ pushItems } as unknown as DatasetClient);
+        const chargingManager = createChargingManagerMock();
+        const backend = createBackend({ createDatasetBackend: async () => inner }, chargingManager);
+
+        const dataset = await backend.createDatasetBackend({ alias: '__default__' });
+        await dataset.pushData(Array.from({ length: 4 }, (_, i) => ({ i, payload: 'a'.repeat(3 * 1024 * 1024) })));
+
+        expect(pushItems.mock.calls.length).toBeGreaterThan(1);
+        expect(chargingManager.charge).toHaveBeenCalledExactlyOnceWith({
+            eventName: DEFAULT_DATASET_ITEM_EVENT,
+            count: 4,
+        });
+    });
+
+    test.each([
+        ['a non-default id', { id: 'other-dataset' }],
+        ['an explicit alias', { alias: 'scratch' }],
+    ])('leaves %s uncharged', async (_, identifier) => {
+        const pushData = vi.fn(async () => {});
+        const chargingManager = createChargingManagerMock();
+        const backend = createBackend(
+            { createDatasetBackend: async () => ({ pushData }) as unknown as DatasetBackend },
+            chargingManager,
+        );
+
+        const dataset = await backend.createDatasetBackend(identifier);
+        await dataset.pushData([{ a: 1 }]);
+
+        expect(pushData).toHaveBeenCalledWith([{ a: 1 }]);
+        expect(chargingManager.charge).not.toHaveBeenCalled();
+    });
+
+    test('charges the default dataset addressed by its id', async () => {
+        const pushData = vi.fn(async () => {});
+        const chargingManager = createChargingManagerMock();
+        const backend = createBackend(
+            { createDatasetBackend: async () => ({ pushData }) as unknown as DatasetBackend },
+            chargingManager,
+        );
+
+        const dataset = await backend.createDatasetBackend({ id: 'default-dataset' });
+        await dataset.pushData([{ a: 1 }]);
+
+        expect(chargingManager.charge).toHaveBeenCalledWith({
+            eventName: DEFAULT_DATASET_ITEM_EVENT,
+            count: 1,
+        });
+    });
+
+    test('does not consult the charging manager outside pay-per-event runs', async () => {
+        const pushData = vi.fn(async () => {});
+        const chargingManager = createChargingManagerMock({ isPayPerEvent: false });
+        const backend = createBackend(
+            { createDatasetBackend: async () => ({ pushData }) as unknown as DatasetBackend },
+            chargingManager,
+        );
+
+        const dataset = await backend.createDatasetBackend();
+        await dataset.pushData([{ a: 1 }]);
+
+        expect(pushData).toHaveBeenCalledWith([{ a: 1 }]);
+        expect(chargingManager.withChargeLock).not.toHaveBeenCalled();
+        expect(chargingManager.charge).not.toHaveBeenCalled();
+    });
+
+    test('keeps optional backend members absent when the wrapped backend lacks them', async () => {
+        const chargingManager = createChargingManagerMock();
+        const withoutOptionals = createBackend(
+            { createDatasetBackend: async () => ({}) as DatasetBackend },
+            chargingManager,
+        );
+        const withOptionals = createBackend(
+            {
+                createDatasetBackend: async () => ({}) as DatasetBackend,
+                storageExists: async () => true,
+                purge: async () => {},
+                teardown: async () => {},
+            },
+            chargingManager,
+        );
+
+        // Crawlee treats a missing `storageExists` as "cannot resolve a string to an id", and a
+        // missing `purge` / `teardown` as "nothing to do", so presence has to survive wrapping.
+        expect(withoutOptionals.storageExists).toBeUndefined();
+        expect(withoutOptionals.purge).toBeUndefined();
+        expect(withoutOptionals.teardown).toBeUndefined();
+        await expect(withOptionals.storageExists!('some-id', 'Dataset')).resolves.toBe(true);
+        expect(withOptionals.purge).toBeDefined();
+        expect(withOptionals.teardown).toBeDefined();
+    });
+
+    test('reuses the wrapped backend cache key so wrapping does not split the storage cache', () => {
+        const chargingManager = createChargingManagerMock();
+        const keyed = createBackend(
+            { createDatasetBackend: async () => ({}) as DatasetBackend, getStorageBackendCacheKey: () => 'inner-key' },
+            chargingManager,
+        );
+        const unkeyed = createBackend({ createDatasetBackend: async () => ({}) as DatasetBackend }, chargingManager);
+
+        expect(keyed.getStorageBackendCacheKey()).toBe('inner-key');
+        // Crawlee's own fallback for a backend without the method.
+        expect(unkeyed.getStorageBackendCacheKey()).toBe('Object');
+    });
+});

--- a/test/createIsolatedActor.ts
+++ b/test/createIsolatedActor.ts
@@ -57,8 +57,10 @@ export function createIsolatedActor(
  * Teardown is automatic (see {@link createIsolatedActor}): when the test
  * finishes, the Actor is exited and the static default instance is dropped.
  */
-export async function initIsolatedDefaultActor(options: { config?: Configuration } = {}): Promise<IsolatedActor> {
-    const isolated = createIsolatedActor(options);
+export async function initIsolatedDefaultActor(
+    options: { config?: Configuration; storage?: StorageBackend } = {},
+): Promise<IsolatedActor> {
+    const isolated = createIsolatedActor({ config: options.config });
     Actor.setDefaultInstance(isolated.actor);
 
     onTestFinished(async () => {
@@ -66,7 +68,9 @@ export async function initIsolatedDefaultActor(options: { config?: Configuration
         Actor.setDefaultInstance();
     });
 
-    await isolated.actor.init();
+    // A caller-supplied backend is deliberately left unwrapped, so dataset items pushed through it
+    // are not charged for - tests that assert on charging must not pass one.
+    await isolated.actor.init({ storage: options.storage });
     return isolated;
 }
 


### PR DESCRIPTION
- related to #352 
- instead of subclassing `DatasetClient` from `apify-client`, we now do the synthetic `apify-default-dataset-item` accounting in `ChargingDatasetBackend`, a decorator installed on top of the `StorageBackend` by the `Actor` class
- the `AsyncLocalStorage` used to group together chunked `pushItems` calls is gone :rocket:
- the chunking logic in the Apify backend is intact
