### PR TITLE
chore(deps): bump `@apify/validations` to 1.1.0 and unify zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,12 +74,12 @@
     "dependencies": {
         "@apify/consts": "^3.0.1",
         "@apify/datastructures": "^3.0.1",
-        "@apify/input_secrets": "^2.0.1",
+        "@apify/input_secrets": "^2.0.3",
         "@apify/log": "^3.0.1",
         "@apify/pseudo_url": "^3.0.1",
         "@apify/timeout": "^1.0.1",
         "@apify/utilities": "^3.0.1",
-        "@apify/validations": "^1.0.1",
+        "@apify/validations": "^1.1.0",
         "@crawlee/core": "^4.0.0-rc.0",
         "@crawlee/types": "^4.0.0-rc.0",
         "@crawlee/utils": "^4.0.0-rc.0",
@@ -88,7 +88,7 @@
         "semver": "^7.8.5",
         "tslib": "^2.8.1",
         "ws": "^8.21.3",
-        "zod": "^4.4.3"
+        "zod": "^4.5.4"
     },
     "devDependencies": {
         "@apify/oxlint-config": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       '@apify/input_secrets':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.3
+        version: 2.0.3
       '@apify/log':
         specifier: ^3.0.1
         version: 3.0.1
@@ -35,8 +35,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       '@apify/validations':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.0
+        version: 1.1.0
       '@crawlee/core':
         specifier: ^4.0.0-rc.0
         version: 4.0.0-rc.0
@@ -62,8 +62,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@apify/oxlint-config':
         specifier: ^0.3.0
@@ -386,8 +386,8 @@ packages:
       react-dom: ^18.2.0 || >=19.0.0
       typescript: ^5.0.0
 
-  '@apify/input_secrets@2.0.1':
-    resolution: {integrity: sha512-DTl4iwsd661wng6nOPxuNQ9xFjZnUGsPLYYvNXdO306GqtAp1VkzZT5KeI7uldAWK9eslT9rRFRas9BP8u+ZWA==}
+  '@apify/input_secrets@2.0.3':
+    resolution: {integrity: sha512-4o9bfVRAceZcohaEacRc7vf5ZfT39QKzwkjDMEcB9aD1WNYTowMuVH7phypWPs2Qq0a/5KQQnXtoL1T4qgPJPw==}
     engines: {node: '>=22'}
 
   '@apify/log@2.5.50':
@@ -441,8 +441,8 @@ packages:
     resolution: {integrity: sha512-Py701iCY26eSLvdG45T9c9uJS2+xqI4j4rHwGqG84RUOmPD8T6Zua5MflSoWwZ+GM/+ABIJtsza/gqVvyJeESg==}
     engines: {node: '>=22'}
 
-  '@apify/validations@1.0.1':
-    resolution: {integrity: sha512-ZOJD9XQtYb5CwXR3MG6PCAibzPzdBQnoPzR40ejzOzKG6tV8Z0DBEeQlcADX6DqoNFDf+jDoQKHCyy9whpB31Q==}
+  '@apify/validations@1.1.0':
+    resolution: {integrity: sha512-1rXw3YOl1rGYRJurac9zLx0NrlrRktewxjVsTL3HxcaZTSJb4e2VTi1LA8QxonCFp1O323sCkNu6CbBisRfdeg==}
     engines: {node: '>=22'}
 
   '@asamuzakjp/css-color@3.2.0':
@@ -7143,6 +7143,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -7680,6 +7684,10 @@ packages:
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.28:
+    resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -9123,8 +9131,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -9491,12 +9499,12 @@ snapshots:
       typescript: 6.0.3
       zx: 8.8.5
 
-  '@apify/input_secrets@2.0.1':
+  '@apify/input_secrets@2.0.3':
     dependencies:
       '@apify/log': 3.0.1
       '@apify/utilities': 3.0.1
-      '@apify/validations': 1.0.1
-      zod: 4.4.3
+      '@apify/validations': 1.1.0
+      zod: 4.5.4
 
   '@apify/log@2.5.50':
     dependencies:
@@ -9578,9 +9586,9 @@ snapshots:
       '@apify/consts': 3.0.1
       '@apify/log': 3.0.1
 
-  '@apify/validations@1.0.1':
+  '@apify/validations@1.1.0':
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -10485,7 +10493,7 @@ snapshots:
       tldts: 7.4.10
       tslib: 2.8.1
       type-fest: 4.41.0
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       '@crawlee/impit-client': 4.0.0-rc.0
     transitivePeerDependencies:
@@ -10505,7 +10513,7 @@ snapshots:
       quick-lru: 7.3.0
       tiny-typed-emitter: 2.1.0
       tslib: 2.8.1
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       playwright: 1.62.1
       puppeteer: 25.8.0
@@ -10521,7 +10529,7 @@ snapshots:
       '@crawlee/utils': 4.0.0-rc.0
       tslib: 2.8.1
       type-fest: 4.41.0
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       playwright: 1.62.1
       puppeteer: 25.8.0
@@ -10573,7 +10581,7 @@ snapshots:
       tough-cookie: 6.0.2
       tslib: 2.8.1
       type-fest: 4.41.0
-      zod: 4.4.3
+      zod: 4.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -10601,7 +10609,7 @@ snapshots:
       '@crawlee/fs-storage-native': 0.1.5-beta.18
       '@crawlee/types': 4.0.0-rc.0
       '@crawlee/utils': 4.0.0-rc.0
-      zod: 4.4.3
+      zod: 4.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -10626,7 +10634,7 @@ snapshots:
       mime-types: 3.0.2
       tslib: 2.8.1
       type-fest: 4.41.0
-      zod: 4.4.3
+      zod: 4.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -10649,7 +10657,7 @@ snapshots:
       cheerio: 1.2.0
       jsdom: 26.1.0
       tslib: 2.8.1
-      zod: 4.4.3
+      zod: 4.5.4
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -10688,7 +10696,7 @@ snapshots:
       string-comparison: 1.3.0
       tslib: 2.8.1
       type-fest: 4.41.0
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       playwright: 1.62.1
     transitivePeerDependencies:
@@ -10707,7 +10715,7 @@ snapshots:
       devtools-protocol: 0.0.1682007
       jquery: 3.7.1
       tslib: 2.8.1
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       puppeteer: 25.8.0
     transitivePeerDependencies:
@@ -10740,7 +10748,7 @@ snapshots:
       tldts: 7.4.10
       tslib: 2.8.1
       whatwg-mimetype: 4.0.0
-      zod: 4.4.3
+      zod: 4.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -17705,6 +17713,8 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  picomatch@4.0.7: {}
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -18369,6 +18379,12 @@ snapshots:
       postcss: 8.5.26
 
   postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.28:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -19659,8 +19675,8 @@ snapshots:
   vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
-      picomatch: 4.0.5
-      postcss: 8.5.26
+      picomatch: 4.0.7
+      postcss: 8.5.28
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -19970,7 +19986,7 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.4.3: {}
+  zod@4.5.4: {}
 
   zwitch@2.0.4: {}
 


### PR DESCRIPTION
Bumps `@apify/validations` to 1.1.0 (the richer error formatting upstreamed from apify-client in apify/apify-shared-js#703) and `@apify/input_secrets` to 2.0.3, and unifies zod on a single 4.5.4 resolution. Without the zod dedupe the new validations resolves its own newer zod instance next to the pinned one, and the two zod type identities do not unify (this broke the build in the crawlee counterpart PR).
